### PR TITLE
Fix links to Android classes in Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,9 +158,8 @@ android.libraryVariants.all { variant ->
         source = variant.javaCompile.source
         ext.androidJar =
                 "${android.sdkDirectory}/platforms/${android.compileSdkVersion}/android.jar"
-        classpath = files(variant.javaCompile.classpath.files) + files(ext.androidJar)
-        options.links("http://docs.oracle.com/javase/7/docs/api/");
-        options.links("http://d.android.com/reference/");
+        classpath = files(variant.javaCompile.classpath.files, ext.androidJar)
+        options.linksOffline "http://d.android.com/reference/", "${android.sdkDirectory}/docs/reference"
         exclude '**/BuildConfig.java'
         exclude '**/R.java'
     }


### PR DESCRIPTION
The classes in the <code>android.*</code> packages weren't clickable links in Javadoc. Now they are.

The <code>java.*</code> classes now link to the Android reference as well instead of the Oracle reference. The Android reference gives a better descriptions when developing for Android.