### PR TITLE
Fix power saver crash

### DIFF
--- a/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaver.java
+++ b/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaver.java
@@ -44,8 +44,8 @@ public class BackgroundPowerSaver implements Application.ActivityLifecycleCallba
             LogManager.w(TAG, "BackgroundPowerSaver requires API 18 or higher.");
             return;
         }
-        ((Application)context.getApplicationContext()).registerActivityLifecycleCallbacks(this);
         beaconManager = BeaconManager.getInstanceForApplication(context);
+        ((Application)context.getApplicationContext()).registerActivityLifecycleCallbacks(this);
     }
 
     @Override


### PR DESCRIPTION
This is an attempt to fix crashes in the BackgroundPowerSaver reported in #469 caused by a null BeaconManager.  This change moves the construction of the BeaconManager before the registration of activity lifecycle callbacks, so if an exception is thrown creating the BeaconManager, it will not be left in a null state.

It is unclear whether this will solve the problem, so this small change is being put in a test build.