### PR TITLE
Added ability to do all publishing from gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import groovyx.net.http.ContentType
+import org._10ne.gradle.rest.RestTask
+
 ext {
     isSnapshot = !project.hasProperty('release')
 }
@@ -31,6 +34,7 @@ buildscript {
         classpath 'org.robolectric:robolectric-gradle-plugin:0.14.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.1'
+        classpath "org._10ne.gradle:rest-gradle-plugin:0.3.1"
     }
 }
 
@@ -167,3 +171,53 @@ apply from: 'gradle/compile.gradle'
 apply from: 'gradle/publishing.gradle'
 apply from: 'gradle/bintray.gradle'
 apply from: 'gradle/artifactory.gradle'
+
+apply plugin: "org.10ne.rest"
+
+/**
+ * Sign the content that has been uploaded to bintray. This must be done since the plugin does not support signing /
+ * bintray doesn't auto sign if the private key requires a password.
+ */
+task bintraySign(type: RestTask) {
+    description = "Sign the release build on bintray"
+    httpMethod = 'post'
+    uri = "https://api.bintray.com/gpg/$project_vendor/$project_bintray_repo/${project.name}/versions/$version"
+    username = bintrayUser
+    password = bintrayKey
+    requestBody = [passphrase: signingPassword]
+    contentType = ContentType.JSON
+}
+
+/**
+ * Publish the content that has been uploaded to bintray, so you don't need to go to the web ui.
+ */
+task bintrayPublishContent(type: RestTask) {
+    description = 'Move files that have been uploaded to bintray to be published'
+    httpMethod = 'post'
+    uri = "https://api.bintray.com/content/$project_vendor/$project_bintray_repo/${project.name}/$version/publish"
+    username = bintrayUser
+    password = bintrayKey
+    contentType = ContentType.JSON
+}
+
+/**
+ * Publish uploaded content to maven central, so you don't need to go to the web ui.
+ */
+task bintrayToMavenCentral(type: RestTask) {
+    description = 'Publish from bintray to maven central'
+    httpMethod = 'post'
+    uri = "https://api.bintray.com/maven_central_sync/$project_vendor/$project_bintray_repo/${project.name}/versions/$version"
+    username = bintrayUser
+    password = bintrayKey
+    requestBody = [username: sonatypeUserName, password: sonatypePassword, close: 1]
+    contentType = ContentType.JSON
+}
+
+task bintrayRelease {
+    description = "Releases a version of the library on Artifactory and Bintray"
+    dependsOn bintrayUpload
+    dependsOn bintrayPublishContent
+    dependsOn bintraySign
+    dependsOn bintrayPublishContent
+    dependsOn bintrayToMavenCentral
+}

--- a/gradle/credentials.gradle
+++ b/gradle/credentials.gradle
@@ -1,2 +1,5 @@
 ext.bintrayUser = project.hasProperty('bintrayUsername') ? project.getProperty('bintrayUsername') : System.getenv('BINTRAY_USER') ?: ''
 ext.bintrayKey = project.hasProperty('bintrayKey') ? project.getProperty('bintrayKey') : System.getenv('BINTRAY_KEY') ?: ''
+ext.signingPassword = project.hasProperty('signingPassword') ? project.getProperty('signingPassword') : System.getenv('SIGNING_PASSWORD') ?: ''
+ext.sonatypeUserName = project.hasProperty('sonatypeUserName') ? project.getProperty('sonatypeUserName') : System.getenv('SONATYPE_USER_NAME') ?: ''
+ext.sonatypePassword = project.hasProperty('sonatypePassword') ? project.getProperty('sonatypePassword') : System.getenv('SONATYPE_PASSWORD') ?: ''


### PR DESCRIPTION
No need to log into the bintray UI anymore.

Since my username and password won't work for this, I couldn't test, but this is very similar to other projects so I should work. Just need to add more values to your gradle.properties and run `gradlew bintrayRelease`.

Let me know if you have any issues.