### PR TITLE
Enable EddystoneTtransmission

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -654,6 +654,12 @@ public class BeaconParser {
         return mDataStartOffsets.size();
     }
 
+    /**
+     * @return the correction value in dBm to apply to the calibrated txPower to get a 1m calibrated value.
+     * Some formats like Eddystone use a 0m calibrated value, which requires this correction
+     */
+    public int getPowerCorrection() { return mDBmCorrection; }
+
     protected static String bytesToHex(byte[] bytes) {
         char[] hexChars = new char[bytes.length * 2];
         int v;

--- a/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
@@ -150,7 +150,7 @@ public class BeaconTransmitter {
             throw new NullPointerException("Beacon cannot be null.  Set beacon before starting advertising");
         }
         int manufacturerCode = mBeacon.getManufacturer();
-        int serviceUuid = mBeacon.getServiceUuid();
+        int serviceUuid = mBeaconParser.getServiceUuid().intValue();
 
         if (mBeaconParser == null) {
             throw new NullPointerException("You must supply a BeaconParser instance to BeaconTransmitter.");
@@ -172,8 +172,8 @@ public class BeaconTransmitter {
             AdvertiseData.Builder dataBuilder = new AdvertiseData.Builder();
             if (serviceUuid > 0) {
                 byte[] serviceUuidBytes = new byte[] {
-                        (byte) ((serviceUuid >> 8) & 0xff),
-                        (byte) (serviceUuid & 0xff)};
+                        (byte) (serviceUuid & 0xff),
+                        (byte) ((serviceUuid >> 8) & 0xff)};
                 ParcelUuid parcelUuid = parseUuidFrom(serviceUuidBytes);
                 dataBuilder.addServiceData(parcelUuid, advertisingBytes);
             }

--- a/src/test/java/org/altbeacon/beacon/BeaconTransmitterTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconTransmitterTest.java
@@ -1,6 +1,7 @@
 package org.altbeacon.beacon;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -19,6 +20,7 @@ import static junit.framework.Assert.assertEquals;
  */
 @RunWith(RobolectricTestRunner.class)
 public class BeaconTransmitterTest {
+    private static final String TAG = "BeaconTransmitterTest";
 
     @Test
     public void testBeaconAdvertisingBytes() {
@@ -47,4 +49,32 @@ public class BeaconTransmitterTest {
         }
         assertEquals("Advertisement bytes should be as expected", "BE AC 2F 23 44 54 CF 6D 4A 0F AD F2 F4 91 1B A9 FF A6 00 01 00 02 C5 00 ", byteString);
     }
+
+    @Test
+    public void testBeaconAdvertisingBytesForEddystone() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        Context context = Robolectric.getShadowApplication().getApplicationContext();
+
+        Beacon beacon = new Beacon.Builder()
+                .setId1("0x2f234454f4911ba9ffa6")
+                .setId2("0x000000000001")
+                .setManufacturer(0x0118)
+                .setTxPower(-59)
+                .build();
+        BeaconParser beaconParser = new BeaconParser()
+                .setBeaconLayout("s:0-1=feaa,m:2-2=00,p:3-3:-41,i:4-13,i:14-19");
+        byte[] data = beaconParser.getBeaconAdvertisementData(beacon);
+        BeaconTransmitter beaconTransmitter = new BeaconTransmitter(context, beaconParser);
+        // TODO: can't actually start transmitter here because Robolectric does not support API 21
+
+        String byteString = "";
+        for (int i = 0; i < data.length; i++) {
+            byteString += String.format("%02X", data[i]);
+            byteString += " ";
+        }
+        Log.d(TAG, "Advertising bytes are "+byteString );
+        assertEquals("Data should be 24 bytes long", 18, data.length);
+        assertEquals("Advertisement bytes should be as expected", "00 C5 2F 23 44 54 F4 91 1B A9 FF A6 00 00 00 00 00 01 ", byteString);
+    }
+
 }

--- a/src/test/java/org/altbeacon/beacon/IdentifierTest.java
+++ b/src/test/java/org/altbeacon/beacon/IdentifierTest.java
@@ -178,4 +178,45 @@ public class IdentifierTest {
         Identifier id = Identifier.parse("2f234454cf6d4a0fadf2f4911ba9ffa6");
         assertEquals("Malformed UUID was parsed as expected.", id.toUuid(), ref);
     }
+
+    @Test
+    public void testParseHexWithNoPrefix() {
+        Identifier id = Identifier.parse("abcd");
+        assertEquals("Should parse and get back equivalent decimal value for small numbers", "43981", id.toString());
+    }
+
+    @Test
+    public void testParseBigHexWithNoPrefix() {
+        Identifier id = Identifier.parse("123456789abcdef");
+        assertEquals("Should parse and get prefixed hex value for big numbers", "0x0123456789abcdef", id.toString());
+    }
+    @Test
+    public void testParseZeroPrefixedDecimalNumberAsHex() {
+        Identifier id = Identifier.parse("0010");
+        assertEquals("Should be treated as hex in parse, but converted back to decimal because it is small", "16", id.toString());
+    }
+    @Test
+    public void testParseNonZeroPrefixedDecimalNumberAsDecimal() {
+        Identifier id = Identifier.parse("10");
+        assertEquals("Should be treated as decimal", "10", id.toString());
+    }
+    @Test
+    public void testParseDecimalNumberWithSpecifiedLength() {
+        Identifier id = Identifier.parse("10", 8);
+        assertEquals("Should be treated as hex because it is long", "0x000000000000000a", id.toString());
+        assertEquals("Byte count should be as specified", 8, id.getByteCount());
+    }
+    @Test
+    public void testParseDecimalNumberWithSpecifiedShortLength() {
+        Identifier id = Identifier.parse("10", 2);
+        assertEquals("Should be treated as decimal because it is short", "10", id.toString());
+        assertEquals("Byte count should be as specified", 2, id.getByteCount());
+    }
+    @Test
+    public void testParseHexNumberWithSpecifiedLength() {
+        Identifier id = Identifier.parse("2fffffffffffffffffff", 10);
+        assertEquals("Should be treated as hex because it is long", "0x2fffffffffffffffffff", id.toString());
+        assertEquals("Byte count should be as specified", 10, id.getByteCount());
+    }
+
 }


### PR DESCRIPTION
* Expose parser service uuid to transmitter
* Fix endianness of service uuid
* Allow more flexibility in parsing identifiers and specifying lengths