### PR TITLE
make the region exit time configurable

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -156,11 +156,17 @@ public class BeaconManager {
      * The default duration in milliseconds spent not scanning between each Bluetooth scan cycle when no ranging/monitoring clients are in the foreground
      */
     public static final long DEFAULT_BACKGROUND_BETWEEN_SCAN_PERIOD = 5 * 60 * 1000;
+    /**
+     * The default duration in milliseconds of region exit time
+     */
+    public static final long DEFAULT_EXIT_PERIOD = 10000L;
 
     private long foregroundScanPeriod = DEFAULT_FOREGROUND_SCAN_PERIOD;
     private long foregroundBetweenScanPeriod = DEFAULT_FOREGROUND_BETWEEN_SCAN_PERIOD;
     private long backgroundScanPeriod = DEFAULT_BACKGROUND_SCAN_PERIOD;
     private long backgroundBetweenScanPeriod = DEFAULT_BACKGROUND_BETWEEN_SCAN_PERIOD;
+
+    private static long exitRegionPeriod = DEFAULT_EXIT_PERIOD;
 
     /**
      * Sets the duration in milliseconds of each Bluetooth LE scan cycle to look for beacons.
@@ -205,6 +211,24 @@ public class BeaconManager {
      */
     public void setBackgroundBetweenScanPeriod(long p) {
         backgroundBetweenScanPeriod = p;
+    }
+
+    /**
+     * Set region exit period in milliseconds
+     *
+     * @param regionExitPeriod
+     */
+    public static void setRegionExitPeriod(long regionExitPeriod){
+        exitRegionPeriod = regionExitPeriod;
+    }
+    
+    /**
+     * Get region exit milliseconds
+     *
+     * @return exit region period in milliseconds
+     */
+    public static long getRegionExitPeriod(){
+        return exitRegionPeriod;
     }
 
     /**

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -161,12 +161,12 @@ public class BeaconManager {
      */
     public static final long DEFAULT_EXIT_PERIOD = 10000L;
 
+    private static long sExitRegionPeriod = DEFAULT_EXIT_PERIOD;
+
     private long foregroundScanPeriod = DEFAULT_FOREGROUND_SCAN_PERIOD;
     private long foregroundBetweenScanPeriod = DEFAULT_FOREGROUND_BETWEEN_SCAN_PERIOD;
     private long backgroundScanPeriod = DEFAULT_BACKGROUND_SCAN_PERIOD;
     private long backgroundBetweenScanPeriod = DEFAULT_BACKGROUND_BETWEEN_SCAN_PERIOD;
-
-    private static long exitRegionPeriod = DEFAULT_EXIT_PERIOD;
 
     /**
      * Sets the duration in milliseconds of each Bluetooth LE scan cycle to look for beacons.
@@ -219,7 +219,7 @@ public class BeaconManager {
      * @param regionExitPeriod
      */
     public static void setRegionExitPeriod(long regionExitPeriod){
-        exitRegionPeriod = regionExitPeriod;
+        sExitRegionPeriod = regionExitPeriod;
     }
     
     /**
@@ -228,7 +228,7 @@ public class BeaconManager {
      * @return exit region period in milliseconds
      */
     public static long getRegionExitPeriod(){
-        return exitRegionPeriod;
+        return sExitRegionPeriod;
     }
 
     /**

--- a/src/main/java/org/altbeacon/beacon/service/MonitorState.java
+++ b/src/main/java/org/altbeacon/beacon/service/MonitorState.java
@@ -23,11 +23,11 @@
  */
 package org.altbeacon.beacon.service;
 
+import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
 
 public class MonitorState {
     private static final String TAG = "MonitorState";
-    public static long INSIDE_EXPIRATION_MILLIS = 10000l;
     private boolean inside = false;
     private long lastSeenTime = 0l;
     private Callback callback;
@@ -51,12 +51,12 @@ public class MonitorState {
     }
     public boolean isNewlyOutside() {
         if (inside) {
-            if (lastSeenTime > 0 && System.currentTimeMillis() - lastSeenTime > INSIDE_EXPIRATION_MILLIS) {
+            if (lastSeenTime > 0 && System.currentTimeMillis() - lastSeenTime > BeaconManager.getRegionExitPeriod()) {
                 inside = false;
                 LogManager.d(TAG, "We are newly outside the region because the lastSeenTime of %s "
                                 + "was %s seconds ago, and that is over the expiration duration "
                                 + "of %s", lastSeenTime, System.currentTimeMillis() - lastSeenTime,
-                        INSIDE_EXPIRATION_MILLIS);
+                        BeaconManager.getRegionExitPeriod());
                 lastSeenTime = 0l;
                 return true;
             }


### PR DESCRIPTION
Hello, I requested the feature that allows to change the exit region time. So, I made the straightforward solution via static variable and methods of BeaconManager where all settings are located.