### PR TITLE
Fix crash when region has more identifiers than beacon

### DIFF
--- a/src/main/java/org/altbeacon/beacon/Region.java
+++ b/src/main/java/org/altbeacon/beacon/Region.java
@@ -148,7 +148,7 @@ public class Region implements Parcelable {
         // All identifiers must match, or the corresponding region identifier must be null.
         for (int i = mIdentifiers.size(); --i >= 0; ) {
             final Identifier ident = mIdentifiers.get(i);
-            if (ident != null && !ident.equals(beacon.mIdentifiers.get(i))) {
+            if (beacon.mIdentifiers.size() <= i || ident != null && !ident.equals(beacon.mIdentifiers.get(i))) {
                 return false;
             }
         }

--- a/src/test/java/org/altbeacon/beacon/RegionTest.java
+++ b/src/test/java/org/altbeacon/beacon/RegionTest.java
@@ -6,6 +6,7 @@ import static android.test.MoreAsserts.assertNotEqual;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 import org.robolectric.RobolectricTestRunner;
 
@@ -69,6 +70,14 @@ public class RegionTest {
                 .setBeaconTypeCode(5).setTxPower(6).setBluetoothAddress("1:2:3:4:5:6").build();
         Region region = new Region("myRegion", Collections.singletonList(Identifier.parse("1")));
         assertTrue("Beacon should match region with first identifier equal and shorter Identifier list", region.matchesBeacon(beacon));
+    }
+
+    @Test
+    public void testBeaconDoesntMatchRegionWithLongerIdentifierList() {
+        Beacon beacon = new Beacon.Builder().setId1("1").setId2("2").setRssi(4)
+                .setBeaconTypeCode(5).setTxPower(6).setBluetoothAddress("1:2:3:4:5:6").build();
+        Region region = new Region("myRegion", Identifier.parse("1"), Identifier.parse("2"), Identifier.parse("3"));
+        assertFalse("Beacon should not match region with more identifers than the beacon", region.matchesBeacon(beacon));
     }
 
     @Test


### PR DESCRIPTION
Prevent an IndexOutOfBoundsException when comparing a Region to a Beacon with fewer identifiers.  This would cause a crash when looking for a Region with three non-null identifiers and then encountering a beacon (such as Eddystone UID) that only has two identifiers.