### PR TITLE
Changed Region to become immutable.

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -413,7 +413,7 @@ public class BeaconManager {
 		msg.obj = obj;
 		serviceMessenger.send(msg);
         synchronized (rangedRegions) {
-            rangedRegions.add((Region) region.clone());
+            rangedRegions.add(region);
         }
 	}
 	/**
@@ -474,7 +474,7 @@ public class BeaconManager {
 		msg.obj = obj;
 		serviceMessenger.send(msg);
         synchronized (monitoredRegions) {
-            monitoredRegions.add((Region) region.clone());
+            monitoredRegions.add(region);
         }
 	}
 	/**
@@ -587,26 +587,19 @@ public class BeaconManager {
      * @return the list of regions currently being monitored
      */
     public Collection<Region> getMonitoredRegions() {
-        ArrayList<Region> clonedMontoredRegions = new ArrayList<Region>();
         synchronized(this.monitoredRegions) {
-            for (Region montioredRegion : this.monitoredRegions) {
-                clonedMontoredRegions.add((Region) montioredRegion.clone());
-            }
+            return new ArrayList<Region>(this.monitoredRegions);
         }
-        return clonedMontoredRegions;
+
     }
 
     /**
      * @return the list of regions currently being ranged
      */
     public Collection<Region> getRangedRegions() {
-        ArrayList<Region> clonedRangedRegions = new ArrayList<Region>();
         synchronized(this.rangedRegions) {
-            for (Region rangedRegion : this.rangedRegions) {
-                clonedRangedRegions.add((Region) rangedRegion.clone());
-            }
+            return new ArrayList<Region>(this.rangedRegions);
         }
-        return clonedRangedRegions;
     }
 
     /**

--- a/src/main/java/org/altbeacon/beacon/Region.java
+++ b/src/main/java/org/altbeacon/beacon/Region.java
@@ -25,7 +25,6 @@ package org.altbeacon.beacon;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,8 +62,8 @@ public class Region implements Parcelable {
             return new Region[size];
         }
     };
-    protected List<Identifier> mIdentifiers;
-	protected String mUniqueId;
+    protected final List<Identifier> mIdentifiers;
+	protected final String mUniqueId;
 
 	/**
 	 * Constructs a new Region object to be used for Ranging or Monitoring
@@ -89,8 +88,8 @@ public class Region implements Parcelable {
      * @param uniqueId - A unique identifier used to later cancel Ranging and Monitoring, or change the region being Ranged/Monitored
      * @param identifiers - list of identifiers for this region
      */
