### PR TITLE
Use CopyOnWriteArrayList for beacon parser list

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3'

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * A class used to set up interaction with beacons from an <code>Activity</code> or <code>Service</code>.
@@ -113,7 +114,7 @@ public class BeaconManager {
     protected MonitorNotifier monitorNotifier = null;
     private final ArrayList<Region> monitoredRegions = new ArrayList<Region>();
     private final ArrayList<Region> rangedRegions = new ArrayList<Region>();
-    private final ArrayList<BeaconParser> beaconParsers = new ArrayList<BeaconParser>();
+    private final List<BeaconParser> beaconParsers = new CopyOnWriteArrayList<>();
     private boolean mBackgroundMode = false;
     private boolean mBackgroundModeUninitialized = true;
 
@@ -252,15 +253,11 @@ public class BeaconManager {
    }
 
    /**
-     * Gets a list of the active beaconParsers.  This list may only be modified before any consumers
-     * are bound to the beacon service
+     * Gets a list of the active beaconParsers.
      *
      * @return list of active BeaconParsers
      */
     public List<BeaconParser> getBeaconParsers() {
-        if (isAnyConsumerBound()) {
-            return Collections.unmodifiableList(beaconParsers);
-        }
         return beaconParsers;
     }
 


### PR DESCRIPTION
BeaconManager used to either return a regular ArrayList or unmodifiableList depending on whether any consumers were bound to the BeaconManager. This unnecessarily caused ConcurrentModificationExceptions if used incorrectly, and was easily bypassed. Replace with the simpler CopyOnWriteArrayList.

I ran the unit tests and did some local testing on a snapshot build and it seemed to be ok.