### PR TITLE
Detect various AltBeacon manufacturers in the foreground

### DIFF
--- a/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
@@ -41,7 +41,16 @@ public class AltBeaconParser extends BeaconParser {
      */
     public AltBeaconParser() {
         super();
-        mHardwareAssistManufacturers = new int[]{0x0118}; // Radius networks
+        // Radius networks and other manufacturers seen in AltBeacons
+        // Note: Other manufacturer codes that have been seen in the wild with AltBeacons are:
+        // 0x004c, 0x00e0
+        // We are not adding these here because there is no indication they are widely used
+        // for production purposes.  We need to keep the hardware assist list short in order to
+        // save slots.  If you are a manufacturer of AltBeacons and want you company code added to
+        // this list, please open an issue on the Github project for this library.  If a beacon
+        // manufacturer code not in this list is used for AltBeacons, phones using Andoroid 5.x+
+        // detection APIs will not be able to detect the beacon in the background.
+        mHardwareAssistManufacturers = new int[]{0x0118};
         this.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
     }
     /**

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -166,6 +166,9 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
         if (mBackgroundFlag) {
             LogManager.d(TAG, "starting scan in SCAN_MODE_LOW_POWER");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
+            filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
+                    mBeaconManager.getBeaconParsers());
+
         } else {
             LogManager.d(TAG, "starting scan in SCAN_MODE_LOW_LATENCY");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();
@@ -174,11 +177,9 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
 
         try {
             if (getScanner() != null) {
-                List scanFilters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
-                        mBeaconManager.getBeaconParsers());
                 ScanCallback callback = getNewLeScanCallback();
                 try {
-                    getScanner().startScan(scanFilters, settings, callback);
+                    getScanner().startScan(filters, settings, callback);
                 }
                 catch (NullPointerException npe) {
                     // Necessary because of https://code.google.com/p/android/issues/detail?id=160503

--- a/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -215,6 +215,22 @@ public class BeaconParserTest {
     }
 
     @Test
+    public void testParseProblematicBeaconFromIssue229() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+
+        // Note that the length field below is 0x16 instead of 0x1b, indicating that the packet ends
+        // one byte before the second identifier field starts
+
+        byte[] bytes = hexStringToByteArray("0201061bffe000beac7777772e626c756b692e636f6d000100010001abaa000000");
+        BeaconParser parser = new BeaconParser();
+        parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
+
+        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        assertNotNull("beacon should be parsed", beacon);
+    }
+
+
+    @Test
     public void testCanParseLocationBeacon() {
         double latitude = 38.93;
         double longitude = -77.23;


### PR DESCRIPTION
A recent commit put into 2.3.0 and 2.3.1 inadvertently started using scan filters on Android 5.x devices in the foreground:

https://github.com/AltBeacon/android-beacon-library/commit/66f9698b194dcf389f514d567816477e8da7b47f#diff-cbe9383c235303f12aa05161f0ed907cR177

Normally this would be no problem, but in some cases the scan filters did not match some beacon types, including AltBeacons with manufacturer type codes of 0x00e0 (Google) and 0x004c (Apple).  These unexpected manufacturer codes did not match the filter, causing no detections of these beacons to happen at all.

This change reverts the change so no filters are active in the foreground.  However, beacon transmitters using these non-standard manufacturer codes for AltBeacons will still fail to match the filters in the background, meaning these beacons can only be detected in the foreground.

Beacon buyers beware!