### PR TITLE
Region state persistence improvements

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -551,7 +551,7 @@ public class BeaconManager {
         MonitoringStatus status = MonitoringStatus.getInstanceForApplication(mContext);
         RegionMonitoringState stateObj = status.stateOf(region);
         int state = MonitorNotifier.OUTSIDE;
-        if (stateObj.isInside()) {
+        if (stateObj != null && stateObj.isInside()) {
             state = MonitorNotifier.INSIDE;
         }
         synchronized (monitorNotifiers) {

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -542,6 +542,24 @@ public class BeaconManager {
     }
 
     /**
+     * Turns off saving the state of monitored regions to persistent storage so it is retained
+     * over app restarts.  Defaults to enabled.  When enabled, there will not be an "extra" region
+     * entry event when the app starts up and a beacon for a monitored region was previously visible
+     * within the past 15 minutes.  Note that there is a limit to 50 monitored regions that may be
+     * perisisted.  If more than 50 regions are monitored, state is not persisted for any.
+     *
+     * @param enabled
+     */
+    public void setRegionStatePeristenceEnabled(boolean enabled) {
+        if (enabled) {
+            MonitoringStatus.getInstanceForApplication(mContext).startStatusPreservation();
+        }
+        else {
+            MonitoringStatus.getInstanceForApplication(mContext).stopStatusPreservation();
+        }
+    }
+
+    /**
      * Requests the current in/out state on the specified region. If the region is being monitored,
      * this will cause an asynchronous callback on the `MonitorNotifier`'s `didDetermineStateForRegion`
      * method.  If it is not a monitored region, it will be ignored.
@@ -551,7 +569,7 @@ public class BeaconManager {
         MonitoringStatus status = MonitoringStatus.getInstanceForApplication(mContext);
         RegionMonitoringState stateObj = status.stateOf(region);
         int state = MonitorNotifier.OUTSIDE;
-        if (stateObj != null && stateObj.isInside()) {
+        if (stateObj != null && stateObj.getInside()) {
             state = MonitorNotifier.INSIDE;
         }
         synchronized (monitorNotifiers) {
@@ -645,6 +663,7 @@ public class BeaconManager {
         if (serviceMessenger == null) {
             throw new RemoteException("The BeaconManager is not bound to the service.  Call beaconManager.bind(BeaconConsumer consumer) and wait for a callback to onBeaconServiceConnect()");
         }
+        LogManager.d(TAG, "Starting monitoring region "+region+" with uniqueID: "+region.getUniqueId());
         Message msg = Message.obtain(null, BeaconService.MSG_START_MONITORING, 0, 0);
         StartRMData obj = new StartRMData(region, callbackPackageName(), this.getScanPeriod(), this.getBetweenScanPeriod(), this.mBackgroundMode);
         msg.obj = obj;

--- a/src/main/java/org/altbeacon/beacon/Region.java
+++ b/src/main/java/org/altbeacon/beacon/Region.java
@@ -213,6 +213,31 @@ public class Region implements Parcelable, Serializable {
         return false;
     }
 
+    public boolean hasSameIdentifiers(Region region) {
+        if (region.mIdentifiers.size() == this.mIdentifiers.size()) {
+            for (int i = 0 ; i < region.mIdentifiers.size(); i++) {
+
+                if (region.getIdentifier(i) == null && this.getIdentifier(i) != null) {
+                    return false;
+                }
+                else if (region.getIdentifier(i) != null && this.getIdentifier(i) == null) {
+                    return false;
+                }
+                else if (!(region.getIdentifier(i) == null && this.getIdentifier(i) == null)) {
+                    if (!region.getIdentifier(i).equals(this.getIdentifier(i))) {
+                        return false;
+                    }
+                }
+            }
+        }
+        else {
+            return false;
+        }
+        return true;
+    }
+
+
+
     public String toString() {
         StringBuilder sb = new StringBuilder();
         int i = 1;

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -222,6 +222,7 @@ public class BeaconService extends Service {
         Beacon.setDistanceCalculator(defaultDistanceCalculator);
 
         monitoringStatus = MonitoringStatus.getInstanceForApplication(getApplicationContext());
+        monitoringStatus.startStatusPreservation();
         // Look for simulated scan data
         try {
             Class klass = Class.forName("org.altbeacon.beacon.SimulatedScanData");
@@ -273,7 +274,7 @@ public class BeaconService extends Service {
         LogManager.i(TAG, "onDestroy called.  stopping scanning");
         handler.removeCallbacksAndMessages(null);
         mCycledScanner.stop();
-        monitoringStatus.stopStatusPreservationOnProcessDestruction();
+        monitoringStatus.stopStatusPreservation();
     }
 
     @Override

--- a/src/main/java/org/altbeacon/beacon/service/RegionMonitoringState.java
+++ b/src/main/java/org/altbeacon/beacon/service/RegionMonitoringState.java
@@ -53,7 +53,8 @@ public class RegionMonitoringState implements Serializable {
         }
         return false;
     }
-    public boolean isNewlyOutside() { //FIXME oh my god, it changes state of object :O
+
+    public boolean markOutsideIfExpired() {
         if (inside) {
             if (lastSeenTime > 0 && SystemClock.elapsedRealtime() - lastSeenTime > BeaconManager.getRegionExitPeriod()) {
                 inside = false;
@@ -67,12 +68,8 @@ public class RegionMonitoringState implements Serializable {
         }
         return false;
     }
-    public boolean isInside() { //FIXME it also can change state through isNewlyOutside()
-        if (inside) {
-            if (!isNewlyOutside()) {
-                return true;
-            }
-        }
-        return false;
+
+    public boolean getInside() {
+        return inside;
     }
 }

--- a/src/main/java/org/altbeacon/beacon/startup/RegionBootstrap.java
+++ b/src/main/java/org/altbeacon/beacon/startup/RegionBootstrap.java
@@ -153,9 +153,9 @@ public class RegionBootstrap {
                 for (Region region : regions) {
                     LogManager.d(TAG, "Background region monitoring activated for region %s", region);
                     beaconManager.startMonitoringBeaconsInRegion(region);
-                        if (beaconManager.isBackgroundModeUninitialized()) {
-                            beaconManager.setBackgroundMode(true);
-                        }
+                    if (beaconManager.isBackgroundModeUninitialized()) {
+                        beaconManager.setBackgroundMode(true);
+                    }
                 }
             } catch (RemoteException e) {
                 LogManager.e(e, TAG, "Can't set up bootstrap regions");

--- a/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
@@ -75,7 +75,8 @@ public class MonitoringStatusTest {
             monitoringStatus.addRegion(region);
         }
         monitoringStatus.saveMonitoringStatusIfOn();
-        monitoringStatus.updateMonitoringStatusTime();
+        // Set update time to one hour ago
+        monitoringStatus.updateMonitoringStatusTime(System.currentTimeMillis() - 1000*3600l);
         MonitoringStatus monitoringStatus2 = new MonitoringStatus(context);
         assertEquals("restored regions should be none", 0, monitoringStatus2.regions().size());
     }

--- a/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
@@ -1,0 +1,83 @@
+package org.altbeacon.beacon.service;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.os.AsyncTask;
+import android.os.Build;
+
+import org.altbeacon.beacon.BeaconManager;
+import org.altbeacon.beacon.Region;
+import org.altbeacon.beacon.logging.LogManager;
+import org.altbeacon.beacon.logging.Loggers;
+import org.altbeacon.beacon.service.scanner.CycledLeScanCallback;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.util.ServiceController;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by dyoung on 7/1/16.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 18)
+public class MonitoringStatusTest {
+    @Before
+    public void before() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        LogManager.setLogger(Loggers.verboseLogger());
+        LogManager.setVerboseLoggingEnabled(true);
+        BeaconManager.setsManifestCheckingDisabled(true);
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    @Test
+    public void savesStatusOfUpTo50RegionsTest() throws Exception {
+        Context context = ShadowApplication.getInstance().getApplicationContext();
+        MonitoringStatus monitoringStatus = new MonitoringStatus(context);
+        for (int i = 0; i < 50; i++) {
+            Region region = new Region(""+i, null, null, null);
+            monitoringStatus.addRegion(region);
+        }
+        monitoringStatus.saveMonitoringStatusIfOn();
+        MonitoringStatus monitoringStatus2 = new MonitoringStatus(context);
+        assertEquals("restored regions should be same number as saved", 50, monitoringStatus2.regions().size());
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    @Test
+    public void clearsStatusOfOver50RegionsTest() throws Exception {
+        Context context = ShadowApplication.getInstance().getApplicationContext();
+        MonitoringStatus monitoringStatus = new MonitoringStatus(context);
+        for (int i = 0; i < 51; i++) {
+            Region region = new Region(""+i, null, null, null);
+            monitoringStatus.addRegion(region);
+        }
+        monitoringStatus.saveMonitoringStatusIfOn();
+        MonitoringStatus monitoringStatus2 = new MonitoringStatus(context);
+        assertEquals("restored regions should be none", 0, monitoringStatus2.regions().size());
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    @Test
+    public void refusesToRestoreRegionsIfTooMuchTimeHasPassedSinceSavingTest() throws Exception {
+        Context context = ShadowApplication.getInstance().getApplicationContext();
+        MonitoringStatus monitoringStatus = new MonitoringStatus(context);
+        for (int i = 0; i < 50; i++) {
+            Region region = new Region(""+i, null, null, null);
+            monitoringStatus.addRegion(region);
+        }
+        monitoringStatus.saveMonitoringStatusIfOn();
+        monitoringStatus.updateMonitoringStatusTime();
+        MonitoringStatus monitoringStatus2 = new MonitoringStatus(context);
+        assertEquals("restored regions should be none", 0, monitoringStatus2.regions().size());
+    }
+
+}


### PR DESCRIPTION
Improves configurability and behavior of persisted monitored region state.  This addresses a number of issues brought up by users combined into #393.

API additions and improvements:

* Adds two new methods to BeaconManager for better control of persisted regions:
  - setRegionStatePeristenceEnabled(boolean)
  - requestStateForRegion(Region)
* Adds guaranteed callback to MonitorNotifier#didDetermineStateForRegion(int state, Region region) when app starts up and region monitoring starts.  This provides the persisted region state if available.
* Sets a maximum time limit of 15 minutes where the beacon service (and the client app) is not running for the persisted region state to be used.  If the app has not been running for longer than this, the persisted state will be ignored.

Bug Fixes:

* Sets the maximum number of persisted regions to 50.  If more than 50 regions are monitored, none will be persisted.  This fixes bug #383 that caused apps to freeze persisting huge numbers of regions.
* Fixes a bug where starting monitoring for a different `Region` definition with the same `uniqueId` could not change the region definition.
