### PR TITLE
Beacon service multiple bind

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -603,31 +603,6 @@ public class BeaconManager {
         return packageName;
     }
 
-    private ServiceConnection beaconServiceConnection = new ServiceConnection() {
-        // Called when the connection with the service is established
-        public void onServiceConnected(ComponentName className, IBinder service) {
-            LogManager.d(TAG, "we have a connection to the service now");
-            serviceMessenger = new Messenger(service);
-            synchronized(consumers) {
-                Iterator<Map.Entry<BeaconConsumer, ConsumerInfo>> iter = consumers.entrySet().iterator();
-                while (iter.hasNext()) {
-                    Map.Entry<BeaconConsumer, ConsumerInfo> entry = iter.next();
-
-                    if (!entry.getValue().isConnected) {
-                        entry.getKey().onBeaconServiceConnect();
-                        entry.getValue().isConnected = true;
-                    }
-                }
-            }
-        }
-
-        // Called when the connection with the service disconnects
-        public void onServiceDisconnected(ComponentName className) {
-            LogManager.e(TAG, "onServiceDisconnected");
-            serviceMessenger = null;
-        }
-    };
-
     /**
      * @return monitorNotifier
      * @see #monitorNotifier

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -297,14 +297,15 @@ public class BeaconManager {
             return;
         }
         synchronized (consumers) {
-            ConsumerInfo consumerInfo = consumers.putIfAbsent(consumer, new ConsumerInfo());
-            if (consumerInfo != null) {
+            ConsumerInfo newConsumerInfo = new ConsumerInfo();
+            ConsumerInfo alreadyBoundConsumerInfo = consumers.putIfAbsent(consumer, newConsumerInfo);
+            if (alreadyBoundConsumerInfo != null) {
                 LogManager.d(TAG, "This consumer is already bound");
             }
             else {
                 LogManager.d(TAG, "This consumer is not bound.  binding: %s", consumer);
                 Intent intent = new Intent(consumer.getApplicationContext(), BeaconService.class);
-                consumer.bindService(intent, beaconServiceConnection, Context.BIND_AUTO_CREATE);
+                consumer.bindService(intent, newConsumerInfo.beaconServiceConnection, Context.BIND_AUTO_CREATE);
                 LogManager.d(TAG, "consumer count is now: %s", consumers.size());
             }
         }
@@ -324,7 +325,7 @@ public class BeaconManager {
         synchronized (consumers) {
             if (consumers.containsKey(consumer)) {
                 LogManager.d(TAG, "Unbinding");
-                consumer.unbindService(beaconServiceConnection);
+                consumer.unbindService(consumers.get(consumer).beaconServiceConnection);
                 consumers.remove(consumer);
                 if (consumers.size() == 0) {
                     // If this is the last consumer to disconnect, the service will exit
@@ -756,10 +757,6 @@ public class BeaconManager {
         mNonBeaconLeScanCallback = callback;
     }
 
-    private class ConsumerInfo {
-        public boolean isConnected = false;
-    }
-
     private long getScanPeriod() {
         if (mBackgroundMode) {
             return backgroundScanPeriod;
@@ -787,6 +784,43 @@ public class BeaconManager {
         }
     }
 
+    private class ConsumerInfo {
+        public boolean isConnected = false;
+        public BeaconServiceConnection beaconServiceConnection;
+
+        public ConsumerInfo() {
+            this.isConnected = false;
+            this.beaconServiceConnection= new BeaconServiceConnection();
+        }
+    }
+
+    private class BeaconServiceConnection implements ServiceConnection {
+        private BeaconServiceConnection() {
+        }
+
+        // Called when the connection with the service is established
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            LogManager.d(TAG, "we have a connection to the service now");
+            serviceMessenger = new Messenger(service);
+            synchronized(consumers) {
+                Iterator<Map.Entry<BeaconConsumer, ConsumerInfo>> iter = consumers.entrySet().iterator();
+                while (iter.hasNext()) {
+                    Map.Entry<BeaconConsumer, ConsumerInfo> entry = iter.next();
+
+                    if (!entry.getValue().isConnected) {
+                        entry.getKey().onBeaconServiceConnect();
+                        entry.getValue().isConnected = true;
+                    }
+                }
+            }
+        }
+
+        // Called when the connection with the service disconnects
+        public void onServiceDisconnected(ComponentName className) {
+            LogManager.e(TAG, "onServiceDisconnected");
+            serviceMessenger = null;
+        }
+    }
 
     public class ServiceNotDeclaredException extends RuntimeException {
         public ServiceNotDeclaredException() {


### PR DESCRIPTION
This commit fixes the issue with multiple beacon service consumers binding.
Till now only one cunsumer could be bound due to the fact that only one ServiceConnection existed.
Trying to bind another consumer resulted with no onBeaconServiceConnected() callback as Android does not produce antoher onServiceConnected() callback when same ServiceConnection is used multiple times.