### PR TITLE
Fix BeaconParser bug: Unable to parse Long data type correctly

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -507,7 +507,7 @@ public class BeaconParser {
                     }
                     else {
                         String dataString = byteArrayToFormattedString(bytesToProcess, mDataStartOffsets.get(i) + startByte, endIndex, mDataLittleEndianFlags.get(i));
-                        dataFields.add(Long.parseLong(dataString));
+                        dataFields.add(Long.decode(dataString));
                     }
                 }
 


### PR DESCRIPTION
Bug in BeaconParser:
 - Unable to parse Long data correctly when the size of data is longer than 4 bytes. 
   Cause: Incorrect usage of `Long.parseLong` on hexadecimal formatted string

Add test case
 - BeaconParserTest.testCanParseLongDataTypeOfDifferentSize()
   It tests whether data fields with various sizes can be correctly parsed or not. 

Related to #173 