### PR TITLE
Fix cancelling wakeup alarm

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -9,7 +9,6 @@ import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
-import android.util.Log;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -319,7 +318,7 @@ public abstract class CycledLeScanner {
         // devices.
         long milliseconds = Long.MAX_VALUE; // 2.9 million years from now
         AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
-        alarmManager.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + milliseconds, getWakeUpOperation());
+        alarmManager.set(AlarmManager.RTC_WAKEUP, milliseconds, getWakeUpOperation());
         LogManager.d(TAG, "Set a wakeup alarm to go off in %s ms: %s", milliseconds, getWakeUpOperation());
 
     }


### PR DESCRIPTION
As it is stated in the comment when cancelling wakeup alarm it was intended to be defered to the long long future due to some Samsung devices constraints. Actually, the time to deploy alarm parameter was passed with overflow (Long.MAX_VALUE + currentTime() is actually in the past) and the alarm is deployed right after it's creation. Not as it is intended to be. This commit fixes it.