### PR TITLE
Fix stackoverflow crash when starting/stopping scanning

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -17,6 +17,7 @@ import android.os.Looper;
 import android.os.SystemClock;
 
 import org.altbeacon.beacon.BeaconManager;
+import org.altbeacon.beacon.BleNotAvailableException;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.startup.StartupBroadcastReceiver;
 import org.altbeacon.bluetooth.BluetoothCrashResolver;
@@ -167,6 +168,13 @@ public abstract class CycledLeScanner {
 
     public void destroy() {
         mScanThread.quit();
+    }
+
+    protected boolean canScan() {
+        if (!mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
+            return false;
+        }
+        return true;
     }
 
     protected abstract void stopScan();

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
@@ -20,7 +20,9 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
 
     @Override
     protected void stopScan() {
-        postStopLeScan();
+        if (canScan()) {
+            postStopLeScan();
+        }
     }
 
     @Override
@@ -48,7 +50,9 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
 
     @Override
     protected void startScan() {
-        postStartLeScan();
+        if (canScan()) {
+            postStartLeScan();
+        }
     }
 
     @Override

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -39,7 +39,9 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
 
     @Override
     protected void stopScan() {
-        postStopLeScan();
+        if (canScan()) {
+            postStopLeScan();
+        }
     }
 
     /*
@@ -155,24 +157,26 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
 
     @Override
     protected void startScan() {
-        if (!isBluetoothOn()) {
-            LogManager.d(TAG, "Not starting scan because bluetooth is off");
-            return;
-        }
-        List<ScanFilter> filters = new ArrayList<ScanFilter>();
-        ScanSettings settings;
+        if (canScan()) {
+            if (!isBluetoothOn()) {
+                LogManager.d(TAG, "Not starting scan because bluetooth is off");
+                return;
+            }
+            List<ScanFilter> filters = new ArrayList<ScanFilter>();
+            ScanSettings settings;
 
-        if (mBackgroundFlag && !mMainScanCycleActive) {
-            LogManager.d(TAG, "starting filtered scan in SCAN_MODE_LOW_POWER");
-            settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
-            filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
-                    mBeaconManager.getBeaconParsers());
-        } else {
-            LogManager.d(TAG, "starting non-filtered scan in SCAN_MODE_LOW_LATENCY");
-            settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();
-        }
+            if (mBackgroundFlag && !mMainScanCycleActive) {
+                LogManager.d(TAG, "starting filtered scan in SCAN_MODE_LOW_POWER");
+                settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
+                filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
+                        mBeaconManager.getBeaconParsers());
+            } else {
+                LogManager.d(TAG, "starting non-filtered scan in SCAN_MODE_LOW_LATENCY");
+                settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();
+            }
 
-        postStartLeScan(filters, settings);
+            postStartLeScan(filters, settings);
+        }
     }
 
     @Override


### PR DESCRIPTION
This attempts to prevent a stackoverflow crash from #472 seen in crash reports by checking first to see if Bluetooth LE is supported on the device before starting or stopping scanning.   It is unclear whether this will fix the problem, but it is being put into a PR and an ad-hoc build so the solution can be tested.

Binary release is here: https://github.com/AltBeacon/android-beacon-library/releases/tag/fix-scan-stackoverflow-crash