### PR TITLE
Use realtime clock for scanning intervals and timers

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/DetectionTracker.java
+++ b/src/main/java/org/altbeacon/beacon/service/DetectionTracker.java
@@ -1,5 +1,7 @@
 package org.altbeacon.beacon.service;
 
+import android.os.SystemClock;
+
 /**
  * Created by dyoung on 1/10/15.
  */
@@ -19,6 +21,6 @@ public class DetectionTracker {
         return mLastDetectionTime;
     }
     public void recordDetection() {
-        mLastDetectionTime = System.currentTimeMillis();
+        mLastDetectionTime = SystemClock.elapsedRealtime();
     }
 }

--- a/src/main/java/org/altbeacon/beacon/service/MonitorState.java
+++ b/src/main/java/org/altbeacon/beacon/service/MonitorState.java
@@ -23,6 +23,8 @@
  */
 package org.altbeacon.beacon.service;
 
+import android.os.SystemClock;
+
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
 
@@ -42,7 +44,7 @@ public class MonitorState {
 
     // returns true if it is newly inside
     public boolean markInside() {
-        lastSeenTime = System.currentTimeMillis();
+        lastSeenTime = SystemClock.elapsedRealtime();
         if (!inside) {
             inside = true;
             return true;
@@ -51,11 +53,11 @@ public class MonitorState {
     }
     public boolean isNewlyOutside() {
         if (inside) {
-            if (lastSeenTime > 0 && System.currentTimeMillis() - lastSeenTime > BeaconManager.getRegionExitPeriod()) {
+            if (lastSeenTime > 0 && SystemClock.elapsedRealtime() - lastSeenTime > BeaconManager.getRegionExitPeriod()) {
                 inside = false;
                 LogManager.d(TAG, "We are newly outside the region because the lastSeenTime of %s "
                                 + "was %s seconds ago, and that is over the expiration duration "
-                                + "of %s", lastSeenTime, System.currentTimeMillis() - lastSeenTime,
+                                + "of %s", lastSeenTime, SystemClock.elapsedRealtime() - lastSeenTime,
                         BeaconManager.getRegionExitPeriod());
                 lastSeenTime = 0l;
                 return true;

--- a/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -1,5 +1,7 @@
 package org.altbeacon.beacon.service;
 
+import android.os.SystemClock;
+
 import org.altbeacon.beacon.Beacon;
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -66,7 +68,7 @@ public class RangedBeacon {
         // http://stackoverflow.com/questions/30118991/rssi-returned-by-altbeacon-library-127-messes-up-distance
         if (rssi != 127) {
             mTracked = true;
-            lastTrackedTimeMillis = System.currentTimeMillis();
+            lastTrackedTimeMillis = SystemClock.elapsedRealtime();
             filter.addMeasurement(rssi);
         }
     }
@@ -85,7 +87,7 @@ public class RangedBeacon {
     }
 
     public long getTrackingAge() {
-        return System.currentTimeMillis() - lastTrackedTimeMillis;
+        return SystemClock.elapsedRealtime() - lastTrackedTimeMillis;
     }
 
     public boolean isExpired() {

--- a/src/main/java/org/altbeacon/beacon/service/RunningAverageRssiFilter.java
+++ b/src/main/java/org/altbeacon/beacon/service/RunningAverageRssiFilter.java
@@ -1,10 +1,11 @@
 package org.altbeacon.beacon.service;
 
+import android.os.SystemClock;
+
 import org.altbeacon.beacon.logging.LogManager;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 
 /**
@@ -23,7 +24,7 @@ public class RunningAverageRssiFilter implements RssiFilter {
     public void addMeasurement(Integer rssi) {
         Measurement measurement = new Measurement();
         measurement.rssi = rssi;
-        measurement.timestamp = new Date().getTime();
+        measurement.timestamp = SystemClock.elapsedRealtime();
         mMeasurements.add(measurement);
     }
 
@@ -55,12 +56,11 @@ public class RunningAverageRssiFilter implements RssiFilter {
     }
 
     private synchronized void refreshMeasurements() {
-        Date now = new Date();
         ArrayList<Measurement> newMeasurements = new ArrayList<Measurement>();
         Iterator<Measurement> iterator = mMeasurements.iterator();
         while (iterator.hasNext()) {
             Measurement measurement = iterator.next();
-            if (now.getTime() - measurement.timestamp < sampleExpirationMilliseconds ) {
+            if (SystemClock.elapsedRealtime() - measurement.timestamp < sampleExpirationMilliseconds ) {
                 newMeasurements.add(measurement);
             }
         }

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -320,7 +320,7 @@ public abstract class CycledLeScanner {
         long milliseconds = Long.MAX_VALUE; // 2.9 million years from now
         AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
         alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, milliseconds, getWakeUpOperation());
-        LogManager.d(TAG, "Set a wakeup alarm to go off in %s ms: %s", milliseconds, getWakeUpOperation());
+        LogManager.d(TAG, "Set a wakeup alarm to go off in %s ms: %s", milliseconds - SystemClock.elapsedRealtime(), getWakeUpOperation());
 
     }
 

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -103,7 +103,7 @@ public abstract class CycledLeScanner {
             LogManager.d(TAG, "We are not in the background.  Cancelling wakeup alarm");
             cancelWakeUpAlarm();
         }
-        long now = new Date().getTime();
+        long now = SystemClock.elapsedRealtime();
         if (mNextScanCycleStartTime > now) {
             // We are waiting to start scanning.  We may need to adjust the next start time
             // only do an adjustment if we need to make it happen sooner.  Otherwise, it will
@@ -111,7 +111,8 @@ public abstract class CycledLeScanner {
             long proposedNextScanStartTime = (mLastScanCycleEndTime + betweenScanPeriod);
             if (proposedNextScanStartTime < mNextScanCycleStartTime) {
                 mNextScanCycleStartTime = proposedNextScanStartTime;
-                LogManager.i(TAG, "Adjusted nextScanStartTime to be %s", new Date(mNextScanCycleStartTime));
+                LogManager.i(TAG, "Adjusted nextScanStartTime to be %s",
+                        new Date(mNextScanCycleStartTime - SystemClock.elapsedRealtime() + System.currentTimeMillis()));
             }
         }
         if (mScanCycleStopTime > now) {
@@ -145,7 +146,7 @@ public abstract class CycledLeScanner {
         }
         if (mBluetoothAdapter != null) {
             stopScan();
-            mLastScanCycleEndTime = new Date().getTime();
+            mLastScanCycleEndTime = SystemClock.elapsedRealtime();
         }
     }
 
@@ -191,7 +192,7 @@ public abstract class CycledLeScanner {
                                     LogManager.d(TAG, "Scanning unnecessary - no monitoring or ranging active.");
                                 }
                             }
-                            mLastScanCycleStartTime = new Date().getTime();
+                            mLastScanCycleStartTime = SystemClock.elapsedRealtime();
                         } else {
                             LogManager.d(TAG, "Bluetooth is disabled.  Cannot scan for beacons.");
                         }
@@ -202,7 +203,7 @@ public abstract class CycledLeScanner {
             } else {
                 LogManager.d(TAG, "We are already scanning");
             }
-            mScanCycleStopTime = (new Date().getTime() + mScanPeriod);
+            mScanCycleStopTime = (SystemClock.elapsedRealtime() + mScanPeriod);
             scheduleScanCycleStop();
 
             LogManager.d(TAG, "Scan started");
@@ -211,13 +212,13 @@ public abstract class CycledLeScanner {
             mScanning = false;
             mScanCyclerStarted = false;
             stopScan();
-            mLastScanCycleEndTime = new Date().getTime();
+            mLastScanCycleEndTime = SystemClock.elapsedRealtime();
         }
     }
 
     protected void scheduleScanCycleStop() {
         // Stops scanning after a pre-defined scan period.
-        long millisecondsUntilStop = mScanCycleStopTime - (new Date().getTime());
+        long millisecondsUntilStop = mScanCycleStopTime - SystemClock.elapsedRealtime();
         if (millisecondsUntilStop > 0) {
             LogManager.d(TAG, "Waiting to stop scan cycle for another %s milliseconds",
                     millisecondsUntilStop);
@@ -251,7 +252,7 @@ public abstract class CycledLeScanner {
                     } catch (Exception e) {
                         LogManager.w(e, TAG, "Internal Android exception scanning for beacons");
                     }
-                    mLastScanCycleEndTime = new Date().getTime();
+                    mLastScanCycleEndTime = SystemClock.elapsedRealtime();
                 } else {
                     LogManager.d(TAG, "Bluetooth is disabled.  Cannot scan for beacons.");
                 }
@@ -334,13 +335,13 @@ public abstract class CycledLeScanner {
         // This, of course, won't help at all if people set custom scan periods.  But since most
         // people accept the defaults, this will likely have a positive effect.
         if (mBetweenScanPeriod == 0) {
-            return System.currentTimeMillis();
+            return SystemClock.elapsedRealtime();
         }
         long fullScanCycle = mScanPeriod + mBetweenScanPeriod;
         long normalizedBetweenScanPeriod = mBetweenScanPeriod-(SystemClock.elapsedRealtime() % fullScanCycle);
         LogManager.d(TAG, "Normalizing between scan period from %s to %s", mBetweenScanPeriod,
                 normalizedBetweenScanPeriod);
 
-        return System.currentTimeMillis()+normalizedBetweenScanPeriod;
+        return SystemClock.elapsedRealtime()+normalizedBetweenScanPeriod;
     }
 }

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -9,6 +9,7 @@ import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Handler;
+import android.os.SystemClock;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -296,7 +297,7 @@ public abstract class CycledLeScanner {
         }
 
         AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
-        alarmManager.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + milliseconds, getWakeUpOperation());
+        alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + milliseconds, getWakeUpOperation());
         LogManager.d(TAG, "Set a wakeup alarm to go off in %s ms: %s", milliseconds, getWakeUpOperation());
     }
 
@@ -318,7 +319,7 @@ public abstract class CycledLeScanner {
         // devices.
         long milliseconds = Long.MAX_VALUE; // 2.9 million years from now
         AlarmManager alarmManager = (AlarmManager) mContext.getSystemService(Context.ALARM_SERVICE);
-        alarmManager.set(AlarmManager.RTC_WAKEUP, milliseconds, getWakeUpOperation());
+        alarmManager.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, milliseconds, getWakeUpOperation());
         LogManager.d(TAG, "Set a wakeup alarm to go off in %s ms: %s", milliseconds, getWakeUpOperation());
 
     }
@@ -336,7 +337,7 @@ public abstract class CycledLeScanner {
             return System.currentTimeMillis();
         }
         long fullScanCycle = mScanPeriod + mBetweenScanPeriod;
-        long normalizedBetweenScanPeriod = mBetweenScanPeriod-(System.currentTimeMillis() % fullScanCycle);
+        long normalizedBetweenScanPeriod = mBetweenScanPeriod-(SystemClock.elapsedRealtime() % fullScanCycle);
         LogManager.d(TAG, "Normalizing between scan period from %s to %s", mBetweenScanPeriod,
                 normalizedBetweenScanPeriod);
 

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
@@ -4,11 +4,10 @@ import android.annotation.TargetApi;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
+import android.os.SystemClock;
 
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.bluetooth.BluetoothCrashResolver;
-
-import java.util.Date;
 
 @TargetApi(18)
 public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
@@ -34,7 +33,7 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
 
     @Override
     protected boolean deferScanIfNeeded() {
-        long millisecondsUntilStart = mNextScanCycleStartTime - (new Date().getTime());
+        long millisecondsUntilStart = mNextScanCycleStartTime - SystemClock.elapsedRealtime();
         if (millisecondsUntilStart > 0) {
             LogManager.d(TAG, "Waiting to start next Bluetooth scan for another %s milliseconds",
                     millisecondsUntilStart);

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -9,6 +9,7 @@ import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
 import android.os.ParcelUuid;
+import android.os.SystemClock;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -87,18 +88,18 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
      */
     protected boolean deferScanIfNeeded() {
         // This method is called to see if it is time to start a scan
-        long millisecondsUntilStart = mNextScanCycleStartTime - System.currentTimeMillis();
+        long millisecondsUntilStart = mNextScanCycleStartTime - SystemClock.elapsedRealtime();
         if (millisecondsUntilStart > 0) {
             mMainScanCycleActive = false;
             if (true) {
-                long secsSinceLastDetection = System.currentTimeMillis() -
+                long secsSinceLastDetection = SystemClock.elapsedRealtime() -
                         DetectionTracker.getInstance().getLastDetectionTime();
                 // If we have seen a device recently
                 // devices should behave like pre-Android L devices, because we don't want to drain battery
                 // by continuously delivering packets for beacons visible in the background
                 if (mScanDeferredBefore == false) {
                     if (secsSinceLastDetection > BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
-                        mBackgroundLScanStartTime = System.currentTimeMillis();
+                        mBackgroundLScanStartTime = SystemClock.elapsedRealtime();
                         mBackgroundLScanFirstDetectionTime = 0l;
                         LogManager.d(TAG, "This is Android L. Doing a filtered scan for the background.");
 
@@ -119,7 +120,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                         if (mBackgroundLScanFirstDetectionTime == 0l) {
                             mBackgroundLScanFirstDetectionTime = DetectionTracker.getInstance().getLastDetectionTime();
                         }
-                        if (System.currentTimeMillis() - mBackgroundLScanFirstDetectionTime
+                        if (SystemClock.elapsedRealtime() - mBackgroundLScanFirstDetectionTime
                                 >= BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
                             // if we are in here, it has been more than 10 seconds since we detected
                             // a beacon in background L scanning mode.  We need to stop scanning

--- a/src/main/java/org/altbeacon/bluetooth/BluetoothCrashResolver.java
+++ b/src/main/java/org/altbeacon/bluetooth/BluetoothCrashResolver.java
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.SystemClock;
 
 import org.altbeacon.beacon.logging.LogManager;
 
@@ -16,7 +17,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -210,7 +210,7 @@ public class BluetoothCrashResolver {
             LogManager.d(TAG, "Distinct Bluetooth devices seen at crash: %s",
                     distinctBluetoothAddresses.size());
         }
-        long nowTimestamp = new Date().getTime();
+        long nowTimestamp = SystemClock.elapsedRealtime();
         lastBluetoothCrashDetectionTime = nowTimestamp;
         detectedCrashCount++;
 
@@ -267,7 +267,7 @@ public class BluetoothCrashResolver {
         if (updateNotifier != null) {
             updateNotifier.dataUpdated();
         }
-        if (System.currentTimeMillis() - lastStateSaveTime > MIN_TIME_BETWEEN_STATE_SAVES_MILLIS) {
+        if (SystemClock.elapsedRealtime() - lastStateSaveTime > MIN_TIME_BETWEEN_STATE_SAVES_MILLIS) {
             saveState();
         }
     }
@@ -345,7 +345,7 @@ public class BluetoothCrashResolver {
                         break;
                     case BluetoothAdapter.STATE_OFF:
                         LogManager.d(TAG, "Bluetooth state is OFF");
-                        lastBluetoothOffTime = System.currentTimeMillis();
+                        lastBluetoothOffTime = SystemClock.elapsedRealtime();
                         break;
                     case BluetoothAdapter.STATE_TURNING_OFF:
                         break;
@@ -357,7 +357,7 @@ public class BluetoothCrashResolver {
                         }
                         break;
                     case BluetoothAdapter.STATE_TURNING_ON:
-                        lastBluetoothTurningOnTime = new Date().getTime();
+                        lastBluetoothTurningOnTime = SystemClock.elapsedRealtime();
                         LogManager.d(TAG, "Bluetooth state is TURNING_ON");
                         break;
                 }
@@ -369,7 +369,7 @@ public class BluetoothCrashResolver {
     private void saveState() {
         FileOutputStream outputStream;
         OutputStreamWriter writer = null;
-        lastStateSaveTime = new Date().getTime();
+        lastStateSaveTime = SystemClock.elapsedRealtime();
 
         try {
             outputStream = context.openFileOutput(DISTINCT_BLUETOOTH_ADDRESSES_FILE, Context.MODE_PRIVATE);


### PR DESCRIPTION
See issue #335

I branched this off the 2.7.1 tag as the current master does not detect beacons on my device.

Besides using `ELAPSED_REALTIME_WAKEUP` alarms, use `SystemClock.elapsedRealTime()`  whenever checking periodic intervals, to be resilient against clock shifts.