### PR TITLE
Format/code cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,30 @@
-#How to Contribute to the Android Beacon Library
+# How to Contribute to the Android Beacon Library
 
-This project welcomes code contributions from the community.  Proposed code changes should be submitted as a pull request on Github.  Please follow the following guidelines when submitting a [pull request](https://github.com/altbeacon/android-beacon-library/pulls).
+This project welcomes code contributions from the communityProposed code changes should be submitted as a pull request on Github. Please follow the following guidelines when submitting a [pull request](https://github.com/altbeacon/android-beacon-library/pulls).
 
-##Style
+## Style
 
 Code style should generally follow the [Android coding style](https://source.android.com/source/code-style.html)
 
-##API Changes
+## API Changes
 
-Changes generally should not break the existing API and should be backward compatible with the current release version.   If the PR does represent a breaking change, the title or description must make this clear.  Breaking changes will be held for the next major version release of the library.
+Changes generally should not break the existing API and should be backward compatible with the current release version If the PR does represent a breaking change, the title or description must make this clear. Breaking changes will be held for the next major version release of the library.
 
-##Testing
+## Testing
 
-PRs must include testing information to ensure the changes are functional and do not adversely affect other library functions.  Testing information must include one or more of the following:
+PRs must include testing information to ensure the changes are functional and do not adversely affect other library functionsTesting information must include one or more of the following:
 
-###1. Automated Robolectric tests:
+### 1. Automated Robolectric tests:
 
-Robolectric tests are required for most changes, and should be submitted along with the PR.  Exceptions include Bluetooth or Android OS-level changes that cannot be tested with Robolectric.  Examples of Robolectric tests exist in the src/test folder.
+Robolectric tests are required for most changes, and should be submitted along with the PRExceptions include Bluetooth or Android OS-level changes that cannot be tested with Robolectric. Examples of Robolectric tests exist in the src/test folder.
 
-Robolectric test updates are absolutely required if existing Robolectric tests exists for the modified code. 
+Robolectric test updates are absolutely required if existing Robolectric tests exists for the modified code.
 
 Regardless of whether Robolectric tests are added or modified, all tests must be passing on the branch of the PR when running `./gradlew test `
 
-###2. Manual tests:
+### 2. Manual tests:
 
-Changes affecting Bluetooth scanning, addressing device-specific issues often cannot be adequately tested using Robolectric since it stubs out Bluetooth and Android OS system calls.  Changes of this nature must be manually tested on a physical device.  Manual tests should be performed with the library's reference application, if possible.
+Changes affecting Bluetooth scanning, addressing device-specific issues often cannot be adequately tested using Robolectric since it stubs out Bluetooth and Android OS system callsChanges of this nature must be manually tested on a physical device. Manual tests should be performed with the library's reference application, if possible.
 
 When submitting a PR, a description of any manual testing performed should include:
 
@@ -36,10 +36,10 @@ When submitting a PR, a description of any manual testing performed should inclu
 
 * A description of the conditions witnessed that verify the code works as designed and that other functions are not broken
 
-###3. Changes that cannot be tested manually or with Robolectric
+### 3. Changes that cannot be tested manually or with Robolectric
 
-In some rare cases where changes cannot be verified manually (e.g. some intermittent issues), a description may be included of why testing cannot be performed and describing why the change is low-risk and can be verified by code review.  For such changes to be considered low-risk they typically must be very small
+In some rare cases where changes cannot be verified manually (e.g. some intermittent issues), a description may be included of why testing cannot be performed and describing why the change is low-risk and can be verified by code reviewFor such changes to be considered low-risk they typically must be very small
 
-##License
+## License
 
-Any code submitted must be the work of the author, or if third party must be covered by the same Apache 2 license as this library or the Android Open Source Project.  Once submitted, the code is covered under the terms of the license of this library.
+Any code submitted must be the work of the author, or if third party must be covered by the same Apache 2 license as this library or the Android Open Source ProjectOnce submitted, the code is covered under the terms of the license of this library.

--- a/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
@@ -23,7 +23,6 @@
  */
 package org.altbeacon.beacon;
 
-import android.annotation.TargetApi;
 import android.bluetooth.BluetoothDevice;
 import android.util.Log;
 
@@ -63,7 +62,6 @@ public class AltBeaconParser extends BeaconParser {
      * @param device The Bluetooth device that was detected
      * @return An instance of an <code>Beacon</code>
      */
-    @TargetApi(5)
     @Override
     public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
         return fromScanData(scanData, rssi, device, new AltBeacon());

--- a/src/main/java/org/altbeacon/beacon/BeaconIntentProcessor.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconIntentProcessor.java
@@ -23,7 +23,6 @@
  */
 package org.altbeacon.beacon;
 
-import android.annotation.TargetApi;
 import android.app.IntentService;
 import android.content.Intent;
 
@@ -36,7 +35,6 @@ import java.util.Set;
 /**
  * Converts internal intents to notifier callbacks
  */
-@TargetApi(3)
 public class BeaconIntentProcessor extends IntentService {
     private static final String TAG = "BeaconIntentProcessor";
 

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -105,7 +105,6 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * @author David G. Young
  * @author Andrew Reitz <andrew@andrewreitz.com>
  */
-@TargetApi(4)
 public class BeaconManager {
     private static final String TAG = "BeaconManager";
     private Context mContext;

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -455,12 +455,12 @@ public class BeaconParser {
             boolean patternFound = false;
 
             if (getServiceUuid() == null) {
-                if (byteArraysMatch(bytesToProcess, startByte + mMatchingBeaconTypeCodeStartOffset, typeCodeBytes, 0)) {
+                if (byteArraysMatch(bytesToProcess, startByte + mMatchingBeaconTypeCodeStartOffset, typeCodeBytes)) {
                     patternFound = true;
                 }
             } else {
-                if (byteArraysMatch(bytesToProcess, startByte + mServiceUuidStartOffset, serviceUuidBytes, 0) &&
-                        byteArraysMatch(bytesToProcess, startByte + mMatchingBeaconTypeCodeStartOffset, typeCodeBytes, 0)) {
+                if (byteArraysMatch(bytesToProcess, startByte + mServiceUuidStartOffset, serviceUuidBytes) &&
+                        byteArraysMatch(bytesToProcess, startByte + mMatchingBeaconTypeCodeStartOffset, typeCodeBytes)) {
                     patternFound = true;
                 }
             }
@@ -819,18 +819,19 @@ public class BeaconParser {
         return lastEndOffset+1;
     }
 
-    private boolean byteArraysMatch(byte[] array1, int offset1, byte[] array2, int offset2) {
-        int minSize = array1.length > array2.length ? array2.length : array1.length;
-        if (offset1+minSize > array1.length || offset2+minSize > array2.length) {
+    private boolean byteArraysMatch(byte[] source, int offset, byte[] expected) {
+        int length = expected.length;
+        if (source.length - offset < length) {
             return false;
         }
-        for (int i = 0; i <  minSize; i++) {
-            if (array1[i+offset1] != array2[i+offset2]) {
+        for (int i = 0; i <  length; i++) {
+            if (source[offset + i] != expected[i]) {
                 return false;
             }
         }
         return true;
     }
+
     private String byteArrayToString(byte[] bytes) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < bytes.length; i++) {

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -412,12 +412,10 @@ public class BeaconParser {
      * @param device The Bluetooth device that was detected
      * @return An instance of a <code>Beacon</code>
      */
-    @TargetApi(5)
     public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
         return fromScanData(scanData, rssi, device, new Beacon());
     }
 
-    @TargetApi(5)
     protected Beacon fromScanData(byte[] bytesToProcess, int rssi, BluetoothDevice device, Beacon beacon) {
         BleAdvertisement advert = new BleAdvertisement(bytesToProcess);
         boolean parseFailed = false;

--- a/src/main/java/org/altbeacon/beacon/distance/ModelSpecificDistanceUpdater.java
+++ b/src/main/java/org/altbeacon/beacon/distance/ModelSpecificDistanceUpdater.java
@@ -1,6 +1,5 @@
 package org.altbeacon.beacon.distance;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.os.AsyncTask;
@@ -14,7 +13,6 @@ import org.json.JSONObject;
 /**
  * Created by dyoung on 9/12/14.
  */
-@TargetApi(Build.VERSION_CODES.CUPCAKE)
 public class ModelSpecificDistanceUpdater extends AsyncTask<Void, Void, Void> {
 
     private static final String TAG = "ModelSpecificDistanceUpdater";

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -74,7 +74,6 @@ import static android.app.PendingIntent.getBroadcast;
  * @author dyoung
  */
 
-@TargetApi(5)
 public class BeaconService extends Service {
     public static final String TAG = "BeaconService";
 

--- a/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -1,6 +1,5 @@
 package org.altbeacon.beacon.startup;
 
-import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -8,7 +7,6 @@ import android.content.Intent;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.BeaconManager;
 
-@TargetApi(4)
 public class StartupBroadcastReceiver extends BroadcastReceiver
 {
     private static final String TAG = "StartupBroadcastReceiver";

--- a/src/main/java/org/altbeacon/bluetooth/BluetoothCrashResolver.java
+++ b/src/main/java/org/altbeacon/bluetooth/BluetoothCrashResolver.java
@@ -39,7 +39,6 @@ import java.util.Set;
  *
  * Created by dyoung on 3/24/14.
  */
-@TargetApi(5)
 public class BluetoothCrashResolver {
     private static final String TAG = "BluetoothCrashResolver";
     private static final boolean PREEMPTIVE_ACTION_ENABLED = true;

--- a/src/test/java/org/altbeacon/beacon/RegionTest.java
+++ b/src/test/java/org/altbeacon/beacon/RegionTest.java
@@ -135,6 +135,7 @@ public class RegionTest {
         region.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
         Region region2 = new Region(parcel);
+        parcel.recycle();
         assertEquals("Right number of identifiers after deserialization", 3, region2.mIdentifiers.size());
         assertEquals("uniqueId is same after deserialization", region.getUniqueId(), region2.getUniqueId());
         assertEquals("id1 is same after deserialization", region.getIdentifier(0), region2.getIdentifier(0));
@@ -151,6 +152,7 @@ public class RegionTest {
         region.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
         Region region2 = new Region(parcel);
+        parcel.recycle();
         assertEquals("Right number of identifiers after deserialization", 0, region2.mIdentifiers.size());
         assertEquals("ac is same after deserialization", region.getBluetoothAddress(), region2.getBluetoothAddress());
     }
@@ -158,7 +160,6 @@ public class RegionTest {
     @Test
     public void rejectsInvalidMac() {
         org.robolectric.shadows.ShadowLog.stream = System.err;
-        Parcel parcel = Parcel.obtain();
         try {
             Region region = new Region("myRegion", "this string is not a valid mac address!");
             assertTrue("IllegalArgumentException should have been thrown", false);


### PR DESCRIPTION
Quick summary:

- Minor markdown formatting update to `CONTRIBUTING.md` so headers render in Github
- Remove legacy `@TargetApi` annotations for Android APIs less than the current min: 7
- Minor lint cleanup of `Parcel3recycle` in tests
- Clarify method behavior of internal helper `BeaconParser#byteArraysMatch`

  This removes potential ambiguity with variable size arrays:

  ```java
  byte[] a1 = { 1, 0, 1, 0 };
  byte[] a2 = { 1, 0, 1 };
  byteArraysMatch(a1, 0, a2, 0);
  byteArraysMatch(a1, 2, a2, 0);
  byteArraysMatch(a2, 1, a1, 1);
  ```

  In the context of parsing BLE payloads we already know which array is the "definitive bytes". Additionally, our usage is always to compare the entire array. Leaving such ambiguity opens up the potential for incorrectly matched payloads. Issues caused by this will be costly to troubleshoot as they will likely only occur far downstream.

  Since this is not a generic utility method this chooses a more restrictive, but contextually explicit, method signature:

  ```java
  boolean byteArraysMatch(byte[] source, int offset, byte[] expected)
  ```

  The same example from before now produces:

  ```java
  byte[] a1 = { 1, 0, 1, 0 };
  byte[] a2 = { 1, 0, 1 };
  byteArraysMatch(a1, 0, a2);    // true
  byteArraysMatch(a1, 2, a2);    // false
  byteArraysMatch(a2, 1, a1);    // false
  ```
