### PR TITLE
v3: Remove convenience accessors, fix UUID parsing

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
@@ -162,10 +162,9 @@ public class BeaconTransmitter {
             byteString += String.format("%02X", advertisingBytes[i]);
             byteString += " ";
         }
-        LogManager.d(TAG, "Starting advertising with ID1: %s ID2: %s ID3: %s and data: %s of size "
-                        + "%s", mBeacon.getId1(),
-                        mBeacon.getIdentifiers().size() > 1 ? mBeacon.getId2() : "",
-                        mBeacon.getIdentifiers().size() > 2 ? mBeacon.getId3() : "", byteString,
+        LogManager.d(TAG, "Starting advertising with %s and data: %s of size %d",
+                mBeacon,
+                byteString,
                 advertisingBytes.length);
 
         try{

--- a/src/main/java/org/altbeacon/beacon/Identifier.java
+++ b/src/main/java/org/altbeacon/beacon/Identifier.java
@@ -17,8 +17,7 @@ import java.util.regex.Pattern;
 public class Identifier implements Comparable<Identifier> {
     private static final Pattern HEX_PATTERN = Pattern.compile("^0x[0-9A-Fa-f]*$");
     private static final Pattern DECIMAL_PATTERN = Pattern.compile("^[0-9]{1,5}$");
-    // BUG: Dashes in UUIDs are not optional!
-    private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9A-Fa-f]{8}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12}$");
+    private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$");
     private static final int MAX_INTEGER = 65535;
 
     private final byte[] mValue;
@@ -55,7 +54,13 @@ public class Identifier implements Comparable<Identifier> {
         }
 
         if (UUID_PATTERN.matcher(stringValue).matches()) {
-            return parseHex(stringValue.replace("-", ""));
+            UUID uuid = null;
+            try {
+                uuid = UUID.fromString(stringValue);
+            } catch (Throwable t) {
+                throw new IllegalArgumentException("Unable to parse Identifier in UUID format.", t);
+            }
+            return fromUuid(uuid);
         }
 
         if (DECIMAL_PATTERN.matcher(stringValue).matches()) {

--- a/src/main/java/org/altbeacon/beacon/Region.java
+++ b/src/main/java/org/altbeacon/beacon/Region.java
@@ -27,6 +27,7 @@ import android.os.Parcel;
 import android.os.Parcelable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -47,7 +48,7 @@ import java.util.List;
  *
  */
 public class Region implements Parcelable {
-	private static final String TAG = "Region";
+    private static final String TAG = "Region";
 
     /**
      * Required to make class Parcelable
@@ -63,25 +64,21 @@ public class Region implements Parcelable {
         }
     };
     protected final List<Identifier> mIdentifiers;
-	protected final String mUniqueId;
+    protected final String mUniqueId;
 
-	/**
-	 * Constructs a new Region object to be used for Ranging or Monitoring
-	 * @param uniqueId - A unique identifier used to later cancel Ranging and Monitoring, or change the region being Ranged/Monitored
-	 * @param id1 - most significant identifier (can be null)
-	 * @param id2 - second most significant identifier (can be null)
-	 * @param id3 - third most significant identifier (can be null)
-	 */
-	public Region(String uniqueId, Identifier id1, Identifier id2, Identifier id3) {
-        this.mIdentifiers = new ArrayList<Identifier>(3);
-		this.mIdentifiers.add(id1);
-        this.mIdentifiers.add(id2);
-        this.mIdentifiers.add(id3);
-		this.mUniqueId = uniqueId;
+    /**
+     * Constructs a new Region object to be used for Ranging or Monitoring
+     *
+     * @param uniqueId    A unique identifier used to later cancel Ranging and Monitoring, or change the region being Ranged/Monitored
+     * @param identifiers Identifiers that define this Region, ordered by significance.
+     */
+    public Region(String uniqueId, Identifier... identifiers) {
+        this.mIdentifiers = Arrays.asList(identifiers);
+        this.mUniqueId = uniqueId;
         if (uniqueId == null) {
             throw new NullPointerException("uniqueId may not be null");
         }
-	}
+    }
 
     /**
      * Constructs a new Region object to be used for Ranging or Monitoring
@@ -97,37 +94,11 @@ public class Region implements Parcelable {
     }
 
     /**
-     * Convenience method to get the first identifier
-     * @return
-     */
-    public Identifier getId1() {
-        return getIdentifier(0);
-    }
-
-    /**
-     * Convenience method to get the second identifier
-     * @return
-     */
-    public Identifier getId2() {
-        return getIdentifier(1);
-    }
-
-    /**
-     * Convenience method to get the third identifier
-     * @return
-     */
-    public Identifier getId3() {
-        return getIdentifier(2);
-    }
-
-    /**
-     * Returns the 0-indexed identifier
-     * Note:  IMPORTANT:  to get id1, you would call getIdentifier(0);
      * @param i
      * @return
      */
     public Identifier getIdentifier(int i) {
-        return mIdentifiers.size() > i ? mIdentifiers.get(i) : null;
+        return mIdentifiers.get(i);
     }
 
     /**
@@ -135,16 +106,16 @@ public class Region implements Parcelable {
      * the <code>BeaconManager</code> methods.
      * @return
      */
-	public String getUniqueId() {
-		return mUniqueId;
-	}
-	
-	/**
-	 * Checks to see if an Beacon object is included in the matching criteria of this Region
-	 * @param beacon the beacon to check to see if it is in the Region
-	 * @return true if is covered
-	 */
-	public boolean matchesBeacon(Beacon beacon) {
+    public String getUniqueId() {
+        return mUniqueId;
+    }
+
+    /**
+     * Checks to see if an Beacon object is included in the matching criteria of this Region
+     * @param beacon the beacon to check to see if it is in the Region
+     * @return true if is covered
+     */
+    public boolean matchesBeacon(Beacon beacon) {
         // all identifiers must match, or the region identifier must be null
         for (int i = 0; i < this.mIdentifiers.size(); i++) {
             if (beacon.getIdentifiers().size() <= i && mIdentifiers.get(i) == null) {
@@ -158,7 +129,7 @@ public class Region implements Parcelable {
             }
         }
         return true;
-	}
+    }
 
     @Override
     public int hashCode() {
@@ -187,7 +158,7 @@ public class Region implements Parcelable {
             i++;
         }
         return sb.toString();
-	}
+    }
 
     public int describeContents() {
         return 0;

--- a/src/test/java/org/altbeacon/beacon/BeaconTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconTest.java
@@ -38,10 +38,9 @@ public class BeaconTest {
         assertEquals("First beacon id should be 1", beacon.getIdentifier(0).toString(), "1");
         assertEquals("Second beacon id should be 1", beacon.getIdentifier(1).toString(), "2");
         assertEquals("Third beacon id should be 1", beacon.getIdentifier(2).toString(), "3");
-        assertEquals("First beacon id should be 1", beacon.getId1().toString(), "1");
-        assertEquals("Second beacon id should be 1", beacon.getId2().toString(), "2");
-        assertEquals("Third beacon id should be 1", beacon.getId3().toString(), "3");
-
+        assertEquals("First beacon id should be 1", beacon.getIdentifier(0).toString(), "1");
+        assertEquals("Second beacon id should be 1", beacon.getIdentifier(1).toString(), "2");
+        assertEquals("Third beacon id should be 1", beacon.getIdentifier(2).toString(), "3");
     }
 
     @Test
@@ -89,7 +88,6 @@ public class BeaconTest {
         assertTrue("Beacons with different id3 are not equal", !beacon1.equals(beacon2));
     }
 
-
     @Test
     public void testCalculateAccuracyWithRssiEqualsPower() {
         Beacon.setDistanceCalculator(new ModelSpecificDistanceCalculator(null, null));
@@ -126,7 +124,6 @@ public class BeaconTest {
         double distance = beacon.getDistance();
         assertEquals("Distance should be one meter if mRssi is the same as power", 1.0, distance, 0.1);
     }
-
 
     @Test
     public void testCanSerializeParcelable() {

--- a/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
+++ b/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
@@ -37,8 +37,8 @@ public class GattBeaconTest {
         assertNotNull("Service uuid parsed should not be null", parser.getServiceUuid());
         Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
-        assertEquals("id1 should be parsed", "0x454452e29735323d81c0", gattBeacon.getId1().toString());
-        assertEquals("id2 should be parsed", "0x060504030201", gattBeacon.getId2().toString());
+        assertEquals("id1 should be parsed", "0x454452e29735323d81c0", gattBeacon.getIdentifier(0).toString());
+        assertEquals("id2 should be parsed", "0x060504030201", gattBeacon.getIdentifier(1).toString());
         assertEquals("serviceUuid should be parsed", 0x0123, gattBeacon.getServiceUuid());
         assertEquals("txPower should be parsed", -59, gattBeacon.getTxPower());
     }

--- a/src/test/java/org/altbeacon/beacon/IdentifierTest.java
+++ b/src/test/java/org/altbeacon/beacon/IdentifierTest.java
@@ -168,14 +168,8 @@ public class IdentifierTest {
         Identifier.parse("3133742");
     }
 
-    /*
-     * This is here because Identifier.parse wrongly accepts UUIDs without
-     * dashes, but we want to be backward compatible.
-     */
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testParseInvalidUuid() {
-        UUID ref = UUID.fromString("2f234454-cf6d-4a0f-adf2-f4911ba9ffa6");
         Identifier id = Identifier.parse("2f234454cf6d4a0fadf2f4911ba9ffa6");
-        assertEquals("Malformed UUID was parsed as expected.", id.toUuid(), ref);
     }
 }

--- a/src/test/java/org/altbeacon/beacon/RegionTest.java
+++ b/src/test/java/org/altbeacon/beacon/RegionTest.java
@@ -92,14 +92,4 @@ public class RegionTest {
         Region region = new Region("myRegion", Identifier.parse("1"), Identifier.parse("2"), null);
         assertEquals("id1: 1 id2: 2 id3: null", region.toString());
     }
-
-    @Test
-    public void testConvenienceIdentifierAccessors() {
-        Region region = new Region("myRegion", Identifier.parse("1"), Identifier.parse("2"), Identifier.parse("3"));
-        assertEquals("1", region.getId1().toString());
-        assertEquals("2", region.getId2().toString());
-        assertEquals("3", region.getId3().toString());
-    }
-
-
 }


### PR DESCRIPTION
This is my wishlist for the next major version (breaking changes).

Convenience access for the first three Identifiers in a Region is complete madness. It provokes off-by-ones (consider `getId1()` vs. `getIdentifier(0)`) and implies that the first three Identifiers are somewhat special when they are not. My solution is removal of those. The constructor for three Identifiers now uses variadic arguments, so you can use it like you always did (just pass three Identifiers, no need to change any code!), but is more flexible.

UUIDs are now implemented correctly and do not maintain the backcompat bug (dashes).

Expect more to come, and please leave comments!
