### PR TITLE
Fix NPE in Beacon.hashCode(), along with some optimizations

### DIFF
--- a/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -25,7 +25,6 @@ package org.altbeacon.beacon;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.util.Log;
 
 import org.altbeacon.beacon.client.BeaconDataFactory;
 import org.altbeacon.beacon.client.NullBeaconDataFactory;
@@ -232,18 +231,9 @@ public class Beacon implements Parcelable {
      */
     protected Beacon(Beacon otherBeacon) {
         super();
-        mIdentifiers = new ArrayList<Identifier>(otherBeacon.mIdentifiers.size());
-        mDataFields = new ArrayList<Long>(otherBeacon.mDataFields.size());
-        mExtraDataFields = new ArrayList<Long>(otherBeacon.mExtraDataFields.size());
-        for (int i = 0; i < otherBeacon.mIdentifiers.size(); i++) {
-            mIdentifiers.add(otherBeacon.mIdentifiers.get(i));
-        }
-        for (int i = 0; i < otherBeacon.mDataFields.size(); i++) {
-            mDataFields.add(otherBeacon.mDataFields.get(i));
-        }
-        for (int i = 0; i < otherBeacon.mExtraDataFields.size(); i++) {
-            mExtraDataFields.add(otherBeacon.mExtraDataFields.get(i));
-        }
+        mIdentifiers = new ArrayList<>(otherBeacon.mIdentifiers);
+        mDataFields = new ArrayList<>(otherBeacon.mDataFields);
+        mExtraDataFields = new ArrayList<>(otherBeacon.mExtraDataFields);
         this.mDistance = otherBeacon.mDistance;
         this.mRunningAverageRssi = otherBeacon.mRunningAverageRssi;
         this.mRssi = otherBeacon.mRssi;
@@ -442,16 +432,7 @@ public class Beacon implements Parcelable {
      */
     @Override
     public int hashCode() {
-        StringBuilder sb = new StringBuilder();
-        int i = 1;
-        for (Identifier identifier: mIdentifiers) {
-            sb.append("id");
-            sb.append(i);
-            sb.append(": ");
-            sb.append(identifier.toString());
-            sb.append(" ");
-            i++;
-        }
+        StringBuilder sb = toStringBuilder(new StringBuilder());
         if (sHardwareEqualityEnforced) {
             sb.append(mBluetoothAddress);
         }
@@ -467,14 +448,8 @@ public class Beacon implements Parcelable {
             return false;
         }
         Beacon thatBeacon = (Beacon) that;
-        if (this.mIdentifiers.size() != thatBeacon.mIdentifiers.size()) {
+        if (!this.mIdentifiers.equals(thatBeacon.mIdentifiers)) {
             return false;
-        }
-        // all identifiers must match
-        for (int i = 0; i < this.mIdentifiers.size(); i++) {
-            if (!this.mIdentifiers.get(i).equals(thatBeacon.mIdentifiers.get(i))) {
-                return false;
-            }
         }
         return sHardwareEqualityEnforced ?
                 this.getBluetoothAddress().equals(thatBeacon.getBluetoothAddress()) :
@@ -496,7 +471,10 @@ public class Beacon implements Parcelable {
      */
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
+        return toStringBuilder(new StringBuilder()).toString();
+    }
+
+    private StringBuilder toStringBuilder(StringBuilder sb) {
         int i = 1;
         for (Identifier identifier: mIdentifiers) {
             if (i > 1) {
@@ -508,7 +486,7 @@ public class Beacon implements Parcelable {
             sb.append(identifier == null ? "null" : identifier.toString());
             i++;
         }
-        return sb.toString();
+        return sb;
     }
 
     /**
@@ -775,6 +753,5 @@ public class Beacon implements Parcelable {
         }
 
     }
-
 
 }

--- a/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -432,7 +432,7 @@ public class Beacon implements Parcelable {
      */
     @Override
     public int hashCode() {
-        StringBuilder sb = toStringBuilder(new StringBuilder());
+        StringBuilder sb = toStringBuilder();
         if (sHardwareEqualityEnforced) {
             sb.append(mBluetoothAddress);
         }
@@ -471,10 +471,11 @@ public class Beacon implements Parcelable {
      */
     @Override
     public String toString() {
-        return toStringBuilder(new StringBuilder()).toString();
+        return toStringBuilder().toString();
     }
 
-    private StringBuilder toStringBuilder(StringBuilder sb) {
+    private StringBuilder toStringBuilder() {
+        final StringBuilder sb = new StringBuilder();
         int i = 1;
         for (Identifier identifier: mIdentifiers) {
             if (i > 1) {

--- a/src/main/java/org/altbeacon/beacon/Region.java
+++ b/src/main/java/org/altbeacon/beacon/Region.java
@@ -145,16 +145,11 @@ public class Region implements Parcelable {
      * @return true if is covered
      */
     public boolean matchesBeacon(Beacon beacon) {
-        // all identifiers must match, or the region identifier must be null
-        for (int i = 0; i < this.mIdentifiers.size(); i++) {
-            if (beacon.getIdentifiers().size() <= i && mIdentifiers.get(i) == null) {
-                // If the beacon has fewer identifiers than the region, but the region's
-                // corresponding identifier is null, consider it a match
-            }
-            else {
-                if (mIdentifiers.get(i) != null && !mIdentifiers.get(i).equals(beacon.mIdentifiers.get(i))) {
-                    return false;
-                }
+        // All identifiers must match, or the corresponding region identifier must be null.
+        for (int i = mIdentifiers.size(); --i >= 0; ) {
+            final Identifier ident = mIdentifiers.get(i);
+            if (ident != null && !ident.equals(beacon.mIdentifiers.get(i))) {
+                return false;
             }
         }
         return true;

--- a/src/test/java/org/altbeacon/beacon/BeaconTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconTest.java
@@ -13,9 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 @Config(sdk = 18)
@@ -134,7 +132,7 @@ public class BeaconTest {
     public void testCalculateAccuracyWithRssiGreaterThanPower() {
         Beacon.setDistanceCalculator(new ModelSpecificDistanceCalculator(null, null));
         double accuracy = Beacon.calculateDistance(-55, -50);
-        assertTrue("Distance should be under one meter if mRssi is less negative than power.  Accuracy was "+accuracy, accuracy < 1.0);
+        assertTrue("Distance should be under one meter if mRssi is less negative than power.  Accuracy was " + accuracy, accuracy < 1.0);
     }
 
     @Test
@@ -185,6 +183,7 @@ public class BeaconTest {
         assertEquals("data field 0 is the same after deserialization", beacon.getDataFields().get(0), beacon2.getDataFields().get(0));
         assertEquals("data field 0 is the right value", beacon.getDataFields().get(0), (Long) 100l);
     }
+
     @Test
     public void noDoubleWrappingOfExtraDataFields() {
         org.robolectric.shadows.ShadowLog.stream = System.err;
@@ -196,5 +195,13 @@ public class BeaconTest {
         assertTrue("getter should return same object after first wrap ", beacon.getExtraDataFields() == list);
     }
 
-
+    @Test
+    public void testHashCodeWithNullIdentifier() {
+        Beacon beacon = new AltBeacon.Builder()
+                .setIdentifiers(Arrays.asList(
+                        Identifier.parse("0x1234"),
+                        null))
+                .build();
+        assertTrue("hashCode() should not throw exception", beacon.hashCode() >= Integer.MIN_VALUE);
+    }
 }


### PR DESCRIPTION
There is a lurking NPE in `Beacon.hashCode()` if any `Identifier` element of `mIndentifiers` is `null`. The similar logic in `toString()` already takes care of this, so this pull request factors out that logic and reuses it.

While I was in the `Beacon` code, I also noticed some low-lying fruit (simplifications/optimizations), which I have included. And I have also included an easier-to-understand simplified version of the related Region.matchesBeacon().