### PR TITLE
Track parser identifier in both BeaconParser and Beacon

### DIFF
--- a/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
@@ -52,6 +52,7 @@ public class AltBeaconParser extends BeaconParser {
         // detection APIs will not be able to detect the beacon in the background.
         mHardwareAssistManufacturers = new int[]{0x0118};
         this.setBeaconLayout(BeaconParser.ALTBEACON_LAYOUT);
+        this.mIdentifier = "altbeacon";
     }
     /**
      * Construct an AltBeacon from a Bluetooth LE packet collected by Android's Bluetooth APIs,

--- a/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -151,6 +151,12 @@ public class Beacon implements Parcelable {
     protected String mBluetoothName;
 
     /**
+     * The identifier of the beaconParser used to create this beacon.  Useful for figuring out
+     * beacon types.
+     */
+    protected String mParserIdentifier;
+
+    /**
      * Required for making object Parcelable.  If you override this class, you must provide an
      * equivalent version of this method.
      */
@@ -223,6 +229,8 @@ public class Beacon implements Parcelable {
         }
         mManufacturer = in.readInt();
         mBluetoothName = in.readString();
+        mParserIdentifier = in.readString();
+
     }
 
     /**
@@ -242,6 +250,7 @@ public class Beacon implements Parcelable {
         this.mBeaconTypeCode = otherBeacon.getBeaconTypeCode();
         this.mServiceUuid = otherBeacon.getServiceUuid();
         this.mBluetoothName = otherBeacon.mBluetoothName;
+        this.mParserIdentifier = otherBeacon.mParserIdentifier;
     }
 
     /**
@@ -427,6 +436,12 @@ public class Beacon implements Parcelable {
     }
 
     /**
+     * @see #mParserIdentifier
+     * @return mParserIdentifier
+     */
+    public String getParserIdentifier() { return mParserIdentifier; }
+
+    /**
      * Calculate a hashCode for this beacon
      * @return
      */
@@ -487,6 +502,9 @@ public class Beacon implements Parcelable {
             sb.append(identifier == null ? "null" : identifier.toString());
             i++;
         }
+        if (mParserIdentifier != null) {
+            sb.append(" type "+mParserIdentifier);
+        }
         return sb;
     }
 
@@ -526,7 +544,7 @@ public class Beacon implements Parcelable {
         }
         out.writeInt(mManufacturer);
         out.writeString(mBluetoothName);
-
+        out.writeString(mParserIdentifier);
     }
 
     /**
@@ -753,6 +771,15 @@ public class Beacon implements Parcelable {
             return this;
         }
 
+        /**
+         * @see Beacon#mParserIdentifier
+         * @param id
+         * @return builder
+         */
+        public Builder setParserIdentifier(String id) {
+            mBeacon.mParserIdentifier = id;
+            return this;
+        }
     }
 
 }

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -53,13 +53,13 @@ public class BeaconParser {
     private static final String VARIABLE_LENGTH_SUFFIX = "v";
 
     private Long mMatchingBeaconTypeCode;
-    protected final List<Integer> mIdentifierStartOffsets;
-    protected final List<Integer> mIdentifierEndOffsets;
-    protected final List<Boolean> mIdentifierLittleEndianFlags;
-    protected final List<Integer> mDataStartOffsets;
-    protected final List<Integer> mDataEndOffsets;
-    protected final List<Boolean> mDataLittleEndianFlags;
-    protected final List<Boolean> mIdentifierVariableLengthFlags;
+    protected final List<Integer> mIdentifierStartOffsets = new ArrayList<Integer>();
+    protected final List<Integer> mIdentifierEndOffsets = new ArrayList<Integer>();
+    protected final List<Boolean> mIdentifierLittleEndianFlags = new ArrayList<Boolean>();
+    protected final List<Integer> mDataStartOffsets = new ArrayList<Integer>();
+    protected final List<Integer> mDataEndOffsets = new ArrayList<Integer>();
+    protected final List<Boolean> mDataLittleEndianFlags = new ArrayList<Boolean>();
+    protected final List<Boolean> mIdentifierVariableLengthFlags = new ArrayList<Boolean>();
     protected Integer mMatchingBeaconTypeCodeStartOffset;
     protected Integer mMatchingBeaconTypeCodeEndOffset;
     protected Integer mServiceUuidStartOffset;
@@ -71,21 +71,22 @@ public class BeaconParser {
     protected Integer mPowerEndOffset;
     protected Integer mDBmCorrection;
     protected Integer mLayoutSize;
-    protected Boolean mAllowPduOverflow;
+    protected Boolean mAllowPduOverflow = true;
+    protected String mIdentifier;
     protected int[] mHardwareAssistManufacturers = new int[] { 0x004c };
 
     /**
      * Makes a new BeaconParser.  Should normally be immediately followed by a call to #setLayout
      */
     public BeaconParser() {
-        mIdentifierStartOffsets = new ArrayList<Integer>();
-        mIdentifierEndOffsets = new ArrayList<Integer>();
-        mDataStartOffsets = new ArrayList<Integer>();
-        mDataEndOffsets = new ArrayList<Integer>();
-        mDataLittleEndianFlags = new ArrayList<Boolean>();
-        mIdentifierLittleEndianFlags = new ArrayList<Boolean>();
-        mIdentifierVariableLengthFlags = new ArrayList<Boolean>();
-        mAllowPduOverflow = true;
+    }
+
+    /**
+     * Makes a new BeaconParser with an identifier that can be used to identify beacons decoded with
+     * this parser
+     */
+    public BeaconParser(String identifier) {
+        mIdentifier = identifier;
     }
 
     /**
@@ -272,6 +273,15 @@ public class BeaconParser {
         }
         mLayoutSize = calculateLayoutSize();
         return this;
+    }
+
+    /**
+     * Gets an optional identifier field that may be used to identify this parser.  If set, it will
+     * be passed along to any beacons decoded with this parser.
+     * @return
+     */
+    public String getIdentifier() {
+        return mIdentifier;
     }
 
     /**
@@ -563,6 +573,7 @@ public class BeaconParser {
             beacon.mBluetoothAddress = macAddress;
             beacon.mBluetoothName= name;
             beacon.mManufacturer = manufacturer;
+            beacon.mParserIdentifier = mIdentifier;
         }
         return beacon;
     }

--- a/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -99,6 +99,17 @@ public class BeaconParserTest {
     }
 
     @Test
+    public void testAllowsAccessToParserIdentifier() {
+        LogManager.setLogger(Loggers.verboseLogger());
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        byte[] bytes = hexStringToByteArray("02011a1aff180112342f234454cf6d4a0fadf2f4911ba9ffa600010002c5");
+        BeaconParser parser = new BeaconParser("my_beacon_type");
+        parser.setBeaconLayout("m:2-3=1234,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
+        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        assertEquals("parser identifier should be accessible", "my_beacon_type", beacon.getParserIdentifier());
+    }
+
+    @Test
     public void testParsesBeaconMissingDataField() {
         LogManager.setLogger(Loggers.verboseLogger());
         org.robolectric.shadows.ShadowLog.stream = System.err;


### PR DESCRIPTION
This adds a new identifier field to a `BeaconParser`, which can be used in the constructor like this:  `new BeaconParser("my_beacon_type")`

A corresponding `parserIdentifier` field has been added to `Beacon` which allows access to this field for any beacon constructed from this parser:  `beacon.getParserIdentifier(); // Returns "my_beacon_type"`

This is useful for scanning for multiple beacon types and then easily knowing which type each ranged beacon is.