### PR TITLE
Start and stop BLE scans from a background thread to prevent blocking the UI (issue #136)

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -273,6 +273,7 @@ public class BeaconService extends Service {
         LogManager.i(TAG, "onDestroy called.  stopping scanning");
         handler.removeCallbacksAndMessages(null);
         mCycledScanner.stop();
+        mCycledScanner.destroy();
         monitoringStatus.stopStatusPreservation();
     }
 


### PR DESCRIPTION
This pull request fixes the problems reported in issue #136 where ANRs are caused by AltBeacon accessing the BluetoothAdapter (which has heavy internal synchronization and even explicit wait() calls) from the main thread.
A HandlerThread is used for the purpose, and no internal state is accessed from within the posted runnables so that it's not necessary to make the CycledLeScanner classes thread safe. In the same way, callbacks from the BluetoothAdapter are already always executed from the main thread (they're called, internally, from a Handler created with the main looper).