### PR TITLE
Added tasks to be able to publish to bintray and artifactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ proguard/
 .idea/dictionaries/*.xml
 
 # Other
-gradle.properties
 .gradle
 /local.properties
 /.idea/workspace.xml

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,6 @@ def getVersionName = {
     }
 }
 
-version = getVersionName()
-group = "org.altbeacon"
-
 buildscript {
     repositories {
         jcenter()
@@ -32,6 +29,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.0.0'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
         classpath 'org.robolectric:robolectric-gradle-plugin:0.14.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.1'
     }
 }
 
@@ -40,17 +39,17 @@ apply plugin: "com.android.library"
 apply plugin: 'robolectric'
 
 allprojects {
+    version = "${getVersionName()}${isSnapshot == true ? "-SNAPSHOT" : ""}"
+    group = "org.altbeacon"
+
     repositories {
-        mavenCentral()
-        maven {
-            url 'https://oss.sonatype.org/content/repositories/snapshots'
-        }
+        jcenter()
     }
 }
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.1"
+    buildToolsVersion "21.1.2"
 
     defaultConfig {
         minSdkVersion 7
@@ -95,7 +94,7 @@ dependencies {
     androidTestCompile('junit:junit:4.11') {
         exclude module: 'hamcrest-core'
     }
-    androidTestCompile('com.squareup:fest-android:1.0.+') {
+    androidTestCompile('com.squareup:fest-android:1.0.+@aar') {
         exclude group: 'com.android.support', module: 'support-v4'
     }
     androidTestCompile('org.robolectric:robolectric:2.3') {
@@ -117,8 +116,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-v4'
     }
 
-    androidTestCompile 'com.squareup:fest-android:1.0.+@aar'
-    compile 'com.android.support:support-v4:21+'
+    androidTestCompile 'com.android.support:support-v4:21.0.2'
 }
 
 apply plugin: 'idea'
@@ -163,3 +161,9 @@ android.libraryVariants.all { variant ->
 
 build.mustRunAfter clean
 bundleEclipse.mustRunAfter build
+
+apply from: 'gradle/credentials.gradle'
+apply from: 'gradle/compile.gradle'
+apply from: 'gradle/publishing.gradle'
+apply from: 'gradle/bintray.gradle'
+apply from: 'gradle/artifactory.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,10 @@
+project_vendor = altbeacon
+project_vendor_name = altbeacon
+project_description = Allows Android apps to interact with BLE beacons
+project_url = https://github.com/AltBeacon/android-beacon-library
+project_scm = https://github.com/AltBeacon/android-beacon-library
+project_issues_url = https://github.com/AltBeacon/android-beacon-library/issues
+project_connection = scm:git:https://github.com/AltBeacon/android-beacon-library.git
+project_dev_connection = scm:git:git@github.com:AltBeacon/android-beacon-library.git
+project_bintray_repo = android
+project_bintray_org = altbeacon

--- a/gradle/artifactory.gradle
+++ b/gradle/artifactory.gradle
@@ -1,0 +1,23 @@
+// handles distribution of snapshots to Artifactory (oss.jfrog.org)
+
+apply plugin: 'com.jfrog.artifactory'
+
+artifactory {
+    contextUrl = 'http://oss.jfrog.org/artifactory'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = bintrayUsername
+            password = bintrayKey
+        }
+        defaults {
+            publications('dist')
+        }
+    }
+    resolve {
+        repository {
+            repoKey = 'libs-release'
+        }
+    }
+
+}

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,0 +1,19 @@
+// Handles publication of distributions to Bintray
+
+apply plugin: 'com.jfrog.bintray'
+
+def attr = { String name -> project."$name" }
+
+bintray {
+    user = bintrayUsername
+    key = bintrayKey
+    publications = ['dist']
+    pkg {
+        repo = attr 'project_bintray_repo'
+        name = attr 'name'
+        userOrg =  attr 'project_bintray_org'
+        desc = attr 'project_description'
+        licenses = ['Apache-2.0']
+        labels = ['android', 'beacon', 'BLE', 'bluetooth']
+    }
+}

--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -1,0 +1,8 @@
+// custom tasks for creating source/javadoc jars
+task androidJavadocsJar(type: Jar) {
+    from "$buildDir/libs/$project.name-$project.version-javadoc.jar"
+}
+
+task androidSourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+}

--- a/gradle/credentials.gradle
+++ b/gradle/credentials.gradle
@@ -1,0 +1,2 @@
+ext.bintrayUser = project.hasProperty('bintrayUsername') ? project.getProperty('bintrayUsername') : System.getenv('BINTRAY_USER') ?: ''
+ext.bintrayKey = project.hasProperty('bintrayKey') ? project.getProperty('bintrayKey') : System.getenv('BINTRAY_KEY') ?: ''

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -1,0 +1,51 @@
+// configuration of the Maven artifacts
+apply plugin: 'maven-publish'
+
+// add javadoc/source jar tasks as artifacts
+artifacts {
+    archives androidSourcesJar, androidJavadocsJar
+}
+
+publishing {
+    publications {
+        dist(MavenPublication) {
+            groupId project.group
+            artifactId project.name
+            version project.version
+            artifact "${project.buildDir}/outputs/aar/${project.name}-release.aar"
+            artifact androidJavadocsJar {
+                classifier 'source'
+            }
+            artifact androidSourcesJar {
+                classifier 'javadoc'
+            }
+
+            pom.withXml {
+                def Node root = asNode()
+                root.appendNode('name', project.name)
+                root.appendNode('description', project.project_description)
+                root.appendNode('url', project.project_url)
+
+                def issues = root.appendNode('issueManagement')
+                issues.appendNode('system', 'github')
+                issues.appendNode('url', project.project_issues_url)
+
+                def scm = root.appendNode('scm')
+                scm.appendNode('url', project.project_scm)
+                scm.appendNode('connection', project.project_connection)
+                scm.appendNode('developerConnection', project.project_dev_connection)
+
+                def license = root.appendNode('licenses').appendNode('license')
+                license.appendNode('name', 'The Apache Software License, Version 2.0')
+                license.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
+                license.appendNode('distribution', 'repo')
+
+                def dev = root.appendNode('developers').appendNode('developer')
+                dev.appendNode('id', project.project_vendor)
+                dev.appendNode('name', project.project_vendor_name)
+                dev.appendNode('organization', 'AltBeacon')
+                dev.appendNode('organizationUrl', 'altbeacon.org')
+            }
+        }
+    }
+}


### PR DESCRIPTION
You will need to add your bintray username and key to `$HOME/.gradle/gradle.properties` as `bintrayUser=userHere` and `bintrayKey=keyHere`

To publish to bintray (Release) run `gradlew bintrayUpload -Prelease` and run `gradlew artifactoryPublish` to publish a snapshot to artifactory.

@davidgyoung Let me know when you get signed up to bintray and I will get you all setup with the altbeacon organization and give you more info on how to publish to maven central.