### PR TITLE
Parse "0" as an integer identifier

### DIFF
--- a/src/main/java/org/altbeacon/beacon/Identifier.java
+++ b/src/main/java/org/altbeacon/beacon/Identifier.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 public class Identifier implements Comparable<Identifier> {
     private static final Pattern HEX_PATTERN = Pattern.compile("^0x[0-9A-Fa-f]*$");
     private static final Pattern HEX_PATTERN_NO_PREFIX = Pattern.compile("^[0-9A-Fa-f]*$");
-    private static final Pattern DECIMAL_PATTERN = Pattern.compile("^[1-9][0-9]*$");
+    private static final Pattern DECIMAL_PATTERN = Pattern.compile("^0|[1-9][0-9]*$");
     // BUG: Dashes in UUIDs are not optional!
     private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9A-Fa-f]{8}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{4}-?[0-9A-Fa-f]{12}$");
     private static final int MAX_INTEGER = 65535;

--- a/src/test/java/org/altbeacon/beacon/IdentifierTest.java
+++ b/src/test/java/org/altbeacon/beacon/IdentifierTest.java
@@ -218,5 +218,11 @@ public class IdentifierTest {
         assertEquals("Should be treated as hex because it is long", "0x2fffffffffffffffffff", id.toString());
         assertEquals("Byte count should be as specified", 10, id.getByteCount());
     }
+    @Test
+    public void testParseZeroAsInteger() {
+        Identifier id = Identifier.parse("0");
+        assertEquals("Should be treated as int because it is a common integer", "0", id.toString());
+        assertEquals("Byte count should be 2 for integers", 2, id.getByteCount());
+    }
 
 }


### PR DESCRIPTION
This fixes a bug where ranging and monitoring for beacons with an Identiier.parse("0") fails.  The reason for the failure is that the parsing was being done as a hex number, assuming a one byte length identifier.  Treating it as an integer defaults it to two bytes, which will match AltBeacon major and minor values.