### PR TITLE
Bug Fix

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -109,7 +109,12 @@ public class BeaconManager {
     private final ArrayList<BeaconParser> beaconParsers = new ArrayList<BeaconParser>();
     private boolean mBackgroundMode = false;
     private boolean mBackgroundModeUninitialized = true;
-
+    
+    /**
+    * set to true if you want to see debug messages associated with this library
+    */
+    public static boolean debug = false;
+    
     private static boolean sAndroidLScanningDisabled = false;
     private static boolean sManifestCheckingDisabled = false;
 


### PR DESCRIPTION
BeaconManager.java:38: error: cannot find symbol
            if (BeaconManager.debug) Log.d(TAG, "BeaconManager instance creation");