### PR TITLE
Protect against NPE in a race condition

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -388,7 +388,7 @@ public class BeaconService extends Service {
         while (matchedRegionIterator.hasNext()) {
             Region region = matchedRegionIterator.next();
             MonitorState state = monitoredRegionState.get(region);
-            if (state.markInside()) {
+            if (state != null && state.markInside()) {
                 state.getCallback().call(BeaconService.this, "monitoringData",
                         new MonitoringData(state.isInside(), region));
             }
@@ -402,7 +402,9 @@ public class BeaconService extends Service {
                 Region region = matchedRegionIterator.next();
                 LogManager.d(TAG, "matches ranging region: %s", region);
                 RangeState rangeState = rangedRegionState.get(region);
-                rangeState.addBeacon(beacon);
+                if (rangeState != null) {
+                    rangeState.addBeacon(beacon);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes issue described in #140 where stopping ranging/monitoring can create a race condition causing a null pointer exception.