### PR TITLE
Fix links to sample projects.

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -24,8 +24,8 @@ layout: android-beacon-library
 <ul>
 <li><a href='configure.html'>Download and project setup guide</a></li>
 <li><a href='samples.html'>Code samples</a></li>
-<li><a href='https://github.com/AltBeacon/android-beacon-library-reference/tree/android-studio/app'>Reference application (Android Studio)</a></li>
-<li><a href='https://github.com/AltBeacon/android-beacon-library-reference'>Reference application (Eclipse)</a></li>
+<li><a href='https://github.com/AltBeacon/android-beacon-library-reference'>Reference application (Android Studio)</a></li>
+<li><a href='https://github.com/AltBeacon/android-beacon-library-reference/tree/eclipse'>Reference application (Eclipse)</a></li>
 <li><a href='javadoc/index.html'>API JavaDoc</a>
 </ul>
 


### PR DESCRIPTION
Looks like Android Studio reference project is in main and Eclipse in a branch but these links were the other way around.