### PR TITLE
Avoid spurious entry/exit events on Android N

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,8 +49,8 @@ allprojects {
 
 android {
     compileSdkVersion 24
-//    buildToolsVersion "24"
-    buildToolsVersion "23.0.3"
+    buildToolsVersion "24"
+//    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 7

--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,8 @@ allprojects {
 }
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 24
+//    buildToolsVersion "24"
     buildToolsVersion "23.0.3"
 
     defaultConfig {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -10,6 +10,7 @@ import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.SystemClock;
 
@@ -29,6 +30,7 @@ public abstract class CycledLeScanner {
     private long mLastScanCycleEndTime = 0l;
     protected long mNextScanCycleStartTime = 0l;
     private long mScanCycleStopTime = 0l;
+    private long mLastScanStopTime = 0l;
 
     private boolean mScanning;
     protected boolean mScanningPaused;
@@ -45,6 +47,8 @@ public abstract class CycledLeScanner {
 
     protected boolean mBackgroundFlag = false;
     protected boolean mRestartNeeded = false;
+
+    private static final long ANDROID_N_MIN_SCAN_CYCLE_MILLIS = 6000l;
 
     protected CycledLeScanner(Context context, long scanPeriod, long betweenScanPeriod, boolean backgroundFlag, CycledLeScanCallback cycledLeScanCallback, BluetoothCrashResolver crashResolver) {
         mScanPeriod = scanPeriod;
@@ -248,14 +252,28 @@ public abstract class CycledLeScanner {
         if (mScanning) {
             if (getBluetoothAdapter() != null) {
                 if (getBluetoothAdapter().isEnabled()) {
-                    try {
-                        LogManager.d(TAG, "stopping bluetooth le scan");
-
-                        finishScan();
-
-                    } catch (Exception e) {
-                        LogManager.w(e, TAG, "Internal Android exception scanning for beacons");
+                    long now = System.currentTimeMillis();
+                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+                            mBetweenScanPeriod+mScanPeriod < ANDROID_N_MIN_SCAN_CYCLE_MILLIS &&
+                            now-mLastScanStopTime < ANDROID_N_MIN_SCAN_CYCLE_MILLIS) {
+                        // As of Android N, only 5 scans may be started in a 30 second period (6
+                        // seconds per cycle)  otherwise they are blocked.  So we check here to see
+                        // if the scan period is 6 seconds or less, and if we last stopped scanning
+                        // fewer than 6 seconds ag and if so, we simply do not stop scanning
+                        LogManager.d(TAG, "Not stopping scan because this is Android N and we" +
+                                " keep scanning for a minimum of 6 seconds at a time. "+
+                                 "We will stop in "+(ANDROID_N_MIN_SCAN_CYCLE_MILLIS-(now-mLastScanStopTime))+" millisconds.");
                     }
+                    else {
+                        try {
+                            LogManager.d(TAG, "stopping bluetooth le scan");
+                            finishScan();
+                            mLastScanStopTime = now;
+                        } catch (Exception e) {
+                            LogManager.w(e, TAG, "Internal Android exception scanning for beacons");
+                        }
+                    }
+
                     mLastScanCycleEndTime = SystemClock.elapsedRealtime();
                 } else {
                     LogManager.d(TAG, "Bluetooth is disabled.  Cannot scan for beacons.");

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -8,6 +8,7 @@ import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
+import android.os.Build;
 import android.os.ParcelUuid;
 import android.os.SystemClock;
 


### PR DESCRIPTION
This change limit restarting scans on Android N to once every 6 seconds to comply with the OS-imposed limit of 5 BLE scans every 30 seconds per app.  Without this change, scans at default rates are blocked for 24.5 out of every 30 seconds causing spurious exits and entry events.

Addresses #418
