### PR TITLE
Add path loss distance calculation algorithm

### DIFF
--- a/src/main/java/org/altbeacon/beacon/distance/AndroidModel.java
+++ b/src/main/java/org/altbeacon/beacon/distance/AndroidModel.java
@@ -91,6 +91,56 @@ public class AndroidModel {
         return score;
     }
 
+    /**
+     * Calculates a qualitative match score between two different Android device models for the
+     * purposes of how likely they are to have similar Bluetooth signal level responses
+     * This algorithm takes into account partial matches of model strings, as Samsung devices
+     * commonly have different model name suffixes
+     * @param otherModel
+     * @return match quality, higher numbers are a better match
+     */
+    public double matchScoreWithPartialModel(AndroidModel otherModel) {
+        double score = 0;
+        if (this.mManufacturer.equalsIgnoreCase(otherModel.mManufacturer)) {
+            score = 1;
+        }
+        if (score == 1 ) {
+            score = 1+ratioOfMatchingPrefixCharacters(this.getModel(), otherModel.getModel());
+        }
+        LogManager.d(TAG, "Score is %s for %s compared to %s", score, toString(), otherModel);
+        return score;
+    }
+
+    /**
+     * Returns 1.0 if the string is a complete match, 0.0 if the first characters are different
+     * and 0.5 if the first halves of each string match.  Not case sensitive.
+     * @param string1
+     * @param string2
+     * @return
+     */
+    private double ratioOfMatchingPrefixCharacters(String string1, String string2) {
+        int maxLength = 0;
+        int minLength = 0;
+        int matchingChars = 0;
+        String lower1 = string1.toLowerCase();
+        String lower2 = string2.toLowerCase();
+        if (string2.length() >= string1.length()) {
+            maxLength = string2.length();
+            minLength = string1.length();
+        }
+        else {
+            maxLength = string1.length();
+            minLength = string2.length();
+        }
+
+        for (int i = 0; i < minLength; i++) {
+            if (lower1.charAt(i) == lower2.charAt(i)) {
+                matchingChars++;
+            }
+        }
+        return 1.0*matchingChars/maxLength;
+    }
+
     @Override
     public String toString() {
         return ""+mManufacturer+";"+mModel+";"+mBuildNumber+";"+mVersion;

--- a/src/main/java/org/altbeacon/beacon/distance/PathLossDistanceCalculator.java
+++ b/src/main/java/org/altbeacon/beacon/distance/PathLossDistanceCalculator.java
@@ -1,0 +1,58 @@
+package org.altbeacon.beacon.distance;
+
+import org.altbeacon.beacon.logging.LogManager;
+
+/**
+ * This class estimates the distance between the mobile device and a BLE beacon based on the measured
+ * RSSI and a txPower calibration value that represents the expected RSSI for an iPhone 5 receiving
+ * the signal when it is 1 meter away.
+ * <p/>
+ * This class uses a path loss equation with a receiverRssiOffset parameter.  The offset must
+ * be supplied by the caller and is specific to the Android device being used.  See the
+ * <code>ModelSpecificDistanceCalculator</code> for more information on the offset.
+ * <p/>
+ * Created by dyoung on 7/26/15.
+ */
+public class PathLossDistanceCalculator implements DistanceCalculator {
+
+    public static final String TAG = "PathLossDistanceCalculator";
+    private double mReceiverRssiOffset;
+
+    /**
+     * Construct a calculator with an offset specific for the device's antenna gain
+     *
+     * @param receiverRssiOffset
+     */
+    public PathLossDistanceCalculator(double receiverRssiOffset) {
+        mReceiverRssiOffset = receiverRssiOffset;
+    }
+
+    /**
+     * Calculated the estimated distance in meters to the beacon based on a reference rssi at 1m
+     * and the known actual rssi at the current location
+     *
+     * @param txPower
+     * @param rssi
+     * @return estimated distance
+     */
+    @Override
+    public double calculateDistance(int txPower, double rssi) {
+        if (rssi == 0) {
+            return -1.0; // if we cannot determine accuracy, return -1.
+        }
+
+        LogManager.d(TAG, "calculating distance based on mRssi of %s and txPower of %s", rssi, txPower);
+
+
+        double ratio = rssi * 1.0 / txPower;
+        double distance;
+        if (ratio < 1.0) {
+            distance = Math.pow(ratio, 10);
+        } else {
+            distance = Math.pow(10.0, ((-rssi+mReceiverRssiOffset+txPower)/10*0.41));
+
+        }
+        LogManager.d(TAG, "avg mRssi: %s distance: %s", rssi, distance);
+        return distance;
+    }
+}

--- a/src/main/resources/model-distance-calculations.json
+++ b/src/main/resources/model-distance-calculations.json
@@ -14,11 +14,34 @@
       "coefficient1": 0.42093,
       "coefficient2": 6.9476,
       "coefficient3": 0.54992,
+      "receiver_rssi_offset": -2.5,
       "version":"4.4.2",
       "build_number":"LPV79",
       "model":"Nexus 5",
       "manufacturer":"LGE",
       "default": true
+    },
+    {
+      "receiver_rssi_offset": -17.25,
+      "version":"5.1.1",
+      "build_number":"LVY48C",
+      "model":"Moto G",
+      "manufacturer":"motorola"
+    },
+    {
+      "receiver_rssi_offset": -21.25,
+      "version":"5.0",
+      "build_number":"LRX21T",
+      "model":"SM-G900V",
+      "manufacturer":"samsung"
+    },
+    {
+      "receiver_rssi_offset": -0.25,
+      "version":"4.4.2",
+      "build_number":"KOT49H",
+      "model":"SCH-I535",
+      "manufacturer":"samsung"
     }
