### PR TITLE
Don't check for location permission on SDK < 23 before scan start 

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -186,7 +186,7 @@ public abstract class CycledLeScanner {
                                         LogManager.d(TAG, "starting a new bluetooth le scan");
                                     }
                                     try {
-                                        if (checkLocationPermission()) {
+                                        if (android.os.Build.VERSION.SDK_INT < 23 || checkLocationPermission()) {
                                             startScan();
                                         }
                                     } catch (Exception e) {


### PR DESCRIPTION
This fixes a bug reported in  #363 where scanning would not start on Android 4.x devices if they did not have the ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION in the AndroidManifest.xml.  The library's AndroidManifest.xml only conditionally includes ACCESS_COARSE_PERMISSION if on SDK 23+.

