### PR TITLE
Fix region matching with fewer ids

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application>
         <receiver android:name="org.altbeacon.beacon.startup.StartupBroadcastReceiver">

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -434,9 +434,12 @@ public class BeaconParser {
                     }
                 } else {
                     if (LogManager.isVerboseLoggingEnabled()) {
-                        LogManager.d(TAG, "This is not a matching Beacon advertisement. Was expecting %s.  "
-                                        + "The bytes I see are: %s", byteArrayToString(serviceUuidBytes),
+                        LogManager.d(TAG, "This is not a matching Beacon advertisement. Was expecting %s at offset %d and %s at offset %d.  "
+                                        + "The bytes I see are: %s",
+                                byteArrayToString(serviceUuidBytes),
+                                startByte + mServiceUuidStartOffset,
                                 byteArrayToString(typeCodeBytes),
+                                startByte + mMatchingBeaconTypeCodeStartOffset,
                                 bytesToHex(bytesToProcess));
                     }
                 }

--- a/src/main/java/org/altbeacon/beacon/Region.java
+++ b/src/main/java/org/altbeacon/beacon/Region.java
@@ -183,8 +183,13 @@ public class Region implements Parcelable {
     public boolean matchesBeacon(Beacon beacon) {
         // All identifiers must match, or the corresponding region identifier must be null.
         for (int i = mIdentifiers.size(); --i >= 0; ) {
-            final Identifier ident = mIdentifiers.get(i);
-            if (beacon.mIdentifiers.size() <= i || ident != null && !ident.equals(beacon.mIdentifiers.get(i))) {
+            final Identifier identifier = mIdentifiers.get(i);
+            Identifier beaconIdentifier = null;
+            if (i < beacon.mIdentifiers.size()) {
+                beaconIdentifier = beacon.getIdentifier(i);
+            }
+            if ((beaconIdentifier == null && identifier != null) ||
+                    (beaconIdentifier != null  && identifier != null && !identifier.equals(beaconIdentifier))) {
                 return false;
             }
         }

--- a/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
+++ b/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
@@ -72,13 +72,26 @@ public class GattBeaconTest {
                 (byte)0x00,
                 gattBeacon.getId1().toByteArray()[0]);
         assertEquals("GattBeacon identifier should have proper second to last byte",
-                (byte)0x73,
+                (byte) 0x73,
                 gattBeacon.getId1().toByteArray()[14]);
         assertEquals("GattBeacon identifier should have proper last byte",
                 (byte)0x07,
                 gattBeacon.getId1().toByteArray()[15]);
 
     }
+
+
+    @Test
+    public void testDetectsEddystoneUID() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        LogManager.setLogger(Loggers.verboseLogger());
+        LogManager.setVerboseLoggingEnabled(true);
+        byte[] bytes = hexStringToByteArray("0201060303aafe1516aafe00e700010203040506070809010203040506000000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser().setBeaconLayout(BeaconParser.EDDYSTONE_UID_LAYOUT);
+        Beacon eddystoneUidBeacon = parser.fromScanData(bytes, -55, null);
+        assertNotNull("Eddystone-UID should be not null if parsed successfully", eddystoneUidBeacon);
+    }
+
 
     @Test
     public void testDetectsGattBeaconWithCnn() {

--- a/src/test/java/org/altbeacon/beacon/RegionTest.java
+++ b/src/test/java/org/altbeacon/beacon/RegionTest.java
@@ -81,6 +81,14 @@ public class RegionTest {
     }
 
     @Test
+    public void testBeaconDoesMatchRegionWithLongerIdentifierListWithSomeNull() {
+        Beacon beacon = new Beacon.Builder().setId1("1").setId2("2").setRssi(4)
+                .setBeaconTypeCode(5).setTxPower(6).setBluetoothAddress("1:2:3:4:5:6").build();
+        Region region = new Region("myRegion", null, null, null);
+        assertTrue("Beacon should match region with more identifers than the beacon, if the region identifiers are null", region.matchesBeacon(beacon));
+    }
+
+    @Test
     public void testBeaconMatchesRegionWithSameBluetoothMac() {
         Beacon beacon = new AltBeacon.Builder().setId1("1").setId2("2").setId3("3").setRssi(4)
                 .setBeaconTypeCode(5).setTxPower(6).setBluetoothAddress("01:02:03:04:05:06").build();


### PR DESCRIPTION
This addresses a bug where Eddystone beacons with 1 or 2 identifiers didn't match region with three null identifiers.  It is important that these do match, as most examples show setting up a region to match all beacons that has three null identifiers.

This bug was introduced in commit 341be144 and first appeared in release 2.6

This addresses #294 