### PR TITLE
MonitoringState preservation improvement

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
+++ b/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
@@ -219,6 +219,18 @@ public class MonitoringStatus {
             for (Region region : obj.keySet()) {
                 LogManager.d(TAG, "Region  "+region+" uniqueId: "+region.getUniqueId()+" state: "+obj.get(region));
             }
+
+            // RegionMonitoringState objects only get serialized to the status preservation file when they are first inside,
+            // therefore, their {@link RegionMonitoringState#lastSeenTime will be when they were first "inside".
+            // Mark all beacons that were inside again so they don't trigger as a new exit - enter.
+            for (RegionMonitoringState regionMonitoringState : obj.values())
+            {
+                if (regionMonitoringState.getInside())
+                {
+                    regionMonitoringState.markInside();
+                }
+            }
+
             mRegionsStatesMap.putAll(obj);
 
         } catch (IOException | ClassNotFoundException | ClassCastException e) {


### PR DESCRIPTION
After a MonitoringStatus restore, beacons that were inside, have their initial lastSeenTime and may trigger quickly as exit - enter. Mark all that are inside again.