### PR TITLE
Fast background detection for Eddystone

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -8,6 +8,7 @@ import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
+import android.os.ParcelUuid;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -222,7 +223,15 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
 
                 @Override
                 public void onScanResult(int callbackType, ScanResult scanResult) {
-                    LogManager.d(TAG, "got record");
+                    if (LogManager.isVerboseLoggingEnabled()) {
+                        LogManager.d(TAG, "got record");
+                        List<ParcelUuid> uuids = scanResult.getScanRecord().getServiceUuids();
+                        if (uuids != null) {
+                            for (ParcelUuid uuid : uuids) {
+                                LogManager.d(TAG, "with service uuid: "+uuid);
+                            }
+                        }
+                    }
                     mCycledLeScanCallback.onLeScan(scanResult.getDevice(),
                             scanResult.getRssi(), scanResult.getScanRecord().getBytes());
                     if (mBackgroundLScanStartTime > 0) {

--- a/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
@@ -1,6 +1,7 @@
 package org.altbeacon.beacon.service.scanner;
 
 
+import android.bluetooth.le.ScanFilter;
 import android.content.Context;
 
 import org.altbeacon.beacon.AltBeaconParser;
@@ -15,12 +16,15 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import org.mockito.Mockito;
 
 @Config(sdk = 18)
 
@@ -61,9 +65,22 @@ public class ScanFilterUtilsTest {
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("manufacturer should be right", 0x004c, sfd.manufacturer);
         assertEquals("mask length should be right", 2, sfd.mask.length);
-        assertArrayEquals("mask should be right", new byte[] {(byte)0xff, (byte)0xff}, sfd.mask);
-        assertArrayEquals("filter should be right", new byte[] {(byte)0x11, (byte)0x11}, sfd.filter);
+        assertArrayEquals("mask should be right", new byte[]{(byte) 0xff, (byte) 0xff}, sfd.mask);
+        assertArrayEquals("filter should be right", new byte[] {(byte)0x11, (byte) 0x11}, sfd.filter);
+        assertNull("serviceUuid should be null", sfd.serviceUuid);
     }
+    @Test
+    public void testEddystoneScanFilterData() throws Exception {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        BeaconParser parser = new BeaconParser();
+        parser.setBeaconLayout(BeaconParser.EDDYSTONE_UID_LAYOUT);
+        BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
+        ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
+        assertEquals("serviceUuid should be right", new Long(0xfeaa), sfd.serviceUuid);
+    }
+
     @Test
     public void testZeroOffsetScanFilter() throws Exception {
         org.robolectric.shadows.ShadowLog.stream = System.err;


### PR DESCRIPTION
This adds the use of hardware scan filters for service advertisements like Eddystone when a scanning app is in background mode.  This will make detections happen within a few seconds instead of within five minutes at default settings.