### PR TITLE
use a private executor to avoid starving the default queue

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -57,6 +57,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 
 /**
@@ -78,6 +80,7 @@ public class BeaconService extends Service {
     private CycledLeScanner mCycledScanner;
     private boolean mBackgroundFlag = false;
     private GattBeaconTracker mGattBeaconTracker = new GattBeaconTracker();
+    private ExecutorService mExecutor;
 
     /*
      * The scan period is how long we wait between restarting the BLE advertisement scans
@@ -198,6 +201,10 @@ public class BeaconService extends Service {
         LogManager.i(TAG, "beaconService version %s is starting up", BuildConfig.VERSION_NAME );
         bluetoothCrashResolver = new BluetoothCrashResolver(this);
         bluetoothCrashResolver.start();
+
+        // Create a private executor so we don't compete with threads used by AsyncTask
+        mExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()*2+1);
+
         mCycledScanner = CycledLeScanner.createScanner(this, BeaconManager.DEFAULT_FOREGROUND_SCAN_PERIOD,
                 BeaconManager.DEFAULT_FOREGROUND_BETWEEN_SCAN_PERIOD, mBackgroundFlag,  mCycledLeScanCallback,  bluetoothCrashResolver);
 
@@ -289,12 +296,12 @@ public class BeaconService extends Service {
         mCycledScanner.setScanPeriods(scanPeriod, betweenScanPeriod, backgroundFlag);
     }
 
-    private CycledLeScanCallback mCycledLeScanCallback = new CycledLeScanCallback() {
+    protected CycledLeScanCallback mCycledLeScanCallback = new CycledLeScanCallback() {
         @TargetApi(Build.VERSION_CODES.HONEYCOMB)
         @Override
         public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {
             try {
-                new ScanProcessor().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR,
+                new ScanProcessor().executeOnExecutor(mExecutor,
                         new ScanData(device, rssi, scanRecord));
             }
             catch (RejectedExecutionException e) {
@@ -438,6 +445,7 @@ public class BeaconService extends Service {
             for (BeaconParser parser : BeaconService.this.beaconParsers) {
                 beacon = parser.fromScanData(scanData.scanRecord,
                         scanData.rssi, scanData.device);
+
                 if (beacon != null) {
                     break;
                 }
@@ -477,5 +485,4 @@ public class BeaconService extends Service {
 
         return matched;
     }
-
 }

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -202,7 +202,8 @@ public class BeaconService extends Service {
         bluetoothCrashResolver.start();
 
         // Create a private executor so we don't compete with threads used by AsyncTask
-        mExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()*2+1);
+        // This uses fewer threads than the default executor so it won't hog CPU
+        mExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()+1);
 
         mCycledScanner = CycledLeScanner.createScanner(this, BeaconManager.DEFAULT_FOREGROUND_SCAN_PERIOD,
                 BeaconManager.DEFAULT_FOREGROUND_BETWEEN_SCAN_PERIOD, mBackgroundFlag,  mCycledLeScanCallback,  bluetoothCrashResolver);

--- a/src/test/java/org/altbeacon/beacon/service/BeaconServiceTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/BeaconServiceTest.java
@@ -51,7 +51,6 @@ public class BeaconServiceTest {
         int activeThreadCountBeforeScan = executor.getActiveCount();
 
         byte[] scanRecord = new byte[1];
-        android.bluetooth.BluetoothDevice device = getTestBluetoothDevice();
         callback.onLeScan(null, -59, scanRecord);
 
         int activeThreadCountAfterScan = executor.getActiveCount();
@@ -62,15 +61,5 @@ public class BeaconServiceTest {
         // Need to sleep here until the thread in the above method completes, otherwise an exception
         // is thrown.  Maybe we don't care about this exception, so we could remove this.
         Thread.sleep(100);
-    }
-
-    private android.bluetooth.BluetoothDevice getTestBluetoothDevice() throws Exception {
-        // Use reflection to make a BluetoothDevice for testing, working around the private
-        // constructor
-        Constructor<android.bluetooth.BluetoothDevice> c =
-                android.bluetooth.BluetoothDevice.class.getDeclaredConstructor();
-        c.setAccessible(true);
-        android.bluetooth.BluetoothDevice device =  c.newInstance();
-        return device;
     }
 }

--- a/src/test/java/org/altbeacon/beacon/service/BeaconServiceTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/BeaconServiceTest.java
@@ -1,0 +1,76 @@
+package org.altbeacon.beacon.service;
+
+import android.annotation.TargetApi;
+import android.bluetooth.BluetoothDevice;
+import android.os.AsyncTask;
+import android.os.Build;
+
+import org.altbeacon.beacon.BeaconManager;
+import org.altbeacon.beacon.logging.LogManager;
+import org.altbeacon.beacon.logging.Loggers;
+import org.altbeacon.beacon.service.scanner.CycledLeScanCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by dyoung on 7/1/15.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(emulateSdk = 18)
+public class BeaconServiceTest {
+
+    @Before
+    public void before() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        LogManager.setLogger(Loggers.verboseLogger());
+        LogManager.setVerboseLoggingEnabled(true);
+        BeaconManager.setsManifestCheckingDisabled(true);
+    }
+
+    /**
+     * This test verifies that processing a beacon in a scan (which starts its own thread) does not
+     * affect the size of the available threads in the main Android AsyncTask.THREAD_POOL_EXECUTOR
+     * @throws Exception
+     */
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    @Test
+    public void beaconScanCallbackTest() throws Exception {
+        BeaconService beaconService = new BeaconService();
+        beaconService.onCreate();
+        CycledLeScanCallback callback = beaconService.mCycledLeScanCallback;
+
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) AsyncTask.THREAD_POOL_EXECUTOR;
+        int activeThreadCountBeforeScan = executor.getActiveCount();
+
+        byte[] scanRecord = new byte[1];
+        android.bluetooth.BluetoothDevice device = getTestBluetoothDevice();
+        callback.onLeScan(null, -59, scanRecord);
+
+        int activeThreadCountAfterScan = executor.getActiveCount();
+
+        assertEquals("The size of the Android thread pool should be unchanged by beacon scanning",
+                activeThreadCountBeforeScan, activeThreadCountAfterScan);
+
+        // Need to sleep here until the thread in the above method completes, otherwise an exception
+        // is thrown.  Maybe we don't care about this exception, so we could remove this.
+        Thread.sleep(100);
+    }
+
+    private android.bluetooth.BluetoothDevice getTestBluetoothDevice() throws Exception {
+        // Use reflection to make a BluetoothDevice for testing, working around the private
+        // constructor
+        Constructor<android.bluetooth.BluetoothDevice> c =
+                android.bluetooth.BluetoothDevice.class.getDeclaredConstructor();
+        c.setAccessible(true);
+        android.bluetooth.BluetoothDevice device =  c.newInstance();
+        return device;
+    }
+}


### PR DESCRIPTION
Simple implementation to avoid maxing out the AsyncTask.THREAD_POOL_EXECUTOR by using it for scan processing threads