### PR TITLE
Fix 143 potential context leak

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -246,7 +246,7 @@ public class BeaconManager {
     }
 
    protected BeaconManager(Context context) {
-      mContext = context;
+      mContext = context.getApplicationContext();
       if (!sManifestCheckingDisabled) {
          verifyServiceDeclaration();
       }


### PR DESCRIPTION
#143 Fix potential memory leak when passing an `Activity` to `BeaconManager.getInstanceForApplication(Context context)` , because the `BeaconManager` would keep a reference to that `Context`.

The fix ensures that `BeaconManager` always keeps a reference to the application `Context`.

