### PR TITLE
backgroundMode-> false after stopping service, so it starts back up in foreground mode

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -307,6 +307,10 @@ public class BeaconManager {
                     // If this is the last consumer to disconnect, the service will exit
                     // release the serviceMessenger.
                     serviceMessenger = null;
+                    // Reset the mBackgroundMode to false, which is the default value
+                    // This way when we restart ranging or monitoring it will always be in
+                    // foreground mode
+                    mBackgroundMode = false;
                 }
             }
             else {


### PR DESCRIPTION
This addresses the issue described here:

https://github.com/AltBeacon/android-beacon-library-reference/issues/10

Where all beacon consumers unbinding can leave the library in a background scanning state.