### PR TITLE
Fix crash on startup for devices without BLE 

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
@@ -49,6 +49,11 @@ public class BeaconTransmitter {
      * @param parser specifies the format of the beacon transmission
      */
     public BeaconTransmitter(Context context, BeaconParser parser) {
+        if (context.checkCallingOrSelfPermission("android.permission.BLUETOOTH_ADMIN") !=
+                PackageManager.PERMISSION_GRANTED) {
+            LogManager.e(TAG, "Application does not have BLUETOOTH_ADMIN permission");
+            return;
+        }
         mBeaconParser = parser;
         BluetoothManager bluetoothManager =
                 (BluetoothManager) context.getSystemService(Context.BLUETOOTH_SERVICE);

--- a/src/main/java/org/altbeacon/bluetooth/BluetoothCrashResolver.java
+++ b/src/main/java/org/altbeacon/bluetooth/BluetoothCrashResolver.java
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.PackageManager;
 import android.os.SystemClock;
 
 import org.altbeacon.beacon.logging.LogManager;
@@ -112,6 +113,11 @@ public class BluetoothCrashResolver {
      * so that crashes can be predicted ahead of time.
      */
     public void start() {
+        if (this.context.checkCallingOrSelfPermission("android.permission.BLUETOOTH_ADMIN") !=
+                PackageManager.PERMISSION_GRANTED) {
+            LogManager.e(TAG, "Application does not have BLUETOOTH_ADMIN permission");
+            return;
+        }
         IntentFilter filter = new IntentFilter();
         filter.addAction(BluetoothAdapter.ACTION_STATE_CHANGED);
         filter.addAction(BluetoothAdapter.ACTION_DISCOVERY_STARTED);


### PR DESCRIPTION
This is an attempt to fix crashes reported in #429, where devices without BLE crash on startup. 

This does a check to see if the BLUETOOTH_ADMIN permission is granted before trying to access the BluetoothAdapter, which is what causes the crash in the bug report.  If the permission is not granted, the subsequent operations are not performed.

I have tested that this does not break existing functionality on devices with BLE, but I have not tested that this actually prevents a crash on devices without BLE, because I have no such test device.  If anybody has such a device and can test this, please let me know.  I am reluctant to merge this change if we cannot test first that it does something beneficial.