### PR TITLE
Don't export services in AndroidManifest

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -16,14 +16,15 @@
         </receiver>
 
         <service android:enabled="true"
-            android:exported="true"
+            android:exported="false"
             android:isolatedProcess="false"
             android:label="beacon"
             android:name=".service.BeaconService"
             />
 
-        <service android:enabled="true"
-            android:name=".BeaconIntentProcessor"
+        <service android:name=".BeaconIntentProcessor"
+            android:enabled="true"
+            android:exported="false"
             />
 
     </application>


### PR DESCRIPTION
Because the services are only used from this library, they don't have to be exported in the manifest. Prevents potential security issues.

Specifying `exported=false` on services without an `intent-filter` element isn't necessary as `false` is then the default in that case, but this makes it more explicit when people read the manifest.