### PR TITLE
Generalized URL compressor to handle upper-case URL components properly

### DIFF
--- a/src/main/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressor.java
+++ b/src/main/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressor.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
  */
 public class UrlBeaconUrlCompressor  {
 
-    private static final String EDDYSTONE_URL_REGEX = "^(http|https):\\/\\/(www\\.)?((?:[0-9a-z_-]+\\.?)+)(/?)([./0-9a-z_-]*)"; // Break into components
+    private static final String EDDYSTONE_URL_REGEX = "^((?i)http|https):\\/\\/((?i)www\\.)?((?:[0-9a-zA-Z_-]+\\.?)+)(/?)([./0-9a-zA-Z_-]*)"; // Break into components
     private static final int EDDYSTONE_URL_PROTOCOL_GROUP = 1;
     private static final int EDDYSTONE_URL_WWW_GROUP      = 2;
     private static final int EDDYSTONE_URL_FQDN_GROUP     = 3;
@@ -180,7 +180,8 @@ public class UrlBeaconUrlCompressor  {
                 boolean haswww = (wwwdot != null);
 
                 // Protocol.
-                String protocol = urlMatcher.group(EDDYSTONE_URL_PROTOCOL_GROUP);
+                String rawProtocol = urlMatcher.group(EDDYSTONE_URL_PROTOCOL_GROUP);
+                String protocol = rawProtocol.toLowerCase();
                 if (protocol.equalsIgnoreCase(URL_PROTOCOL_HTTP)) {
                     byteBuffer[byteBufferIndex] = (haswww ? EDDYSTONE_URL_PROTOCOL_HTTP_WWW : EDDYSTONE_URL_PROTOCOL_HTTP);
                 }
@@ -192,7 +193,8 @@ public class UrlBeaconUrlCompressor  {
                 // Fully-qualified domain name (FQDN).  This includes the hostname and any other components after the dots
                 // but BEFORE the first single slash in the URL.
                 byte[] hostnameBytes = urlMatcher.group(EDDYSTONE_URL_FQDN_GROUP).getBytes();
-                String hostname = new String(hostnameBytes);
+                String rawHostname = new String(hostnameBytes);
+                String hostname = rawHostname.toLowerCase();
                 String[] domains = hostname.split(Pattern.quote("."));
 
                 boolean consumedSlash = false;

--- a/src/test/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressorTest.java
+++ b/src/test/java/org/altbeacon/beacon/utils/UrlBeaconUrlCompressorTest.java
@@ -116,6 +116,51 @@ public class UrlBeaconUrlCompressorTest {
     }
 
     @Test
+    public void testCompressWithShortenedURLContainingCaps() throws MalformedURLException {
+        String testURL = "http://goo.gl/C2HC48";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', '.', 'g', 'l', '/', 'C', '2', 'H', 'C', '4', '8'};
+        String hexBytes = bytesToHex(UrlBeaconUrlCompressor.compress(testURL));
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithSchemeInCaps() throws MalformedURLException {
+        String testURL = "HTTP://goo.gl/C2HC48";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', '.', 'g', 'l', '/', 'C', '2', 'H', 'C', '4', '8'};
+        String hexBytes = bytesToHex(UrlBeaconUrlCompressor.compress(testURL));
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressWithDomainInCaps() throws MalformedURLException {
+        String testURL = "http://GOO.GL/C2HC48";
+        byte[] expectedBytes = {0x02, 'g', 'o', 'o', '.', 'g', 'l', '/', 'C', '2', 'H', 'C', '4', '8'};
+        String hexBytes = bytesToHex(UrlBeaconUrlCompressor.compress(testURL));
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressHttpsAndWWWInCaps() throws MalformedURLException {
+        String testURL = "HTTPS://WWW.radiusnetworks.com";
+        byte[] expectedBytes = {0x01, 'r', 'a', 'd', 'i', 'u', 's', 'n', 'e', 't', 'w', 'o', 'r', 'k', 's', 0x07};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressEntireURLInCaps() throws MalformedURLException {
+        String testURL = "HTTPS://WWW.RADIUSNETWORKS.COM";
+        byte[] expectedBytes = {0x01, 'r', 'a', 'd', 'i', 'u', 's', 'n', 'e', 't', 'w', 'o', 'r', 'k', 's', 0x07};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
+    public void testCompressEntireURLInCapsWithPath() throws MalformedURLException {
+        String testURL = "HTTPS://WWW.RADIUSNETWORKS.COM/C2HC48";
+        byte[] expectedBytes = {0x01, 'r', 'a', 'd', 'i', 'u', 's', 'n', 'e', 't', 'w', 'o', 'r', 'k', 's', 0x00, 'C', '2', 'H', 'C', '4', '8'};
+        assertTrue(Arrays.equals(expectedBytes, UrlBeaconUrlCompressor.compress(testURL)));
+    }
+
+    @Test
     public void testDecompressWithDotCoTLD() {
         String testURL = "http://google.co";
         byte[] testBytes = {0x02, 'g', 'o', 'o', 'g', 'l', 'e', '.', 'c', 'o'};


### PR DESCRIPTION
1. Properly matches upper/mixed-case scheme, e. g. HTTP or HTTPS
2. Properly matches upper/mixed-case domain, e. g. CIRCLE8.NET
3. Properly matches upper/mixed-case WWW
4. Properly matches upper/mixed-case known TLDs, e. g. .COM
5. Properly _preserves_ case in path, e. g. `http://goo.gl/C2HC48`

Fixes #262.