### PR TITLE
Avoid Qark flagging vulnerabilities by creating explicit intents

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -290,8 +290,7 @@ public class BeaconService extends Service {
     }
 
     private PendingIntent getRestartIntent() {
-        Intent restartIntent = new Intent();
-        restartIntent.setClassName(getApplicationContext(), StartupBroadcastReceiver.class.getName());
+        Intent restartIntent = new Intent(getApplicationContext(), StartupBroadcastReceiver.class);
         return getBroadcast(getApplicationContext(), 1, restartIntent, FLAG_ONE_SHOT);
     }
 

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -326,9 +326,7 @@ public abstract class CycledLeScanner {
 
     protected PendingIntent getWakeUpOperation() {
         if (mWakeUpOperation == null) {
-            Intent wakeupIntent = new Intent();
-            //intent.setFlags(Intent.FLAG_UPDATE_CURRENT);
-            wakeupIntent.setClassName(mContext, StartupBroadcastReceiver.class.getName());
+            Intent wakeupIntent = new Intent(mContext, StartupBroadcastReceiver.class);
             wakeupIntent.putExtra("wakeup", true);
             mWakeUpOperation = PendingIntent.getBroadcast(mContext, 0, wakeupIntent, PendingIntent.FLAG_UPDATE_CURRENT);
         }


### PR DESCRIPTION
As reported in #434, I ran Qark against the reference app, and verified that it flags *both* BeaconService and *CycledLEScanner* with the code as-is:

```
POTENTIAL VULNERABILITY - Implicit Intent: localIntent used to create instance of PendingIntent. A malicious application could potentially intercept, redirect and/or modify (in a limited manner) this Intent. Pending Intents retain the UID of your application and all related permissions, allowing another application to act as yours.  File: /Users/dyoung/workspace/android-beacon-library-reference/app/build/outputs/apk/app-debug/classes_dex2jar/org/altbeacon/beacon/service/BeaconService.java More details: https://www.securecoding.cert.org/confluence/display/android/DRD21-J.+Always+pass+explicit+intents+to+a+PendingIntent

POTENTIAL VULNERABILITY - Implicit Intent: localIntent used to create instance of PendingIntent. A malicious application could potentially intercept, redirect and/or modify (in a limited manner) this Intent. Pending Intents retain the UID of your application and all related permissions, allowing another application to act as yours.  File: /Users/dyoung/workspace/android-beacon-library-reference/app/build/outputs/apk/app-debug/classes_dex2jar/org/altbeacon/beacon/service/scanner/CycledLeScanner.java More details: https://www.securecoding.cert.org/confluence/display/android/DRD21-J.+Always+pass+explicit+intents+to+a+PendingIntent
```

Making the changes in this PR, then re-running Qark no longer flags the vulnerabilities.

Even though this does not represent a real vulnerability, updating the code will set folks' mind at ease.