+
   ]
 }

--- a/src/test/java/org/altbeacon/beacon/distance/ModelSpecificDistanceCalculatorTest.java
+++ b/src/test/java/org/altbeacon/beacon/distance/ModelSpecificDistanceCalculatorTest.java
@@ -30,10 +30,34 @@ public class ModelSpecificDistanceCalculatorTest {
     public void testCalculatesDistance() {
         org.robolectric.shadows.ShadowLog.stream = System.err;
 
+        ModelSpecificDistanceCalculator.setDistanceCalculatorClassName(CurveFittedDistanceCalculator.class.getName());
         ModelSpecificDistanceCalculator distanceCalculator = new ModelSpecificDistanceCalculator(null, null);
         Double distance = distanceCalculator.calculateDistance(-59, -59);
         assertEquals("Distance should be 1.0 for same power and rssi", 1.0, distance, 0.1);
     }
+
+    @Test
+    public void testCalculatesDistanceAt10MetersOnANexus5() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        AndroidModel model = new AndroidModel("5.0.0", "LPV79","Nexus 5","LGE");
+
+        ModelSpecificDistanceCalculator.setDistanceCalculatorClassName(CurveFittedDistanceCalculator.class.getName());
+        ModelSpecificDistanceCalculator distanceCalculator = new ModelSpecificDistanceCalculator(null, null, model);
+        Double distance = distanceCalculator.calculateDistance(-45,-71);
+        assertEquals("Distance should be 10.0 ", 10.0, distance, 1.0);
+    }
+
+    @Test
+    public void testCalculatesDistanceAt10MetersOnANexus5WithPathLossFormula() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        AndroidModel model = new AndroidModel("5.0.0", "LPV79","Nexus 5","LGE");
+        ModelSpecificDistanceCalculator.setDistanceCalculatorClassName(PathLossDistanceCalculator.class.getName());
+
+        ModelSpecificDistanceCalculator distanceCalculator = new ModelSpecificDistanceCalculator(null, null, model);
+        Double distance = distanceCalculator.calculateDistance(-45,-71);
+        assertEquals("Distance should be 10.0 ", 10.0, distance, 1.0);
+    }
+
 
     @Test
     public void testSelectsDefaultModel() {
@@ -51,6 +75,16 @@ public class ModelSpecificDistanceCalculatorTest {
         ModelSpecificDistanceCalculator distanceCalculator = new ModelSpecificDistanceCalculator(null, null, model);
         assertEquals("should be Nexus 4", "Nexus 4", distanceCalculator.getModel().getModel());
     }
+
+    @Test
+    public void testSelectsSamsungS3OnEPartialMatch() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        AndroidModel model = new AndroidModel("4.4.4.4.4", "nonsense","SCH-I536","samsung");
+        ModelSpecificDistanceCalculator distanceCalculator = new ModelSpecificDistanceCalculator(null, null, model);
+        assertEquals("should be S3 SCH-I535", "SCH-I535", distanceCalculator.getModel().getModel());
+    }
+
+
 
 	@Test
 	public void testConcurrentModificationException() {

--- a/src/test/resources/model-distance-calculations.json
+++ b/src/test/resources/model-distance-calculations.json
@@ -2,9 +2,9 @@
   "models":
   [
     {
-      "coefficient1": 0.89976,
-      "coefficient2": 7.7095,
-      "coefficient3": 0.111,
+      "coefficient1": 0.42093,
+      "coefficient2": 6.9476,
+      "coefficient3": 0.54992,
       "version":"4.4.2",
       "build_number":"KOT49H",
       "model":"Nexus 4",
@@ -14,11 +14,34 @@
       "coefficient1": 0.42093,
       "coefficient2": 6.9476,
       "coefficient3": 0.54992,
+      "receiver_rssi_offset": -2.5,
       "version":"4.4.2",
       "build_number":"LPV79",
       "model":"Nexus 5",
       "manufacturer":"LGE",
       "default": true
+    },
+    {
+      "receiver_rssi_offset": -17.25,
+      "version":"5.1.1",
+      "build_number":"LVY48C",
+      "model":"Moto G",
+      "manufacturer":"motorola"
+    },
+    {
+      "receiver_rssi_offset": -21.25,
+      "version":"5.0",
+      "build_number":"LRX21T",
+      "model":"SM-G900V",
+      "manufacturer":"samsung"
+    },
+    {
+      "receiver_rssi_offset": -0.25,
+      "version":"4.4.2",
+      "build_number":"KOT49H",
+      "model":"SCH-I535",
+      "manufacturer":"samsung"
     }
+
   ]
 }


### PR DESCRIPTION
Adds experimental support for a new formula for calculating distance based on a path loss formula rather than a curve fitted formula.  This returns better results with low power beacon transmitters and is easier to add calculations for different device models.

This alternate means of calculating distance may be enabled by calling:

```
ModelSpecificDistanceCalculator.setDistanceCalculatorClassName(
        PathLossDistanceCalculator.class.getName());
```

Correction factors for various Android models may be added by doing a 1 meter calibration with that device model, to obtain the average RSSI for that model at 1 meter, then subtracting the known iPhone 5 calibration value at 1 meter.    This yields a "Receiver RSSI Offset", which indicates the relative sensitivity of the Android device's bluetooth receiver compared to an iPhone 5.  For a Nexus 5, this value is -2.5 dB, indicating its receiver is only very slightly less sensitive to Bluetooth signals than an iPhone 5.  For a Samsung Galaxy S5, this value is -21.5 dB, indicating its receiver is much less sensitive to Bluetooth signals than an iPhone 5.