### PR TITLE
Updated to use bintray plugin 1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,3 @@
-import groovyx.net.http.ContentType
-import org._10ne.gradle.rest.RestTask
-
 ext {
     isSnapshot = !project.hasProperty('release')
     isSnapCi = System.getenv('SNAP_CI') != null
@@ -34,9 +31,8 @@ buildscript {
         classpath 'com.android.tools.build:gradle:1.0.0'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
         classpath 'org.robolectric:robolectric-gradle-plugin:0.14.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:0.6'
-        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.1'
-        classpath "org._10ne.gradle:rest-gradle-plugin:0.3.1"
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
+        classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3'
     }
 }
 
@@ -178,56 +174,6 @@ apply from: 'gradle/compile.gradle'
 apply from: 'gradle/publishing.gradle'
 apply from: 'gradle/bintray.gradle'
 apply from: 'gradle/artifactory.gradle'
-
-apply plugin: "org.10ne.rest"
-
-/**
- * Sign the content that has been uploaded to bintray. This must be done since the plugin does not support signing /
- * bintray doesn't auto sign if the private key requires a password.
- */
-task bintraySign(type: RestTask) {
-    description = "Sign the release build on bintray"
-    httpMethod = 'post'
-    uri = "https://api.bintray.com/gpg/$project_vendor/$project_bintray_repo/${project.name}/versions/$version"
-    username = bintrayUsername
-    password = bintrayKey
-    requestBody = [passphrase: signingPassword]
-    contentType = ContentType.JSON
-}
-
-/**
- * Publish the content that has been uploaded to bintray, so you don't need to go to the web ui.
- */
-task bintrayPublishContent(type: RestTask) {
-    description = 'Move files that have been uploaded to bintray to be published'
-    httpMethod = 'post'
-    uri = "https://api.bintray.com/content/$project_vendor/$project_bintray_repo/${project.name}/$version/publish"
-    username = bintrayUsername
-    password = bintrayKey
-    contentType = ContentType.JSON
-}
-
-/**
- * Publish uploaded content to maven central, so you don't need to go to the web ui.
- */
-task bintrayToMavenCentral(type: RestTask) {
-    description = 'Publish from bintray to maven central'
-    httpMethod = 'post'
-    uri = "https://api.bintray.com/maven_central_sync/$project_vendor/$project_bintray_repo/${project.name}/versions/$version"
-    username = bintrayUsername
-    password = bintrayKey
-    requestBody = [username: sonatypeUserName, password: sonatypePassword, close: 1]
-    contentType = ContentType.JSON
-}
-
-task bintrayRelease {
-    description = 'Releases a version of the library on Artifactory and Bintray'
-    dependsOn bintrayUpload
-    dependsOn bintrayPublishContent
-    dependsOn bintraySign
-    dependsOn bintrayPublishContent
-    dependsOn bintrayToMavenCentral
-}
 
 artifactoryPublish {
     // Skip deploying to artifactory if building a pull request

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -8,6 +8,9 @@ bintray {
     user = bintrayUsername
     key = bintrayKey
     publications = ['dist']
+    filesSpec {
+        from "${project.buildDir}/outputs/aar/${project.name}-${project.version}.tar.gz"
+    }
     pkg {
         repo = attr 'project_bintray_repo'
         name = attr 'name'
@@ -15,5 +18,17 @@ bintray {
         desc = attr 'project_description'
         licenses = ['Apache-2.0']
         labels = ['android', 'beacon', 'BLE', 'bluetooth']
+        version {
+            name = attr 'version'
+            gpg {
+                sign = true
+                passphrase = attr 'signingPassword'
+            }
+            mavenCentralSync {
+                sync = true
+                user = attr 'sonatypeUserName'
+                password = attr 'sonatypePassword'
+            }
+        }
     }
 }

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -13,7 +13,6 @@ publishing {
             artifactId project.name
             version project.version
             artifact "${project.buildDir}/outputs/aar/${project.name}-release.aar"
-            artifact "${project.buildDir}/outputs/aar/${project.name}-${project.version}.tar.gz"
             artifact androidJavadocsJar {
                 classifier 'source'
             }


### PR DESCRIPTION
@davidgyoung You'll have to test this out with the next release to make sure it's working as expected, but moving the tar.gz upload into the bintray task fixes the snapshot publishing issue.

 #93