### PR TITLE
Fix crash on comparison overrun 

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -773,6 +773,9 @@ public class BeaconParser {
 
     private boolean byteArraysMatch(byte[] array1, int offset1, byte[] array2, int offset2) {
         int minSize = array1.length > array2.length ? array2.length : array1.length;
+        if (offset1+minSize > array1.length || offset2+minSize > array2.length) {
+            return false;
+        }
         for (int i = 0; i <  minSize; i++) {
             if (array1[i+offset1] != array2[i+offset2]) {
                 return false;

--- a/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -290,5 +290,20 @@ public class BeaconParserTest {
         byte[] bytes = p.getBeaconAdvertisementData(beacon);
         assertEquals("First byte of url should be in position 3", 0x02, bytes[2]);
     }
+    @Test
+    public void doesNotCashWithOverflowingByteCodeComparisonOnPdu() {
+        // Test for https://github.com/AltBeacon/android-beacon-library/issues/323
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+
+        // Note that the length field below is 0x16 instead of 0x1b, indicating that the packet ends
+        // one byte before the second identifier field starts
+
+        byte[] bytes = hexStringToByteArray("02010604ffe000be");
+        BeaconParser parser = new BeaconParser();
+        parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
+
+        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        assertNull("beacon not be parsed without an exception being thrown", beacon);
+    }
 
 }


### PR DESCRIPTION
When comparing two byte arrays, check first to see if one is shorter than the other.  If so, consider them unequal and short-circuit the comparison rather than crash on an ArrayIndexOutOfBoundsException looping through the bytes.  Fixes #323