### PR TITLE
Eddystone url transmitter support

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -150,6 +150,8 @@ public class BeaconParser {
      */
     public BeaconParser setBeaconLayout(String beaconLayout) {
 
+        Log.d(TAG, "Parsing beacon layout: "+beaconLayout);
+
         String[] terms =  beaconLayout.split(",");
         mExtraFrame = false; // this is not an extra frame by default
 
@@ -563,6 +565,7 @@ public class BeaconParser {
      * @param beacon the beacon containing the data to be transmitted
      * @return the byte array of the advertisement
      */
+    @TargetApi(Build.VERSION_CODES.GINGERBREAD)
     public byte[] getBeaconAdvertisementData(Beacon beacon) {
         byte[] advertisingBytes;
 
@@ -573,7 +576,7 @@ public class BeaconParser {
         if (mPowerEndOffset != null && mPowerEndOffset > lastIndex) {
             lastIndex = mPowerEndOffset;
         }
-        for (int identifierNum = 0; identifierNum < this.mIdentifierStartOffsets.size(); identifierNum++) {
+        for (int identifierNum = 0; identifierNum < this.mIdentifierEndOffsets.size(); identifierNum++) {
             if (this.mIdentifierEndOffsets.get(identifierNum) != null && this.mIdentifierEndOffsets.get(identifierNum) > lastIndex) {
                 lastIndex = this.mIdentifierEndOffsets.get(identifierNum);
             }
@@ -587,10 +590,12 @@ public class BeaconParser {
         // we must adjust the lastIndex to account for variable length identifiers, if there are any.
         int adjustedIdentifiersLength = 0;
         for (int identifierNum = 0; identifierNum < this.mIdentifierStartOffsets.size(); identifierNum++) {
-            int declaredIdentifierLength = (this.mIdentifierEndOffsets.get(identifierNum) - this.mIdentifierStartOffsets.get(identifierNum)+1);
-            int actualIdentifierLength = beacon.getIdentifier(identifierNum).getByteCount();
-            adjustedIdentifiersLength += actualIdentifierLength;
-            adjustedIdentifiersLength -= declaredIdentifierLength;
+            if (mIdentifierVariableLengthFlags.get(identifierNum)) {
+                int declaredIdentifierLength = (this.mIdentifierEndOffsets.get(identifierNum) - this.mIdentifierStartOffsets.get(identifierNum)+1);
+                int actualIdentifierLength = beacon.getIdentifier(identifierNum).getByteCount();
+                adjustedIdentifiersLength += actualIdentifierLength;
+                adjustedIdentifiersLength -= declaredIdentifierLength;
+            }
         }
         lastIndex += adjustedIdentifiersLength;
 
@@ -605,15 +610,40 @@ public class BeaconParser {
 
         // set identifiers
         for (int identifierNum = 0; identifierNum < this.mIdentifierStartOffsets.size(); identifierNum++) {
-            byte[] identifierBytes = beacon.getIdentifier(identifierNum).toByteArrayOfSpecifiedEndianness(this.mIdentifierLittleEndianFlags.get(identifierNum));
-            for (int index = this.mIdentifierStartOffsets.get(identifierNum); index <= this.mIdentifierStartOffsets.get(identifierNum)+identifierBytes.length-1; index ++) {
-                int identifierByteIndex = this.mIdentifierEndOffsets.get(identifierNum)-index;
-                if (identifierByteIndex < identifierBytes.length) {
-                    advertisingBytes[index-2] = (byte) identifierBytes[this.mIdentifierEndOffsets.get(identifierNum)-index];
+            byte[] identifierBytes = beacon.getIdentifier(identifierNum).toByteArrayOfSpecifiedEndianness(!this.mIdentifierLittleEndianFlags.get(identifierNum));
+
+            // If the identifier we are trying to stuff into the space is different than the space available
+            // adjust it
+            if (identifierBytes.length < getIdentifierByteCount(identifierNum)) {
+                // Pad it
+                if (mIdentifierLittleEndianFlags.get(identifierNum)) {
+                    // this is little endian.  Pad at the end of the array
+                    identifierBytes = Arrays.copyOf(identifierBytes,getIdentifierByteCount(identifierNum));
                 }
                 else {
-                    advertisingBytes[index-2] = 0;
+                    // this is big endian.  Pad at the beginning of the array
+                    byte[] newIdentifierBytes = new byte[getIdentifierByteCount(identifierNum)];
+                    System.arraycopy(identifierBytes, 0, newIdentifierBytes, getIdentifierByteCount(identifierNum)-identifierBytes.length, identifierBytes.length);
+                    identifierBytes = newIdentifierBytes;
                 }
+                LogManager.d(TAG, "Expanded identifier because it is too short.  It is now: "+byteArrayToString(identifierBytes));
+            }
+            else if (identifierBytes.length > getIdentifierByteCount(identifierNum)) {
+                if (mIdentifierLittleEndianFlags.get(identifierNum)) {
+                    // Truncate it at the beginning for big endian
+                    identifierBytes = Arrays.copyOfRange(identifierBytes, getIdentifierByteCount(identifierNum)-identifierBytes.length, getIdentifierByteCount(identifierNum));
+                }
+                else {
+                    // Truncate it at the end for little endian
+                    identifierBytes = Arrays.copyOf(identifierBytes,getIdentifierByteCount(identifierNum));
+                }
+                LogManager.d(TAG, "Truncated identifier because it is too long.  It is now: "+byteArrayToString(identifierBytes));
+            }
+            else {
+                LogManager.d(TAG, "Identifier size is just right: "+byteArrayToString(identifierBytes));
+            }
+            for (int index = this.mIdentifierStartOffsets.get(identifierNum); index <= this.mIdentifierStartOffsets.get(identifierNum)+identifierBytes.length-1; index ++) {
+                advertisingBytes[index-2] = (byte) identifierBytes[index-this.mIdentifierStartOffsets.get(identifierNum)];
             }
         }
 
@@ -625,6 +655,7 @@ public class BeaconParser {
         // set data fields
         for (int dataFieldNum = 0; dataFieldNum < this.mDataStartOffsets.size(); dataFieldNum++) {
             long dataField = beacon.getDataFields().get(dataFieldNum);
+
             for (int index = this.mDataStartOffsets.get(dataFieldNum); index <= this.mDataEndOffsets.get(dataFieldNum); index ++) {
                 int endianCorrectedIndex = index;
                 if (this.mDataLittleEndianFlags.get(dataFieldNum)) {

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -584,6 +584,16 @@ public class BeaconParser {
             }
         }
 
+        // we must adjust the lastIndex to account for variable length identifiers, if there are any.
+        int adjustedIdentifiersLength = 0;
+        for (int identifierNum = 0; identifierNum < this.mIdentifierStartOffsets.size(); identifierNum++) {
+            int declaredIdentifierLength = (this.mIdentifierEndOffsets.get(identifierNum) - this.mIdentifierStartOffsets.get(identifierNum)+1);
+            int actualIdentifierLength = beacon.getIdentifier(identifierNum).getByteCount();
+            adjustedIdentifiersLength += actualIdentifierLength;
+            adjustedIdentifiersLength -= declaredIdentifierLength;
+        }
+        lastIndex += adjustedIdentifiersLength;
+
         advertisingBytes = new byte[lastIndex+1-2];
         long beaconTypeCode = this.getMatchingBeaconTypeCode();
 
@@ -596,7 +606,7 @@ public class BeaconParser {
         // set identifiers
         for (int identifierNum = 0; identifierNum < this.mIdentifierStartOffsets.size(); identifierNum++) {
             byte[] identifierBytes = beacon.getIdentifier(identifierNum).toByteArrayOfSpecifiedEndianness(this.mIdentifierLittleEndianFlags.get(identifierNum));
-            for (int index = this.mIdentifierStartOffsets.get(identifierNum); index <= this.mIdentifierEndOffsets.get(identifierNum); index ++) {
+            for (int index = this.mIdentifierStartOffsets.get(identifierNum); index <= this.mIdentifierStartOffsets.get(identifierNum)+identifierBytes.length-1; index ++) {
                 int identifierByteIndex = this.mIdentifierEndOffsets.get(identifierNum)-index;
                 if (identifierByteIndex < identifierBytes.length) {
                     advertisingBytes[index-2] = (byte) identifierBytes[this.mIdentifierEndOffsets.get(identifierNum)-index];

--- a/src/main/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressor.java
+++ b/src/main/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressor.java
@@ -1,5 +1,6 @@
 package org.altbeacon.beacon.utils;
 
+import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -10,17 +11,20 @@ import java.util.regex.Pattern;
 /**
  * Provides encoding / decoding functions for the URL beacon https://github.com/google/uribeacon
  */
-public class UrlBeaconUrlCompressor {
+public class UrlBeaconUrlCompressor  {
 
-    private static final String EXPANSION_CODE_URL_REGEX = "^(http|https):\\/\\/(www.)?((?:[0-9a-z_-]+\\.??)+)(\\.[0-9a-z_-]+\\/?)(.*)$";
-    private static final int EXPANSION_CODE_URL_PROTOCOL_GROUP = 1;
-    private static final int EXPANSION_CODE_URL_WWW_GROUP      = 2;
-    private static final int EXPANSION_CODE_URL_HOST_GROUP     = 3;
-    private static final int EXPANSION_CODE_URL_TLD_GROUP      = 4;
-    private static final int EXPANSION_CODE_URL_PATH_GROUP     = 5;
+    private static final String EDDYSTONE_URL_REGEX = "^(http|https):\\/\\/(www\\.)?((?:[0-9a-z_-]+\\.?)+)(/?)([./0-9a-z_-]*)"; // Break into components
+    private static final int EDDYSTONE_URL_PROTOCOL_GROUP = 1;
+    private static final int EDDYSTONE_URL_WWW_GROUP      = 2;
+    private static final int EDDYSTONE_URL_FQDN_GROUP     = 3;
+    private static final int EDDYSTONE_URL_SLASH_GROUP      = 4;
+    private static final int EDDYSTONE_URL_PATH_GROUP     = 5;
 
+    private static final String URL_PROTOCOL_HTTP_WWW_DOT  = "http://www.";
+    private static final String URL_PROTOCOL_HTTPS_WWW_DOT = "https://www.";
     private static final String URL_PROTOCOL_HTTP  = "http";
-    private static final String URL_PROTOCOL_HTTPS = "https";
+    private static final String URL_PROTOCOL_HTTP_COLON_SLASH_SLASH  = "http://";
+    private static final String URL_PROTOCOL_HTTPS_COLON_SLASH_SLASH = "https://";
     private static final String URL_HOST_WWW = "www.";
     private static final String URL_TLD_DOT_COM =  ".com";
     private static final String URL_TLD_DOT_ORG =  ".org";
@@ -37,25 +41,25 @@ public class UrlBeaconUrlCompressor {
     private static final String URL_TLD_DOT_BIZ_SLASH =  ".biz/";
     private static final String URL_TLD_DOT_GOV_SLASH =  ".gov/";
 
-    private static final byte EXPANSION_CODE_URL_PROTOCOL_HTTP_WWW  = 0x00;
-    private static final byte EXPANSION_CODE_URL_PROTOCOL_HTTPS_WWW = 0x01;
-    private static final byte EXPANSION_CODE_URL_PROTOCOL_HTTP      = 0x02;
-    private static final byte EXPANSION_CODE_URL_PROTOCOL_HTTPS     = 0x03;
+    private static final byte EDDYSTONE_URL_PROTOCOL_HTTP_WWW  = 0x00;
+    private static final byte EDDYSTONE_URL_PROTOCOL_HTTPS_WWW = 0x01;
+    private static final byte EDDYSTONE_URL_PROTOCOL_HTTP      = 0x02;
+    private static final byte EDDYSTONE_URL_PROTOCOL_HTTPS     = 0x03;
 
-    private static final byte EXPANSION_CODE_URL_COM_SLASH  = 0x00;
-    private static final byte EXPANSION_CODE_URL_ORG_SLASH  = 0x01;
-    private static final byte EXPANSION_CODE_URL_EDU_SLASH  = 0x02;
-    private static final byte EXPANSION_CODE_URL_NET_SLASH  = 0x03;
-    private static final byte EXPANSION_CODE_URL_INFO_SLASH = 0x04;
-    private static final byte EXPANSION_CODE_URL_BIZ_SLASH  = 0x05;
-    private static final byte EXPANSION_CODE_URL_GOV_SLASH  = 0x06;
-    private static final byte EXPANSION_CODE_URL_COM        = 0x07;
-    private static final byte EXPANSION_CODE_URL_ORG        = 0x08;
-    private static final byte EXPANSION_CODE_URL_EDU        = 0x09;
-    private static final byte EXPANSION_CODE_URL_NET        = 0x0a;
-    private static final byte EXPANSION_CODE_URL_INFO       = 0x0b;
-    private static final byte EXPANSION_CODE_URL_BIZ        = 0x0c;
-    private static final byte EXPANSION_CODE_URL_GOV        = 0x0d;
+    private static final byte EDDYSTONE_URL_COM_SLASH  = 0x00;
+    private static final byte EDDYSTONE_URL_ORG_SLASH  = 0x01;
+    private static final byte EDDYSTONE_URL_EDU_SLASH  = 0x02;
+    private static final byte EDDYSTONE_URL_NET_SLASH  = 0x03;
+    private static final byte EDDYSTONE_URL_INFO_SLASH = 0x04;
+    private static final byte EDDYSTONE_URL_BIZ_SLASH  = 0x05;
+    private static final byte EDDYSTONE_URL_GOV_SLASH  = 0x06;
+    private static final byte EDDYSTONE_URL_COM        = 0x07;
+    private static final byte EDDYSTONE_URL_ORG        = 0x08;
+    private static final byte EDDYSTONE_URL_EDU        = 0x09;
+    private static final byte EDDYSTONE_URL_NET        = 0x0a;
+    private static final byte EDDYSTONE_URL_INFO       = 0x0b;
+    private static final byte EDDYSTONE_URL_BIZ        = 0x0c;
+    private static final byte EDDYSTONE_URL_GOV        = 0x0d;
 
     private static final byte TLD_NOT_ENCODABLE        = (byte) 0xff;
 
@@ -75,26 +79,25 @@ public class UrlBeaconUrlCompressor {
     private static List<TLDMapEntry> tldMap;
     static {
         tldMap = new ArrayList<>();
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_COM_SLASH , EXPANSION_CODE_URL_COM_SLASH ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_ORG_SLASH , EXPANSION_CODE_URL_ORG_SLASH ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_EDU_SLASH , EXPANSION_CODE_URL_EDU_SLASH ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_NET_SLASH , EXPANSION_CODE_URL_NET_SLASH ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_INFO_SLASH, EXPANSION_CODE_URL_INFO_SLASH));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_BIZ_SLASH , EXPANSION_CODE_URL_BIZ_SLASH ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_GOV_SLASH , EXPANSION_CODE_URL_GOV_SLASH ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_COM       , EXPANSION_CODE_URL_COM       ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_ORG       , EXPANSION_CODE_URL_ORG       ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_EDU       , EXPANSION_CODE_URL_EDU       ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_NET       , EXPANSION_CODE_URL_NET       ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_INFO      , EXPANSION_CODE_URL_INFO      ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_BIZ       , EXPANSION_CODE_URL_BIZ       ));
-        tldMap.add(new TLDMapEntry(URL_TLD_DOT_GOV       , EXPANSION_CODE_URL_GOV       ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_COM_SLASH , EDDYSTONE_URL_COM_SLASH ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_ORG_SLASH , EDDYSTONE_URL_ORG_SLASH ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_EDU_SLASH , EDDYSTONE_URL_EDU_SLASH ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_NET_SLASH , EDDYSTONE_URL_NET_SLASH ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_INFO_SLASH, EDDYSTONE_URL_INFO_SLASH));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_BIZ_SLASH , EDDYSTONE_URL_BIZ_SLASH ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_GOV_SLASH , EDDYSTONE_URL_GOV_SLASH ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_COM       , EDDYSTONE_URL_COM       ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_ORG       , EDDYSTONE_URL_ORG       ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_EDU       , EDDYSTONE_URL_EDU       ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_NET       , EDDYSTONE_URL_NET       ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_INFO      , EDDYSTONE_URL_INFO      ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_BIZ       , EDDYSTONE_URL_BIZ       ));
+        tldMap.add(new TLDMapEntry(URL_TLD_DOT_GOV       , EDDYSTONE_URL_GOV       ));
     };
 
     private static byte encodedByteForTopLevelDomain(String tld) {
         byte encodedByte = TLD_NOT_ENCODABLE;
         boolean tldFound = false;
-        int tldMapIndex = 0;
         Iterator<TLDMapEntry> iterator = tldMap.iterator();
         while (! tldFound && iterator.hasNext()) {
             TLDMapEntry entry = iterator.next();
@@ -104,6 +107,20 @@ public class UrlBeaconUrlCompressor {
             }
         }
         return encodedByte;
+    }
+
+    private static String topLevelDomainForByte(Byte encodedByte) {
+        String tld = null;
+        boolean tldFound = false;
+        Iterator<TLDMapEntry> iterator = tldMap.iterator();
+        while (! tldFound && iterator.hasNext()) {
+            TLDMapEntry entry = iterator.next();
+            tldFound = entry.encodedByte == encodedByte;
+            if (tldFound) {
+                tld = entry.tld;
+            }
+        }
+        return tld;
     }
 
     /**
@@ -147,7 +164,7 @@ public class UrlBeaconUrlCompressor {
      * @param urlString
      * @return
      */
-    public static byte[] compress(String urlString)  {
+    public static byte[] compress(String urlString) throws MalformedURLException {
         byte[] compressedBytes = null;
         if (urlString != null) {
             // Figure the compressed bytes can't be longer than the original string.
@@ -155,40 +172,78 @@ public class UrlBeaconUrlCompressor {
             int byteBufferIndex = 0;
             Arrays.fill(byteBuffer, (byte) 0x00);
 
-            Pattern urlPattern = Pattern.compile(EXPANSION_CODE_URL_REGEX);
+            Pattern urlPattern = Pattern.compile(EDDYSTONE_URL_REGEX);
             Matcher urlMatcher = urlPattern.matcher(urlString);
             if (urlMatcher.matches()) {
                 // www.
-                String wwwdot = urlMatcher.group(EXPANSION_CODE_URL_WWW_GROUP);
+                String wwwdot = urlMatcher.group(EDDYSTONE_URL_WWW_GROUP);
                 boolean haswww = (wwwdot != null);
 
                 // Protocol.
-                String protocol = urlMatcher.group(EXPANSION_CODE_URL_PROTOCOL_GROUP);
+                String protocol = urlMatcher.group(EDDYSTONE_URL_PROTOCOL_GROUP);
                 if (protocol.equalsIgnoreCase(URL_PROTOCOL_HTTP)) {
-                    byteBuffer[byteBufferIndex] = (haswww ? EXPANSION_CODE_URL_PROTOCOL_HTTP_WWW : EXPANSION_CODE_URL_PROTOCOL_HTTP);
+                    byteBuffer[byteBufferIndex] = (haswww ? EDDYSTONE_URL_PROTOCOL_HTTP_WWW : EDDYSTONE_URL_PROTOCOL_HTTP);
                 }
                 else {
-                    byteBuffer[byteBufferIndex] = (haswww ? EXPANSION_CODE_URL_PROTOCOL_HTTPS_WWW : EXPANSION_CODE_URL_PROTOCOL_HTTPS);
+                    byteBuffer[byteBufferIndex] = (haswww ? EDDYSTONE_URL_PROTOCOL_HTTPS_WWW : EDDYSTONE_URL_PROTOCOL_HTTPS);
                 }
                 byteBufferIndex++;
 
-                // Hostname.
-                byte[] hostnameBytes = urlMatcher.group(EXPANSION_CODE_URL_HOST_GROUP).getBytes();
-                int hostnameLength = hostnameBytes.length;
-                System.arraycopy(hostnameBytes, 0, byteBuffer, byteBufferIndex, hostnameLength);
-                byteBufferIndex += hostnameLength;
+                // Fully-qualified domain name (FQDN).  This includes the hostname and any other components after the dots
+                // but BEFORE the first single slash in the URL.
+                byte[] hostnameBytes = urlMatcher.group(EDDYSTONE_URL_FQDN_GROUP).getBytes();
+                String hostname = new String(hostnameBytes);
+                String[] domains = hostname.split(Pattern.quote("."));
 
-                // Optional TLD.
-                String tld = urlMatcher.group(EXPANSION_CODE_URL_TLD_GROUP);
-                if (tld != null) {
-                    byte encodedTLDByte = encodedByteForTopLevelDomain(tld);
-                    if (encodedTLDByte != TLD_NOT_ENCODABLE) {
-                        byteBuffer[byteBufferIndex++] = encodedTLDByte;
+                boolean consumedSlash = false;
+                if (domains != null) {
+                    // Write the hostname/subdomains prior to the last one.  If there's only one (e. g. http://localhost)
+                    // then that's the only thing to write out.
+                    byte[] periodBytes = {'.'};
+                    int writableDomainsCount = (domains.length == 1 ? 1 : domains.length - 1);
+                    for (int domainIndex = 0; domainIndex < writableDomainsCount; domainIndex++) {
+                        // Write out leading period, if necessary.
+                        if (domainIndex > 0) {
+                            System.arraycopy(periodBytes, 0, byteBuffer, byteBufferIndex, periodBytes.length);
+                            byteBufferIndex += periodBytes.length;
+                        }
+
+                        byte[] domainBytes = domains[domainIndex].getBytes();
+                        int domainLength = domainBytes.length;
+                        System.arraycopy(domainBytes, 0, byteBuffer, byteBufferIndex, domainLength);
+                        byteBufferIndex += domainLength;
+                    }
+
+                    // Is the TLD one that we can encode?
+                    if (domains.length > 1) {
+                        String tld = "." + domains[domains.length - 1];
+                        String slash = urlMatcher.group(EDDYSTONE_URL_SLASH_GROUP);
+                        String encodableTLDCandidate = (slash == null ? tld : tld + slash);
+                        byte encodedTLDByte = encodedByteForTopLevelDomain(encodableTLDCandidate);
+                        if (encodedTLDByte != TLD_NOT_ENCODABLE) {
+                            byteBuffer[byteBufferIndex++] = encodedTLDByte;
+                            consumedSlash = (slash != null);
+                        } else {
+                            byte[] tldBytes = tld.getBytes();
+                            int tldLength = tldBytes.length;
+                            System.arraycopy(tldBytes, 0, byteBuffer, byteBufferIndex, tldLength);
+                            byteBufferIndex += tldLength;
+                        }
+                    }
+                }
+
+                // Optional slash.
+                if (! consumedSlash) {
+                    String slash = urlMatcher.group(EDDYSTONE_URL_SLASH_GROUP);
+                    if (slash != null) {
+                        int slashLength = slash.length();
+                        System.arraycopy(slash.getBytes(), 0, byteBuffer, byteBufferIndex, slashLength);
+                        byteBufferIndex += slashLength;
                     }
                 }
 
                 // Path.
-                String path = urlMatcher.group(EXPANSION_CODE_URL_PATH_GROUP);
+                String path = urlMatcher.group(EDDYSTONE_URL_PATH_GROUP);
                 if (path != null) {
                     int pathLength =  path.length();
                     System.arraycopy(path.getBytes(), 0, byteBuffer, byteBufferIndex, pathLength);
@@ -200,8 +255,11 @@ public class UrlBeaconUrlCompressor {
                 System.arraycopy(byteBuffer, 0, compressedBytes, 0, compressedBytes.length);
             }
             else {
-                // Throw an exception, e. g. MalformedURLException
+                throw new MalformedURLException();
             }
+        }
+        else {
+            throw new MalformedURLException();
         }
         return compressedBytes;
     }
@@ -209,17 +267,17 @@ public class UrlBeaconUrlCompressor {
     public static String uncompress(byte[] compressedURL) {
         StringBuffer url = new StringBuffer();
         switch (compressedURL[0] & 0x0f) {
-            case 0:
-                url.append("http://www.");
+            case EDDYSTONE_URL_PROTOCOL_HTTP_WWW:
+                url.append(URL_PROTOCOL_HTTP_WWW_DOT);
                 break;
-            case 1:
-                url.append("https://www.");
+            case EDDYSTONE_URL_PROTOCOL_HTTPS_WWW:
+                url.append(URL_PROTOCOL_HTTPS_WWW_DOT);
                 break;
-            case 2:
-                url.append("http://");
+            case EDDYSTONE_URL_PROTOCOL_HTTP:
+                url.append(URL_PROTOCOL_HTTP_COLON_SLASH_SLASH);
                 break;
-            case 3:
-                url.append("https://");
+            case EDDYSTONE_URL_PROTOCOL_HTTPS:
+                url.append(URL_PROTOCOL_HTTPS_COLON_SLASH_SLASH);
                 break;
             default:
                 break;
@@ -227,57 +285,16 @@ public class UrlBeaconUrlCompressor {
         byte lastByte = -1;
         for (int i = 1; i < compressedURL.length; i++) {
             byte b = compressedURL[i];
-            // If the previous byte was a suffix
-            if (lastByte <= EXPANSION_CODE_URL_GOV && b == 0 ) {
+            if (lastByte == 0 && b == 0 ) {
                 break;
             }
             lastByte = b;
-            switch (b) {
-                case 0:
-                    url.append(".com");
-                    break;
-                case 1:
-                    url.append(".org");
-                    break;
-                case 2:
-                    url.append(".edu");
-                    break;
-                case 3:
-                    url.append(".net");
-                    break;
-                case 4:
-                    url.append(".info");
-                    break;
-                case 5:
-                    url.append(".biz");
-                    break;
-                case 6:
-                    url.append(".gov");
-                    break;
-                case 7:
-                    url.append(".com");
-                    break;
-                case 8:
-                    url.append(".org");
-                    break;
-                case 9:
-                    url.append(".edu");
-                    break;
-                case 10:
-                    url.append(".net");
-                    break;
-                case 11:
-                    url.append(".info");
-                    break;
-                case 12:
-                    url.append(".biz");
-                    break;
-                case 13:
-                    url.append("gov");
-                    break;
-                default:
-                    url.append((char) b);
-                    break;
+            String tld = topLevelDomainForByte(b);
+            if (tld != null) {
+                url.append(tld);
+            }
+            else {
+                url.append((char) b);
             }
         }
 

--- a/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -266,5 +266,19 @@ public class BeaconParserTest {
         assertEquals("longitude should be about right", longitude, parsedLongitude, 0.0001);
 
     }
+    @Test
+    public void testCanGetAdvertisementDataForUrlBeacon() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        BeaconManager.setDebug(true);
+        Beacon beacon = new Beacon.Builder()
+                .setManufacturer(0x0118)
+                .setId1("02646576656c6f7065722e636f6d") // http://developer.com
+                .setTxPower(-59) // The measured transmitter power at one meter in dBm
+                .build();
+        BeaconParser p = new BeaconParser().
+                setBeaconLayout("s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-20v");
+        byte[] bytes = p.getBeaconAdvertisementData(beacon);
+        assertEquals("First byte of url should be in position 3", 0x02, bytes[2]);
+    }
 
 }

--- a/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -233,13 +233,16 @@ public class BeaconParserTest {
 
     @Test
     public void testCanParseLocationBeacon() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        BeaconManager.setDebug(true);
+
         double latitude = 38.93;
         double longitude = -77.23;
         Beacon beacon = new Beacon.Builder()
                 .setManufacturer(0x0118) // Radius Networks
                 .setId1("1") // device sequence number
-                .setId2(String.format("0x%X", (long)((latitude+90)*10000.0)))
-                .setId3(String.format("0x%X", (long)((longitude+180)*10000.0)))
+                .setId2(String.format("0x%08X", (long)((latitude+90)*10000.0)))
+                .setId3(String.format("0x%08X", (long)((longitude+180)*10000.0)))
                 .setTxPower(-59) // The measured transmitter power at one meter in dBm
                 .build();
         // TODO: make this pass if data fields are little endian or > 4 bytes (or even > 2 bytes)

--- a/src/test/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressorTest.java
+++ b/src/test/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressorTest.java
@@ -1,0 +1,192 @@
+package org.altbeacon.beacon.utils;
+
+import java.net.MalformedURLException;
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.robolectric.RobolectricTestRunner;
+
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@Config(emulateSdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class UrlBeaconUrlCompressorTest {
+
+    final protected static char[] hexArray = "0123456789ABCDEF" .toCharArray();
+
+    /**
+     * URLs to test:
+     * <p/>
+     * http://www.radiusnetworks.com
+     * https://www.radiusnetworks.com
+     * http://radiusnetworks.com
+     * https://radiusnetworks.com
+     * https://radiusnetworks.com/
+     * https://radiusnetworks.com/v1/index.html
+     * https://api.v1.radiusnetworks.com
+     * https://www.api.v1.radiusnetworks.com
+     */
+    @Test
+    public void testCompressURL() throws MalformedURLException {
+        String testURL = "http://www.radiusnetworks.com";
+        byte[] expectedBytes = {0x00, 'r', 'a', 'd', 'i', 'u', 's', 'n', 'e', 't', 'w', 'o', 'r', 'k', 's', 0x07};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressHttpsURL() throws MalformedURLException {
+        String testURL = "https://www.radiusnetworks.com";
+        byte[] expectedBytes = {0x01, 'r', 'a', 'd', 'i', 'u', 's', 'n', 'e', 't', 'w', 'o', 'r', 'k', 's', 0x07};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithTrailingSlash() throws MalformedURLException {
+        String testURL = "http://google.com/123";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', 0x00, '1', '2', '3'};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithoutTLD() throws MalformedURLException {
+        String testURL = "http://xxx";
+        byte[] expectedBytes = {0x02, 'x', 'x', 'x'};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithSubdomains() throws MalformedURLException {
+        String testURL = "http://www.forums.google.com";
+        byte[] expectedBytes = {0x00, 'f', 'o', 'r', 'u', 'm', 's', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x07};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithSubdomainsWithTrailingSlash() throws MalformedURLException {
+        String testURL = "http://www.forums.google.com/";
+        byte[] expectedBytes = {0x00, 'f', 'o', 'r', 'u', 'm', 's', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x00};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithMoreSubdomains() throws MalformedURLException {
+        String testURL = "http://www.forums.developer.google.com/123";
+        byte[] expectedBytes = {0x00, 'f', 'o', 'r', 'u', 'm', 's', '.', 'd', 'e', 'v', 'e', 'l', 'o', 'p', 'e', 'r', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x00, '1', '2', '3'};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithSubdomainsAndSlashesInPath() throws MalformedURLException {
+        String testURL = "http://www.forums.google.com/123/456";
+        byte[] expectedBytes = {0x00, 'f', 'o', 'r', 'u', 'm', 's', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x00, '1', '2', '3', '/', '4', '5', '6'};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithDotCaTLD() throws MalformedURLException {
+        String testURL = "http://google.ca";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', '.', 'c', 'a'};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithDotInfoTLD() throws MalformedURLException {
+        String testURL = "http://google.info";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', 0x0b};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithDotCaTLDWithSlash() throws MalformedURLException {
+        String testURL = "http://google.ca/";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', '.', 'c', 'a', '/'};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithDotCoTLD() throws MalformedURLException {
+        String testURL = "http://google.co";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', '.', 'c', 'o'};
+        String hexBytes = bytesToHex(UrlBeaconUrlCompressor.compress(testURL));
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testDecompressWithDotCoTLD() {
+        String testURL = "http://google.co";
+        byte[] testBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', '.', 'c', 'o'};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testDecompressWithPath() {
+        String testURL = "http://google.com/123";
+        byte[] testBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', 0x00, '1', '2', '3'};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testUncompressHttpsURL() {
+        String testURL = "https://www.radiusnetworks.com";
+        byte[] testBytes = {0x01, 'r', 'a', 'd', 'i', 'u', 's', 'n', 'e', 't', 'w', 'o', 'r', 'k', 's', 0x07};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testUncompressHttpsURLWithTrailingSlash() {
+        String testURL = "https://www.radiusnetworks.com/";
+        byte[] testBytes = {0x01, 'r', 'a', 'd', 'i', 'u', 's', 'n', 'e', 't', 'w', 'o', 'r', 'k', 's', 0x00};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testUncompressWithoutTLD() throws MalformedURLException {
+        String testURL = "http://xxx";
+        byte[] testBytes = {0x02, 'x', 'x', 'x'};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testUncompressWithSubdomains() throws MalformedURLException {
+        String testURL = "http://www.forums.google.com";
+        byte[] testBytes = {0x00, 'f', 'o', 'r', 'u', 'm', 's', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x07};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testUncompressWithSubdomainsAndTrailingSlash() throws MalformedURLException {
+        String testURL = "http://www.forums.google.com/";
+        byte[] testBytes = {0x00, 'f', 'o', 'r', 'u', 'm', 's', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x00};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testUncompressWithSubdomainsAndSlashesInPath() throws MalformedURLException {
+        String testURL = "http://www.forums.google.com/123/456";
+        byte[] testBytes = {0x00, 'f', 'o', 'r', 'u', 'm', 's', '.', 'g', 'o', 'o', 'g', 'l', 'e', 0x00, '1', '2', '3', '/', '4', '5', '6'};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    @Test
+    public void testUncompressWithDotInfoTLD() throws MalformedURLException {
+        String testURL = "http://google.info";
+        byte[] testBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', 0x0b};
+        assertEquals(testURL, UrlBeaconUrlCompressor.uncompress(testBytes));
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
+
+}


### PR DESCRIPTION
Changes to make Eddystone URL transmitter work
* Allow variable length identifiers in transmitted advertisement
* Properly handle additional cases in URL compression/decompression