### PR TITLE
Switched artifacts to be lowercase

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,10 +107,10 @@ afterEvaluate { project ->
 
 
                     pom.project {
-                        name 'AndroidBeaconLibrary'
+                        name 'Android Beacon Library'
                         packaging 'aar'
                         description 'Beacon library for Android applications'
-                        artifactId = 'AndroidBeaconLibrary'
+                        artifactId = 'android-beacon-library'
                         groupId GROUP
                         version version
                         url 'https://github.com/RadiusNetworks/android-beacon-library'

--- a/scripts/bundle-eclipse
+++ b/scripts/bundle-eclipse
@@ -1,12 +1,12 @@
 #!/bin/sh
-rm -rf build/libs/AndroidBeaconLibrary
-AAR_FILE=`ls build/libs/AndroidBeaconLibrary*.aar | grep -v debug | head -1`
+rm -rf build/libs/android-beacon-library
+AAR_FILE=`ls build/libs/android-beacon-library*.aar | grep -v debug | head -1`
 TARGZ_FILE=`echo "$AAR_FILE" | sed -e 's/aar/tar.gz/g'`
 echo "Generating eclipse bundle from $AAR_FILE to make $TARGZ_FILE"
-cp -r scripts/eclipse-support build/libs/AndroidBeaconLibrary
-tar -xvf $AAR_FILE -C build/libs/AndroidBeaconLibrary
-mkdir build/libs/AndroidBeaconLibrary/src
-mkdir build/libs/AndroidBeaconLibrary/libs
-mkdir build/libs/AndroidBeaconLibrary/gen
-mv build/libs/AndroidBeaconLibrary/*.jar build/libs/AndroidBeaconLibrary/libs
-tar -czvf $TARGZ_FILE -C build/libs AndroidBeaconLibrary
+cp -r scripts/eclipse-support build/libs/android-beacon-library
+tar -xvf $AAR_FILE -C build/libs/android-beacon-library
+mkdir build/libs/android-beacon-library/src
+mkdir build/libs/android-beacon-library/libs
+mkdir build/libs/android-beacon-library/gen
+mv build/libs/AndroidBeaconLibrary/*.jar build/libs/android-beacon-library/libs
+tar -czvf $TARGZ_FILE -C build/libs android-beacon-library

--- a/scripts/eclipse-support/.project
+++ b/scripts/eclipse-support/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>AndroidBeaconLibrary</name>
+	<name>android-beacon-library</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name="AndroidBeaconLibrary" 
+rootProject.name="android-beacon-library"


### PR DESCRIPTION
Switched gradle modules and eclipse conversion script to use lowercase artifacts.  So now we have:

android-beacon-library.aar
android-beacon-libarary.tar.gz
