### PR TITLE
Add utility to access raw Eddystone-TLM bytes

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -661,8 +661,11 @@ public class BeaconParser {
         }
 
         // set power
-        for (int index = this.mPowerStartOffset; index <= this.mPowerEndOffset; index ++) {
-            advertisingBytes[index-2] = (byte) (beacon.getTxPower() >> (8*(index - this.mPowerStartOffset)) & 0xff);
+
+        if (this.mPowerStartOffset != null && this.mPowerEndOffset != null) {
+            for (int index = this.mPowerStartOffset; index <= this.mPowerEndOffset; index ++) {
+                advertisingBytes[index-2] = (byte) (beacon.getTxPower() >> (8*(index - this.mPowerStartOffset)) & 0xff);
+            }
         }
 
         // set data fields

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -672,13 +672,13 @@ public class BeaconParser {
         // set data fields
         for (int dataFieldNum = 0; dataFieldNum < this.mDataStartOffsets.size(); dataFieldNum++) {
             long dataField = beacon.getDataFields().get(dataFieldNum);
-
-            for (int index = this.mDataStartOffsets.get(dataFieldNum); index <= this.mDataEndOffsets.get(dataFieldNum); index ++) {
+            int dataFieldLength = this.mDataEndOffsets.get(dataFieldNum) - this.mDataStartOffsets.get(dataFieldNum);
+            for (int index = 0; index <= dataFieldLength; index ++) {
                 int endianCorrectedIndex = index;
-                if (this.mDataLittleEndianFlags.get(dataFieldNum)) {
-                    endianCorrectedIndex = this.mDataEndOffsets.get(dataFieldNum) - index;
+                if (!this.mDataLittleEndianFlags.get(dataFieldNum)) {
+                    endianCorrectedIndex = dataFieldLength-index;
                 }
-                advertisingBytes[endianCorrectedIndex-2] = (byte) (dataField >> (8*(index - this.mDataStartOffsets.get(dataFieldNum))) & 0xff);
+                advertisingBytes[this.mDataStartOffsets.get(dataFieldNum)-2+endianCorrectedIndex] = (byte) (dataField >> (8*index) & 0xff);
             }
         }
         return advertisingBytes;

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -449,6 +449,7 @@ public class BeaconParser {
                 if (LogManager.isVerboseLoggingEnabled()) {
                     LogManager.d(TAG, "This is a recognized beacon advertisement -- %s seen",
                             byteArrayToString(typeCodeBytes));
+                    LogManager.d(TAG, "Bytes are: %s", bytesToHex(bytesToProcess));
                 }
             }
 

--- a/src/main/java/org/altbeacon/beacon/utils/EddystoneTelemetryAccessor.java
+++ b/src/main/java/org/altbeacon/beacon/utils/EddystoneTelemetryAccessor.java
@@ -1,0 +1,68 @@
+package org.altbeacon.beacon.utils;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.util.Base64;
+import android.util.Log;
+
+import org.altbeacon.beacon.Beacon;
+import org.altbeacon.beacon.BeaconParser;
+
+/**
+ * Created by dyoung on 12/21/15.
+ */
+public class EddystoneTelemetryAccessor {
+    private static final String TAG = "EddystoneTLMAccessor";
+    /**
+     * Extracts the raw Eddystone telemetry bytes from the extra data fields of an associated beacon.
+     * This is useful for passing the telemetry to Google's backend services.
+     * @param beacon
+     * @return the bytes of the telemetry frame
+     */
+    public byte[] getTelemetryBytes(Beacon beacon) {
+        if (beacon.getExtraDataFields().size() >= 5) {
+            Beacon telemetryBeacon = new Beacon.Builder()
+                    .setDataFields(beacon.getExtraDataFields())
+                    .build();
+            BeaconParser telemetryParser = new BeaconParser()
+                    .setBeaconLayout(BeaconParser.EDDYSTONE_TLM_LAYOUT);
+            byte[] telemetryBytes = telemetryParser.getBeaconAdvertisementData(telemetryBeacon);
+            Log.d(TAG, "Rehydrated telemetry bytes are :" + byteArrayToString(telemetryBytes));
+            return telemetryBytes;
+        }
+        else {
+            return null;
+        }
+    }
+
+    /**
+     * Extracts the raw Eddystone telemetry bytes from the extra data fields of an associated beacon
+     * and base64 encodes them.  This is useful for passing the telemetry to Google's backend
+     * services.
+     * @param beacon
+     * @return
+     */
+    @TargetApi(Build.VERSION_CODES.FROYO)
+    public String getBase64EncodedTelemetry(Beacon beacon) {
+        byte[] bytes = getTelemetryBytes(beacon);
+        if (bytes != null) {
+            String base64EncodedTelemetry = Base64.encodeToString(bytes, Base64.DEFAULT);
+            // 12-21 00:17:18.844 20180-20180/? D/EddystoneTLMAccessor: Rehydrated telemetry bytes are :20 00 00 00 88 29 18 4d 00 00 18 4d 00 00
+            // 12-21 00:17:18.844 20180-20180/? D/EddystoneTLMAccessor: Base64 telemetry bytes are :IAAAAIgpGE0AABhNAAA=
+            Log.d(TAG, "Base64 telemetry bytes are :"+base64EncodedTelemetry);
+            return base64EncodedTelemetry;
+        }
+        else {
+            return null;
+        }
+    }
+
+    private String byteArrayToString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            sb.append(String.format("%02x", bytes[i]));
+            sb.append(" ");
+        }
+        return sb.toString().trim();
+    }
+}

--- a/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -146,6 +146,18 @@ public class BeaconParserTest {
         assertArrayEquals("beacon advertisement bytes should be the same after re-encoding", expectedMatch, regeneratedBytes);
     }
 
+    @TargetApi(Build.VERSION_CODES.GINGERBREAD)
+    @Test
+    public void testReEncodesBeaconForEddystoneTelemetry() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        byte[] bytes = hexStringToByteArray("0201060303aafe1516aafe2001021203130414243405152535");
+        BeaconParser parser = new BeaconParser();
+        parser.setBeaconLayout(BeaconParser.EDDYSTONE_TLM_LAYOUT);
+        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        byte[] regeneratedBytes = parser.getBeaconAdvertisementData(beacon);
+        byte[] expectedMatch = Arrays.copyOfRange(bytes, 11, bytes.length);
+        assertEquals("beacon advertisement bytes should be the same after re-encoding", byteArrayToHexString(expectedMatch), byteArrayToHexString(regeneratedBytes));
+    }
 
     @Test
     public void testLittleEndianIdentifierParsing() {
@@ -174,7 +186,7 @@ public class BeaconParserTest {
         byte[] expectedMatch = Arrays.copyOfRange(bytes, 7, bytes.length);
         System.err.println(byteArrayToHexString(expectedMatch));
         System.err.println(byteArrayToHexString(regeneratedBytes));
-        assertArrayEquals("beacon advertisement bytes should be the same after re-encoding", expectedMatch, regeneratedBytes);
+        assertEquals("beacon advertisement bytes should be the same after re-encoding", byteArrayToHexString(expectedMatch), byteArrayToHexString(regeneratedBytes));
     }
 
 

--- a/src/test/java/org/altbeacon/beacon/utils/EddystoneTelemetryAccessorTest.java
+++ b/src/test/java/org/altbeacon/beacon/utils/EddystoneTelemetryAccessorTest.java
@@ -1,0 +1,63 @@
+package org.altbeacon.beacon.utils;
+
+import junit.framework.Assert;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.altbeacon.beacon.Beacon;
+import org.junit.Test;
+import org.robolectric.RobolectricTestRunner;
+
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@Config(sdk = 18)
+@RunWith(RobolectricTestRunner.class)
+public class EddystoneTelemetryAccessorTest {
+
+    public static String byteArrayToHexString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            sb.append(String.format("%02x", bytes[i]));
+        }
+        return sb.toString();
+    }
+
+    @Test
+    public void testAllowsAccessToTelemetryBytes() throws MalformedURLException {
+        ArrayList<Long> telemetryFields = new ArrayList<Long>();
+        telemetryFields.add(0x01l); // version
+        telemetryFields.add(0x0212l); // battery level
+        telemetryFields.add(0x0313l); // temperature
+        telemetryFields.add(0x04142434l); // pdu count
+        telemetryFields.add(0x05152535l); // uptime
+
+        Beacon beaconWithTelemetry = new Beacon.Builder().setId1("0x0102030405060708090a").setId2("0x01020304050607").setTxPower(-59).setExtraDataFields(telemetryFields).build();
+        byte[] telemetryBytes = new EddystoneTelemetryAccessor().getTelemetryBytes(beaconWithTelemetry);
+
+        byte[] expectedBytes = {0x20, 0x01, 0x02, 0x12, 0x03, 0x13, 0x04, 0x14, 0x24, 0x34, 0x05, 0x15, 0x25, 0x35};
+        assertEquals(byteArrayToHexString(telemetryBytes), byteArrayToHexString(expectedBytes));
+    }
+
+
+    @Test
+    public void testAllowsAccessToBase64EncodedTelemetryBytes() throws MalformedURLException {
+        ArrayList<Long> telemetryFields = new ArrayList<Long>();
+        telemetryFields.add(0x01l); // version
+        telemetryFields.add(0x0212l); // battery level
+        telemetryFields.add(0x0313l); // temperature
+        telemetryFields.add(0x04142434l); // pdu count
+        telemetryFields.add(0x05152535l); // uptime
+
+        Beacon beaconWithTelemetry = new Beacon.Builder().setId1("0x0102030405060708090a").setId2("0x01020304050607").setTxPower(-59).setExtraDataFields(telemetryFields).build();
+        byte[] telemetryBytes = new EddystoneTelemetryAccessor().getTelemetryBytes(beaconWithTelemetry);
+
+        String encodedTelemetryBytes = new EddystoneTelemetryAccessor().getBase64EncodedTelemetry(beaconWithTelemetry);
+        assertNotNull(telemetryBytes);
+    }
+}


