### PR TITLE
removed unused properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,3 @@ project_connection = scm:git:https://github.com/AltBeacon/android-beacon-library
 project_dev_connection = scm:git:git@github.com:AltBeacon/android-beacon-library.git
 project_bintray_repo = android
 project_bintray_org = altbeacon
-# The following are placeholders that you can override with your ~/.gradle/gradle.properties file
-bintrayUsername=
-bintrayKey=


### PR DESCRIPTION
This removes properties that are causing System properties to not be pulled in, and thus not being able to be set by CI or being about to be set from global gradle.properties.

If these are not set, the properties should now be set to empty strings in the credentials.gradle.