### PR TITLE
Fix Eddystone transmissions to meet spec

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
@@ -179,15 +179,17 @@ public class BeaconTransmitter {
                         (byte) ((serviceUuid >> 8) & 0xff)};
                 ParcelUuid parcelUuid = parseUuidFrom(serviceUuidBytes);
                 dataBuilder.addServiceData(parcelUuid, advertisingBytes);
-            }
-            else {
+                dataBuilder.addServiceUuid(parcelUuid);
+                dataBuilder.setIncludeTxPowerLevel(false);
+                dataBuilder.setIncludeDeviceName(false);
+
+            } else {
                 dataBuilder.addManufacturerData(manufacturerCode, advertisingBytes);
             }
 
             AdvertiseSettings.Builder settingsBuilder = new AdvertiseSettings.Builder();
 
             settingsBuilder.setAdvertiseMode(mAdvertiseMode);
-
             settingsBuilder.setTxPowerLevel(mAdvertiseTxPowerLevel);
             settingsBuilder.setConnectable(false);
 


### PR DESCRIPTION
Users reported that Google's BeaconTools for Android and Google Chrome for Android could not detect Eddystone-URL frames sent by this library.  This turned out to be true, because the transmission did not include the Service UUID in a separate PDU from the Service data.  This change corrects that.

Prior to this change BeaconTools and Chrome for iOS detected Eddystone transmissions from this library just fine.  Android versions of these apps, however, did not.
