### PR TITLE
Stopping and starting monitoring disables scans

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -208,7 +208,7 @@ public abstract class CycledLeScanner {
         } else {
             LogManager.d(TAG, "disabling scan");
             mScanning = false;
-
+            mScanCyclerStarted = false;
             stopScan();
             mLastScanCycleEndTime = new Date().getTime();
         }


### PR DESCRIPTION
This fixes a race condition where stopping monitoring and scanning and then immediately restarting monitoring and scanning leaves the library in a state where it is not doing any scanning at all.  This was caused by a race condition that kept the `mScanCyclerStarted` flag from being set to false if a scan cycle was not allowed to end normally after stopping scanning/monitoring before restarting again.

This change eliminates that race condition by setting the flag immediately.