### PR TITLE
Correct PDU length calculation and protect against overruns

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -394,11 +394,6 @@ public class BeaconParser {
                 serviceUuidBytes = longToByteArray(getServiceUuid(), mServiceUuidEndOffset - mServiceUuidStartOffset + 1, false);
             }
             startByte = pduToParse.getStartIndex();
-            LogManager.d(TAG, "actual length: "+pduToParse.getActualLength());
-            LogManager.d(TAG, "declared length: "+pduToParse.getDeclaredLength());
-            LogManager.d(TAG, "start Index: "+pduToParse.getStartIndex());
-            LogManager.d(TAG, "end Index: "+pduToParse.getEndIndex());
-            LogManager.d(TAG, "end-start+1: "+(pduToParse.getEndIndex()-pduToParse.getStartIndex()+1));
             boolean patternFound = false;
 
             if (getServiceUuid() == null) {
@@ -470,8 +465,6 @@ public class BeaconParser {
                         dataFields.add(new Long(0l));
                     }
                     else {
-
-                        LogManager.d(TAG, "Getting data field starting at byte "+(mDataStartOffsets.get(i) + startByte)+" and going to byte "+endIndex );
                         String dataString = byteArrayToFormattedString(bytesToProcess, mDataStartOffsets.get(i) + startByte, endIndex, mDataLittleEndianFlags.get(i));
                         dataFields.add(Long.parseLong(dataString));
                     }

--- a/src/main/java/org/altbeacon/bluetooth/BleAdvertisement.java
+++ b/src/main/java/org/altbeacon/bluetooth/BleAdvertisement.java
@@ -19,6 +19,7 @@ public class BleAdvertisement {
         mBytes = bytes;
         mPdus = parsePdus();
     }
+
     private List<Pdu> parsePdus() {
         ArrayList<Pdu> pdus = new ArrayList<Pdu>();
         Pdu pdu = null;

--- a/src/main/java/org/altbeacon/bluetooth/BleAdvertisement.java
+++ b/src/main/java/org/altbeacon/bluetooth/BleAdvertisement.java
@@ -19,7 +19,6 @@ public class BleAdvertisement {
         mBytes = bytes;
         mPdus = parsePdus();
     }
-
     private List<Pdu> parsePdus() {
         ArrayList<Pdu> pdus = new ArrayList<Pdu>();
         Pdu pdu = null;

--- a/src/main/java/org/altbeacon/bluetooth/Pdu.java
+++ b/src/main/java/org/altbeacon/bluetooth/Pdu.java
@@ -2,12 +2,6 @@ package org.altbeacon.bluetooth;
 
 import android.annotation.TargetApi;
 import android.os.Build;
-import android.util.Log;
-
-import org.altbeacon.beacon.logging.LogManager;
-
-import java.util.ArrayList;
-import java.util.Arrays;
 
 /**
  * Converts a byte string from a Bluetooth LE scan into a Payload Data Unit (PDU)

--- a/src/main/java/org/altbeacon/bluetooth/Pdu.java
+++ b/src/main/java/org/altbeacon/bluetooth/Pdu.java
@@ -4,6 +4,8 @@ import android.annotation.TargetApi;
 import android.os.Build;
 import android.util.Log;
 
+import org.altbeacon.beacon.logging.LogManager;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -39,7 +41,7 @@ public class Pdu {
                 int firstIndex = startIndex + 2;
                 if (firstIndex < bytes.length) {
                     pdu = new Pdu();
-                    pdu.mEndIndex = firstIndex + length - 2;
+                    pdu.mEndIndex = firstIndex + length - 1;
                     if (pdu.mEndIndex >= bytes.length) {
                         pdu.mEndIndex = bytes.length - 1;
                     }

--- a/src/test/java/org/altbeacon/beacon/AltBeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/AltBeaconParserTest.java
@@ -77,7 +77,7 @@ public class AltBeaconParserTest {
     public void testParsesBeaconMissingDataField() {
         BeaconManager.setDebug(true);
         org.robolectric.shadows.ShadowLog.stream = System.err;
-        byte[] bytes = hexStringToByteArray("02011a1aff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c5");
+        byte[] bytes = hexStringToByteArray("02011a1aff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c5000000");
         AltBeaconParser parser = new AltBeaconParser();
         Beacon beacon = parser.fromScanData(bytes, -55, null);
         assertEquals("mRssi should be as passed in", -55, beacon.getRssi());

--- a/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -55,7 +55,7 @@ public class BeaconParserTest {
 
     @Test
     public void testSetBeaconLayout() {
-        byte[] bytes = hexStringToByteArray("02011a1bffbeac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
+        byte[] bytes = hexStringToByteArray("02011a1bffbeac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
 
@@ -86,9 +86,9 @@ public class BeaconParserTest {
     public void testRecognizeBeacon() {
         LogManager.setLogger(Loggers.verboseLogger());
         org.robolectric.shadows.ShadowLog.stream = System.err;
-        byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
+        byte[] bytes = hexStringToByteArray("02011a1aff180112342f234454cf6d4a0fadf2f4911ba9ffa600010002c5");
         BeaconParser parser = new BeaconParser();
-        parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
+        parser.setBeaconLayout("m:2-3=1234,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
         Beacon beacon = parser.fromScanData(bytes, -55, null);
         assertEquals("mRssi should be as passed in", -55, beacon.getRssi());
         assertEquals("uuid should be parsed", "2f234454-cf6d-4a0f-adf2-f4911ba9ffa6", beacon.getIdentifier(0).toString());
@@ -102,7 +102,7 @@ public class BeaconParserTest {
     public void testParsesBeaconMissingDataField() {
         LogManager.setLogger(Loggers.verboseLogger());
         org.robolectric.shadows.ShadowLog.stream = System.err;
-        byte[] bytes = hexStringToByteArray("02011a1aff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c5");
+        byte[] bytes = hexStringToByteArray("02011a1aff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c5000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
         Beacon beacon = parser.fromScanData(bytes, -55, null);
@@ -121,7 +121,7 @@ public class BeaconParserTest {
     public void testRecognizeBeaconWithFormatSpecifyingManufacturer() {
         LogManager.setLogger(Loggers.verboseLogger());
         org.robolectric.shadows.ShadowLog.stream = System.err;
-        byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
+        byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:0-3=1801beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
         Beacon beacon = parser.fromScanData(bytes, -55, null);
@@ -150,7 +150,7 @@ public class BeaconParserTest {
     @Test
     public void testLittleEndianIdentifierParsing() {
         org.robolectric.shadows.ShadowLog.stream = System.err;
-        byte[] bytes = hexStringToByteArray("02011a1bff1801beac0102030405060708090a0b0c0d0e0f1011121314c509");
+        byte[] bytes = hexStringToByteArray("02011a1bff1801beac0102030405060708090a0b0c0d0e0f1011121314c50900000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-9,i:10-15l,i:16-23,p:24-24,d:25-25");
         Beacon beacon = parser.fromScanData(bytes, -55, null);
@@ -190,24 +190,25 @@ public class BeaconParserTest {
 
 
     @Test
-    public void testParseIdentifierThatRunsOverPduLength() {
+    public void testParseGattIdentifierThatRunsOverPduLength() {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         byte[] bytes = hexStringToByteArray("0201060303aafe0d16aafe10e702676f6f676c65000c09526164426561636f6e204700000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser();
+        parser.setAllowPduOverflow(false);
         parser.setBeaconLayout("s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-20");
         Beacon beacon = parser.fromScanData(bytes, -55, null);
         assertNull("beacon should not be parsed", beacon);
-
     }
 
     @Test
-    public void testParseIdentifierThatRunsUnderPduLength() {
+    public void testParseManufacturerIdentifierThatRunsOverPduLength() {
         org.robolectric.shadows.ShadowLog.stream = System.err;
 
         // Note that the length field below is 0x16 instead of 0x1b, indicating that the packet ends
         // one byte before the second identifier field starts
-        byte[] bytes = hexStringToByteArray("02011a16ff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
+        byte[] bytes = hexStringToByteArray("02011a16ff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509000000");
         BeaconParser parser = new BeaconParser();
+        parser.setAllowPduOverflow(false);
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
 
         Beacon beacon = parser.fromScanData(bytes, -55, null);

--- a/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
+++ b/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
@@ -8,6 +8,7 @@ import android.content.Context;
 
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.logging.Loggers;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -15,6 +16,8 @@ import java.util.Arrays;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+
 import org.robolectric.annotation.Config;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
@@ -34,17 +37,28 @@ public class GattBeaconTest {
         LogManager.setLogger(Loggers.verboseLogger());
         LogManager.setVerboseLoggingEnabled(true);
         System.err.println("verbose logging:"+LogManager.isVerboseLoggingEnabled());
-        byte[] bytes = hexStringToByteArray("0201060303f4fe161601230025c5454452e29735323d81c0060504030201");
-        BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=2301,m:2-2=00,d:3-3,p:4-4:41,i:5-14,i:15-20");
+        byte[] bytes = hexStringToByteArray("020106030334121516341200e72f234454f4911ba9ffa6000000000001000000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=00,p:3-3:-41,i:4-13,i:14-19");
         assertNotNull("Service uuid parsed should not be null", parser.getServiceUuid());
         Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
         LogManager.d("xxx", "where is my debug");
         LogManager.e("xxx", "where is my debug");
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
-        assertEquals("id1 should be parsed", "0x454452e29735323d81c0", gattBeacon.getId1().toString());
-        assertEquals("id2 should be parsed", "0x060504030201", gattBeacon.getId2().toString());
-        assertEquals("serviceUuid should be parsed", 0x2301, gattBeacon.getServiceUuid());
-        assertEquals("txPower should be parsed", -18, gattBeacon.getTxPower());
+        assertEquals("id1 should be parsed", "0x2f234454f4911ba9ffa6", gattBeacon.getId1().toString());
+        assertEquals("id2 should be parsed", "0x000000000001", gattBeacon.getId2().toString());
+        assertEquals("serviceUuid should be parsed", 0x1234, gattBeacon.getServiceUuid());
+        assertEquals("txPower should be parsed", -66, gattBeacon.getTxPower());
+    }
+
+    @Test
+    public void testDetectsGattBeacon2() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        LogManager.setLogger(Loggers.verboseLogger());
+        LogManager.setVerboseLoggingEnabled(true);
+        byte[] bytes = hexStringToByteArray("020106030334121516341210ec007261646975736e6574776f726b7307000000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=10,p:3-3:-41,i:4-20");
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
     }
 
     @Test

--- a/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
+++ b/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
@@ -41,8 +41,6 @@ public class GattBeaconTest {
         BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=00,p:3-3:-41,i:4-13,i:14-19");
         assertNotNull("Service uuid parsed should not be null", parser.getServiceUuid());
         Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
-        LogManager.d("xxx", "where is my debug");
-        LogManager.e("xxx", "where is my debug");
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
         assertEquals("id1 should be parsed", "0x2f234454f4911ba9ffa6", gattBeacon.getId1().toString());
         assertEquals("id2 should be parsed", "0x000000000001", gattBeacon.getId2().toString());
@@ -56,10 +54,41 @@ public class GattBeaconTest {
         LogManager.setLogger(Loggers.verboseLogger());
         LogManager.setVerboseLoggingEnabled(true);
         byte[] bytes = hexStringToByteArray("020106030334121516341210ec007261646975736e6574776f726b7307000000000000000000000000000000000000000000000000000000000000000000");
-        BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=10,p:3-3:-41,i:4-20");
+        BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=10,p:3-3:-41,i:4-20v");
         Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
+        assertEquals("GattBeacon identifier length should be proper length",
+                17,
+                gattBeacon.getId1().toByteArray().length);
+
     }
+
+    @Test
+    public void testDetectsGattBeacon2WithShortIdentifier() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        LogManager.setLogger(Loggers.verboseLogger());
+        LogManager.setVerboseLoggingEnabled(true);
+        LogManager.d("GattBeaconTest", "Parsing short packet");
+        byte[] bytes = hexStringToByteArray("020106030334121416341210ec007261646975736e6574776f726b7307000000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=10,p:3-3:-41,i:4-20v");
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
+        assertEquals("GattBeacon identifier length should be adjusted smaller if packet is short",
+                     16,
+                     gattBeacon.getId1().toByteArray().length);
+        assertEquals("GattBeacon identifier should have proper first byte",
+                (byte)0x00,
+                gattBeacon.getId1().toByteArray()[0]);
+        assertEquals("GattBeacon identifier should have proper second to last byte",
+                (byte)0x73,
+                gattBeacon.getId1().toByteArray()[14]);
+        assertEquals("GattBeacon identifier should have proper last byte",
+                (byte)0x07,
+                gattBeacon.getId1().toByteArray()[15]);
+
+    }
+
+
 
     @Test
     public void testBeaconAdvertisingBytes() {


### PR DESCRIPTION
* Corrected the PDU length calculation was undercounting the length by one byte.  
* Added buffer overrun protection against overruns on BeaconParser layouts that go beyond the length of the actual PDU size.  By default, the `BeaconParserClass`now  has `allowPduOverflow` set to true, allowing malformed packets to be parsed.  This can be configured to false to enforce stricter compliance, but may result in ignoring beacons with malformed PDU lengths.
* Added utility for compressing/decompressing UriBeacon URLs.