### PR TITLE
Android 6.0 Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,12 +50,12 @@ allprojects {
 }
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23"
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName version
         testInstrumentationRunner "com.google.android.apps.common.testing.testrunner.GoogleInstrumentationTestRunner"

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -1,7 +1,6 @@
 package org.altbeacon.beacon.service.scanner;
 
 import android.annotation.TargetApi;
-import android.app.usage.UsageStatsManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
@@ -9,7 +8,6 @@ import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
-import android.os.Build;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -87,17 +85,6 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
            operating system versions.
      */
     protected boolean deferScanIfNeeded() {
-        try {
-            @SuppressWarnings("ResourceType") final UsageStatsManager usageStatsManager=(UsageStatsManager)mContext.getSystemService("usagestats");// Context.USAGE_STATS_SERVICE);
-            if (Build.VERSION.SDK_INT >=  23) {
-                LogManager.d(TAG, "isAppInactive: "+usageStatsManager.isAppInactive("org.altbeacon.beaconreference"));
-
-            }
-        }
-        catch (Exception e) {
-            LogManager.d(TAG, "Can't get UsageStatsManager", e);
-        }
-
         // This method is called to see if it is time to start a scan
         long millisecondsUntilStart = mNextScanCycleStartTime - System.currentTimeMillis();
         if (millisecondsUntilStart > 0) {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -1,6 +1,7 @@
 package org.altbeacon.beacon.service.scanner;
 
 import android.annotation.TargetApi;
+import android.app.usage.UsageStatsManager;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanCallback;
@@ -8,6 +9,7 @@ import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
+import android.os.Build;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -85,6 +87,17 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
            operating system versions.
      */
     protected boolean deferScanIfNeeded() {
+        try {
+            @SuppressWarnings("ResourceType") final UsageStatsManager usageStatsManager=(UsageStatsManager)mContext.getSystemService("usagestats");// Context.USAGE_STATS_SERVICE);
+            if (Build.VERSION.SDK_INT >=  23) {
+                LogManager.d(TAG, "isAppInactive: "+usageStatsManager.isAppInactive("org.altbeacon.beaconreference"));
+
+            }
+        }
+        catch (Exception e) {
+            LogManager.d(TAG, "Can't get UsageStatsManager", e);
+        }
+
         // This method is called to see if it is time to start a scan
         long millisecondsUntilStart = mNextScanCycleStartTime - System.currentTimeMillis();
         if (millisecondsUntilStart > 0) {
@@ -105,6 +118,8 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                         // if we see one of those beacons, we need to deliver the results
                         startScan();
                     } else {
+                        // TODO: Consider starting a scan with delivery based on the filters *NOT* being seen
+                        // This API is now available in Android M
                         LogManager.d(TAG, "This is Android L, but we last saw a beacon only %s "
                                 + "ago, so we will not keep scanning in background.",
                                 secsSinceLastDetection);

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -26,6 +26,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
     private long mBackgroundLScanStartTime = 0l;
     private long mBackgroundLScanFirstDetectionTime = 0l;
     private boolean mScanDeferredBefore = false;
+    private boolean mMainScanCycleActive = false;
     private BeaconManager mBeaconManager;
 
     public CycledLeScannerForLollipop(Context context, long scanPeriod, long betweenScanPeriod, boolean backgroundFlag, CycledLeScanCallback cycledLeScanCallback, BluetoothCrashResolver crashResolver) {
@@ -84,8 +85,10 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
            operating system versions.
      */
     protected boolean deferScanIfNeeded() {
+        // This method is called to see if it is time to start a scan
         long millisecondsUntilStart = mNextScanCycleStartTime - System.currentTimeMillis();
         if (millisecondsUntilStart > 0) {
+            mMainScanCycleActive = false;
             if (true) {
                 long secsSinceLastDetection = System.currentTimeMillis() -
                         DetectionTracker.getInstance().getLastDetectionTime();
@@ -100,7 +103,6 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
 
                         // On Android L, between scan cycles do a scan with a filter looking for any beacon
                         // if we see one of those beacons, we need to deliver the results
-                        ScanSettings settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
                         startScan();
                     } else {
                         LogManager.d(TAG, "This is Android L, but we last saw a beacon only %s "
@@ -154,6 +156,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                 mBackgroundLScanStartTime = 0;
             }
             mScanDeferredBefore = false;
+            mMainScanCycleActive = true;
         }
         return false;
     }
@@ -163,16 +166,14 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
         List<ScanFilter> filters = new ArrayList<ScanFilter>();
         ScanSettings settings;
 
-        if (mBackgroundFlag) {
-            LogManager.d(TAG, "starting scan in SCAN_MODE_LOW_POWER");
+        if (mBackgroundFlag && !mMainScanCycleActive) {
+            LogManager.d(TAG, "starting filtered scan in SCAN_MODE_LOW_POWER");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
             filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
                     mBeaconManager.getBeaconParsers());
-
         } else {
-            LogManager.d(TAG, "starting scan in SCAN_MODE_LOW_LATENCY");
+            LogManager.d(TAG, "starting non-filtered scan in SCAN_MODE_LOW_LATENCY");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();
-
         }
 
         try {
@@ -194,6 +195,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
 
     @Override
     protected void finishScan() {
+        LogManager.d(TAG, "Stopping scan");
         stopScan();
         mScanningPaused = true;
     }


### PR DESCRIPTION
* Upgrade to SDK 23 (Marshmallow)
* When scanning in the background, do an unfiltered scan on each main scan cycle in case chips do not support filtering, or no more filter slots are unavailable.  This will cause background detections on Android 5.x+ to still happen in 5 minutes even if there are no hardware acceleration capability.