### PR TITLE
fixed ConcurrentModificationException on BeaconManager

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -575,15 +574,12 @@ public class BeaconManager {
             LogManager.d(TAG, "we have a connection to the service now");
             serviceMessenger = new Messenger(service);
             synchronized(consumers) {
-                Iterator<BeaconConsumer> consumerIterator = consumers.keySet().iterator();
-                while (consumerIterator.hasNext()) {
-                    BeaconConsumer consumer = consumerIterator.next();
+                for (BeaconConsumer consumer : consumers.keySet()) {
                     Boolean alreadyConnected = consumers.get(consumer).isConnected;
                     if (!alreadyConnected) {
                         consumer.onBeaconServiceConnect();
                         ConsumerInfo consumerInfo = consumers.get(consumer);
                         consumerInfo.isConnected = true;
-                        consumers.put(consumer, consumerInfo);
                     }
                 }
             }

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -569,12 +570,14 @@ public class BeaconManager {
 	}
 
 	private ServiceConnection beaconServiceConnection = new ServiceConnection() {
-		// Called when the connection with the service is established
-	    public void onServiceConnected(ComponentName className, IBinder service) {
+      // Called when the connection with the service is established
+      public void onServiceConnected(ComponentName className, IBinder service) {
             LogManager.d(TAG, "we have a connection to the service now");
-	        serviceMessenger = new Messenger(service);
+            serviceMessenger = new Messenger(service);
             synchronized(consumers) {
-                for (BeaconConsumer consumer : consumers.keySet()) {
+                Iterator<BeaconConsumer> consumerIterator = consumers.keySet().iterator();
+                while (consumerIterator.hasNext()) {
+                    BeaconConsumer consumer = consumerIterator.next();
                     Boolean alreadyConnected = consumers.get(consumer).isConnected;
                     if (!alreadyConnected) {
                         consumer.onBeaconServiceConnect();


### PR DESCRIPTION
I investigated the problem I told before (#116). It seems like 94520a8 caused problem. I have fixed the problem (actually reverted code). Since, ConsumerInfo is not an immutable class, putting the same reference to the map after changing isConnected to true is unnecessary.

So, it could be in this way as well:

```
for (BeaconConsumer consumer : consumers.keySet()) {
    Boolean alreadyConnected = consumers.get(consumer).isConnected;
    if (!alreadyConnected) {
        consumer.onBeaconServiceConnect();
        ConsumerInfo consumerInfo = consumers.get(consumer);
        consumerInfo.isConnected = true;
    }
}
```

BTW, sorry for the last PR.