### PR DESCRIPTION
This experimental utility allows recreating the raw bytes of an Eddystone-TLM advertisement.  This is useful, because Google APIs allow reporting of detected telemetry packets to their backend, but want the raw bytes to be sent to the server.  While this library is designed to decode beacon packets into fields based on their layout, and format beacon fields into packets for advertising purposes, it does not easily allow access to raw bytes of a previously detected beacon.  This utility makes that possible.

To use this feature, you will need a copy of the library with this code added.  An ad-hoc release is available for download [here.](https://github.com/AltBeacon/android-beacon-library/releases/tag/ad-hoc-eddystone-telemetry-accessor)

Once your project is compiled with a library version that supports this feature, you can access the raw Eddystone-TLM bytes of any Beacon object with associated Eddystone-TLM fields (stored in the beacon.getExtraDataFields() list) with code like this:

```
byte[] telemetryBytes = new EddystoneTelemetryAccessor().getTelemetryBytes(beaconWithTelemetry);
```

You can also get the raw bytes as a Base64 encoded string with:

```
String encodedTelemetryBytes = new EddystoneTelemetryAccessor().getBase64EncodedTelemetry(beaconWithTelemetry);
```

Example debug output showing this in action:

```
12-26 14:25:58.951 16117-16117/com.radiusnetworks.locate D/EddystoneTLMAccessor: Rehydrated telemetry bytes are :20 00 00 00 4e 23 fc 02 00 00 fc 02 00 00
12-26 14:25:58.951 16117-16117/com.radiusnetworks.locate D/EddystoneTLMAccessor: Base64 telemetry bytes are :IAAAAE4j/AIAAPwCAAA=
```