### PR TITLE
Fixed ignoring of http redirection limit

### DIFF
--- a/src/main/java/org/altbeacon/beacon/distance/DistanceConfigFetcher.java
+++ b/src/main/java/org/altbeacon/beacon/distance/DistanceConfigFetcher.java
@@ -46,7 +46,7 @@ public class DistanceConfigFetcher {
         String currentUrlString = mUrlString;
         int requestCount = 0;
         StringBuilder responseBuilder = new StringBuilder();
-        URL url = null;
+        URL url;
         HttpURLConnection conn = null;
         do {
             if (requestCount != 0) {
@@ -56,6 +56,7 @@ public class DistanceConfigFetcher {
             }
             requestCount++;
             mResponseCode = -1;
+            url = null;
             try {
                 url = new URL(currentUrlString);
             } catch (Exception e) {
@@ -84,9 +85,10 @@ public class DistanceConfigFetcher {
                 }
             }
         }
-        while (requestCount < 10 && mResponseCode == HttpURLConnection.HTTP_MOVED_TEMP
-                || mResponseCode == HttpURLConnection.HTTP_MOVED_PERM
-                || mResponseCode == HttpURLConnection.HTTP_SEE_OTHER);
+        while (requestCount < 10 &&
+                (mResponseCode == HttpURLConnection.HTTP_MOVED_TEMP
+                        || mResponseCode == HttpURLConnection.HTTP_MOVED_PERM
+                        || mResponseCode == HttpURLConnection.HTTP_SEE_OTHER));
 
         if (mException == null) {
             try {

--- a/src/main/java/org/altbeacon/beacon/distance/ModelSpecificDistanceCalculator.java
+++ b/src/main/java/org/altbeacon/beacon/distance/ModelSpecificDistanceCalculator.java
@@ -236,7 +236,7 @@ public class ModelSpecificDistanceCalculator implements DistanceCalculator {
                     }
                 }
             }
-        }).execute(null, null, null);
+        }).execute();
     }
 
     private void buildModelMap(String jsonString) throws JSONException {


### PR DESCRIPTION
First: You've created a great library! Thank you for that.

A small issue I noted when I looked at the code. When the status code is `HTTP_MOVED_PERM` or `HTTP_SEE_OTHER`, it ignores the request count. This is because the `&&` has a higher operator precedence and therefore get evaluated before the `||` operators.