### PR TITLE
Provide proguard rules for library users.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ android {
         versionCode 1
         versionName version
         testInstrumentationRunner "com.google.android.apps.common.testing.testrunner.GoogleInstrumentationTestRunner"
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     compileOptions {

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,6 @@
+# These proguard rules will be used in apps that use obfuscation automatically.
+
+#AltBeacon
+-dontwarn org.altbeacon.**
+-keep class org.altbeacon.** { *; }
+-keep interface org.altbeacon.** { *; }


### PR DESCRIPTION
By providing the proguard rules, apps that use AltBeacon no longer have to include the proguard rules themselves.