### PR TITLE
Simplify BackroundPowerSaver

### DIFF
--- a/src/main/java/org/altbeacon/beacon/startup/RegionBootstrap.java
+++ b/src/main/java/org/altbeacon/beacon/startup/RegionBootstrap.java
@@ -110,7 +110,7 @@ public class RegionBootstrap {
 	        	for (Region region : regions) {
                     BeaconManager.logDebug(TAG, "Background region monitoring activated for region "+region);
 	                beaconManager.startMonitoringBeaconsInRegion(region);
-                    beaconManager.setBackgroundMode(this, true);
+                    beaconManager.setBackgroundMode(true);
 	        	}
 	        } catch (RemoteException e) {   
 	        	Log.e(TAG, "Can't set up bootstrap regions due to "+e);


### PR DESCRIPTION
This can be simplified because it has been moved to the open source library. Fallback background mode APIs are no longer needed.  This also simplifies external integration.
