### PR TITLE
Add callback allowing processing of scanned non-Beacon BLE devices

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -38,6 +38,7 @@ import android.os.RemoteException;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.logging.Loggers;
 import org.altbeacon.beacon.service.BeaconService;
+import org.altbeacon.beacon.service.scanner.NonBeaconLeScanCallback;
 import org.altbeacon.beacon.service.RangeState;
 import org.altbeacon.beacon.service.RangedBeacon;
 import org.altbeacon.beacon.service.RunningAverageRssiFilter;
@@ -114,7 +115,7 @@ public class BeaconManager {
     private final ArrayList<Region> monitoredRegions = new ArrayList<Region>();
     private final ArrayList<Region> rangedRegions = new ArrayList<Region>();
     private final ArrayList<BeaconParser> beaconParsers = new ArrayList<BeaconParser>();
-    private BeaconService.NonBeaconScannedCallbacks mNonBeaconScannedCallbacks;
+    private NonBeaconLeScanCallback mNonBeaconLeScanCallback;
     private boolean mBackgroundMode = false;
     private boolean mBackgroundModeUninitialized = true;
 
@@ -726,12 +727,12 @@ public class BeaconManager {
         return this.dataRequestNotifier;
     }
 
-    public BeaconService.NonBeaconScannedCallbacks getNonBeaconScannedCallbacks() {
-        return mNonBeaconScannedCallbacks;
+    public NonBeaconLeScanCallback getNonBeaconLeScanCallback() {
+        return mNonBeaconLeScanCallback;
     }
 
-    public void setNonBeaconScannedCallbacks(BeaconService.NonBeaconScannedCallbacks callbacks) {
-        mNonBeaconScannedCallbacks = callbacks;
+    public void setNonBeaconLeScanCallback(NonBeaconLeScanCallback callback) {
+        mNonBeaconLeScanCallback = callback;
     }
 
     private class ConsumerInfo {

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -114,6 +114,7 @@ public class BeaconManager {
     private final ArrayList<Region> monitoredRegions = new ArrayList<Region>();
     private final ArrayList<Region> rangedRegions = new ArrayList<Region>();
     private final ArrayList<BeaconParser> beaconParsers = new ArrayList<BeaconParser>();
+    private BeaconService.NonBeaconScannedCallbacks mNonBeaconScannedCallbacks;
     private boolean mBackgroundMode = false;
     private boolean mBackgroundModeUninitialized = true;
 
@@ -723,6 +724,14 @@ public class BeaconManager {
 
     protected RangeNotifier getDataRequestNotifier() {
         return this.dataRequestNotifier;
+    }
+
+    public BeaconService.NonBeaconScannedCallbacks getNonBeaconScannedCallbacks() {
+        return mNonBeaconScannedCallbacks;
+    }
+
+    public void setNonBeaconScannedCallbacks(BeaconService.NonBeaconScannedCallbacks callbacks) {
+        mNonBeaconScannedCallbacks = callbacks;
     }
 
     private class ConsumerInfo {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/NonBeaconLeScanCallback.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/NonBeaconLeScanCallback.java
@@ -1,0 +1,37 @@
+package org.altbeacon.beacon.service.scanner;
+
+import android.bluetooth.BluetoothDevice;
+
+/**
+ * Allows an implementation to see non-Beacon BLE devices as they are scanned.
+ * <p/>
+ * To use:
+ * <pre><code>
+ * public class BeaconReferenceApplication extends Application implements ..., NonBeaconLeScanCallback {
+ *     public void onCreate() {
+ *         super.onCreate();
+ *         BeaconManager beaconManager = BeaconManager.getInstanceForApplication(this);
+ *         ...
+ *         beaconManager.setNonBeaconLeScanCallback(this);
+ *         ...
+ *     }
+ *
+ *     {@literal @}Override
+ *     public void onNonBeaconLeScan(BluetoothDevice device, int rssi, byte[] scanRecord) {
+ *          ...
+ *     }
+ *  }
+ * </code></pre>
+ */
+public interface NonBeaconLeScanCallback {
+    /**
+     * NOTE: This method is NOT called on the main UI thread.
+     *
+     * @param device Identifies the remote device
+     * @param rssi The RSSI value for the remote device as reported by the
+     *             Bluetooth hardware. 0 if no RSSI value is available.
+     * @param scanRecord The content of the advertisement record offered by
+     *                   the remote device.
+     */
+    void onNonBeaconLeScan(BluetoothDevice device, int rssi, byte[] scanRecord);
+}


### PR DESCRIPTION
The AltBeacon library is beautiful (sucking up here a little bit), and fixes a lot of general non-Beacon BLE scanning issues.
If a single app wants to scan both Beacon and non-Beacon BLE devices, then it currently has to spin up two active scanners: 1) AltBeacon library for Beacons, 2) a second android.bluetooth.le.BluetoothLeScanner to scan for non-BLE devices that duplicates all of the AltBeacon's non-Beacon agnostic BLE scanning logic.
This would be both hard to maintain and inefficient use of CPU.

I propose that AltBeason expose a callback that allows processing of non-Beacon BLE devices.
My proposed change is pretty simple and does not harm existing behavior.
An implementation only needs to call "BeaconManager.getInstanceForApplication(...).setNonBeaconScannedCallbacks(...)" to opt in to allowing seeing scanned non-Beacon BLE devices in a "@Override public void onNonBeaconScanned(BluetoothDevice device, int rssi, byte[] scanRecord) { ... }" method.