### PR TITLE
Adjust the BackgroundPowerSaver so it accepts any context

### DIFF
--- a/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaver.java
+++ b/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaver.java
@@ -30,17 +30,7 @@ public class BackgroundPowerSaver implements Application.ActivityLifecycleCallba
      *
      */
     public BackgroundPowerSaver(Context context, boolean countActiveActivityStrategy) {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "BackgroundPowerSaver requires API 18 or higher.");
-            return;
-        }
-        if (context instanceof Application) {
-            ((Application)context).registerActivityLifecycleCallbacks(this);
-        }
-        else {
-            LogManager.e(TAG, "Context is not an application instance, so we cannot use the BackgroundPowerSaver");
-        }
-        beaconManager = BeaconManager.getInstanceForApplication(context);
+        this(context);
     }
 
     /**
@@ -50,7 +40,12 @@ public class BackgroundPowerSaver implements Application.ActivityLifecycleCallba
      * @param context
      */
     public BackgroundPowerSaver(Context context) {
-        this(context, false);
+        if (android.os.Build.VERSION.SDK_INT < 18) {
+            LogManager.w(TAG, "BackgroundPowerSaver requires API 18 or higher.");
+            return;
+        }
+        ((Application)context.getApplicationContext()).registerActivityLifecycleCallbacks(this);
+        beaconManager = BeaconManager.getInstanceForApplication(context);
     }
 
     @Override


### PR DESCRIPTION
A more logical way to use the BackgroundPowerSaver would be to register it yourself.
Assuming `app` is an instance of Application, you can do

`app.registerActivityLifecycleCallbacks(new BackgroundPowerSaver(context));`

As this class is right now, you can already do this.
However, this would mean you register the object twice, which might cause some implications.
I haven't tested what it might do, but registering it twice can't be good.

Also, I'm unsure why you required API 18 for this class, since `Application.registerActivityLifecycleCallbacks` is available since API 14.

This would also make it possible to pass any `Context` in the constructor and still be able to use it.

### NOTE
This is a non-obvious breaking change, since no errors will be thrown if a user updates the library and this change is applied.