### PR TITLE
Fixed typo in Ranging Example Code

### DIFF
--- a/samples.md
+++ b/samples.md
@@ -71,7 +71,7 @@ public class RangingActivity extends Activity implements BeaconConsumer {
 	@Override 
 	protected void onDestroy() {
 		super.onDestroy();
-		beaconManager.unBind(this);
+		beaconManager.unbind(this);
 	}
 	@Override
 	public void onBeaconServiceConnect() {


### PR DESCRIPTION
Minor typo in Ranging Example Code with beaconManager.unBind(this); which should be beaconManager.unbind(this);