-    public Region(String uniqueId, ArrayList<Identifier> identifiers) {
-        this.mIdentifiers = new ArrayList<Identifier>(3);
+    public Region(String uniqueId, List<Identifier> identifiers) {
+        this.mIdentifiers = new ArrayList<Identifier>(identifiers);
         this.mUniqueId = uniqueId;
         if (uniqueId == null) {
             throw new NullPointerException("uniqueId may not be null");
@@ -102,7 +101,7 @@ public class Region implements Parcelable {
      * @return
      */
     public Identifier getId1() {
-        return mIdentifiers.get(0);
+        return getIdentifier(0);
     }
 
     /**
@@ -110,7 +109,7 @@ public class Region implements Parcelable {
      * @return
      */
     public Identifier getId2() {
-        return mIdentifiers.get(1);
+        return getIdentifier(1);
     }
 
     /**
@@ -118,7 +117,7 @@ public class Region implements Parcelable {
      * @return
      */
     public Identifier getId3() {
-        return mIdentifiers.get(2);
+        return getIdentifier(2);
     }
 
     /**
@@ -128,7 +127,7 @@ public class Region implements Parcelable {
      * @return
      */
     public Identifier getIdentifier(int i) {
-        return mIdentifiers.get(i);
+        return mIdentifiers.size() > i ? mIdentifiers.get(i) : null;
     }
 
     /**
@@ -150,7 +149,7 @@ public class Region implements Parcelable {
         for (int i = 0; i < this.mIdentifiers.size(); i++) {
             if (beacon.getIdentifiers().size() <= i && mIdentifiers.get(i) == null) {
                 // If the beacon has fewer identifiers than the region, but the region's
-                // corresponding identifer is null, consider it a match
+                // corresponding identifier is null, consider it a match
             }
             else {
                 if (mIdentifiers.get(i) != null && !mIdentifiers.get(i).equals(beacon.mIdentifiers.get(i))) {
@@ -161,19 +160,20 @@ public class Region implements Parcelable {
         return true;
 	}
 
-	@Override
-	public int hashCode() {
-		return this.mUniqueId.hashCode();
-	}
+    @Override
+    public int hashCode() {
+        return this.mUniqueId.hashCode();
+    }
 
-	public boolean equals(Object other) {
-		 if (other instanceof Region) {
-			return ((Region)other).mUniqueId.equals(this.mUniqueId);
-		 }
-		 return false;
-	}
-	
-	public String toString() {
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof Region) {
+            return ((Region)other).mUniqueId.equals(this.mUniqueId);
+        }
+        return false;
+    }
+
+    public String toString() {
         StringBuilder sb = new StringBuilder();
         int i = 1;
         for (Identifier identifier: mIdentifiers) {
@@ -207,18 +207,6 @@ public class Region implements Parcelable {
         }
     }
 
-    protected Region(Region otherRegion) {
-        super();
-        mIdentifiers = new ArrayList<Identifier>(otherRegion.mIdentifiers.size());
-        for (int i = 0; i < otherRegion.mIdentifiers.size(); i++) {
-            Identifier otherIdentifier = otherRegion.mIdentifiers.get(i);
-            mIdentifiers.add(otherIdentifier != null ? new Identifier(otherIdentifier) : null);
-        }
-        mUniqueId = otherRegion.mUniqueId;
-    }
-    
-    protected Region() {
-    }
 
     protected Region(Parcel in) {
         mUniqueId = in.readString();
@@ -234,9 +222,16 @@ public class Region implements Parcelable {
             }
         }
     }
-    @Override
-    public Object clone() {
-        return new Region(this);
-    }
 
+    /**
+     * Returns a clone of this instance.
+     * @deprecated instances of this class are immutable and therefore don't have to be cloned when
+     * used in concurrent code.
+     * @return a new instance of this class with the same uniqueId and identifiers
+     */
+    @Override
+    @Deprecated
+    public Region clone() {
+        return new Region(mUniqueId, mIdentifiers);
+    }
 }

--- a/src/test/java/org/altbeacon/beacon/RegionTest.java
+++ b/src/test/java/org/altbeacon/beacon/RegionTest.java
@@ -13,6 +13,9 @@ import org.junit.runner.RunWith;
 import org.junit.Test;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 @Config(emulateSdk = 18)
 
 @RunWith(RobolectricTestRunner.class)
@@ -61,6 +64,14 @@ public class RegionTest {
     }
 
     @Test
+    public void testBeaconMatchesRegionWithShorterIdentifierList() {
+        Beacon beacon = new AltBeacon.Builder().setId1("1").setId2("2").setId3("3").setRssi(4)
+                .setBeaconTypeCode(5).setTxPower(6).setBluetoothAddress("1:2:3:4:5:6").build();
+        Region region = new Region("myRegion", Collections.singletonList(Identifier.parse("1")));
+        assertTrue("Beacon should match region with first identifier equal and shorter Identifier list", region.matchesBeacon(beacon));
+    }
+
+    @Test
     public void testCanSerializeParcelable() {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         Parcel parcel = Parcel.obtain();
@@ -81,15 +92,6 @@ public class RegionTest {
         Region region = new Region("myRegion", Identifier.parse("1"), Identifier.parse("2"), null);
         assertEquals("id1: 1 id2: 2 id3: null", region.toString());
     }
-
-    @Test
-    public void testCopyConstructor() {
-        Region region = new Region("myRegion", Identifier.parse("1"), Identifier.parse("2"), null);
-        Region region2 = new Region(region);
-        assertEquals(region, region2);
-        assertNull(region2.getId3());
-    }
-
 
     @Test
     public void testConvenienceIdentifierAccessors() {


### PR DESCRIPTION
I've changed the Region class to become immutable of instantiation. Therefore it is no longer needed to have a copy constructor or for the object to be cloneable.

Also fixed the constructor that supported custom length Identifier lists and let equals take into account the identifiers.

Maybe for the backwards compatibility it is better to bring back the public clone method, maybe in deprecated form? What do you think?