### PR TITLE
Include support annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ android {
 
 dependencies {
     compile fileTree ( dir: 'libs', include: ['*.jar'] )
+    compile 'com.android.support:support-annotations:24.2.1'
     testCompile 'org.hamcrest:hamcrest-integration:1.3'
     testCompile 'org.hamcrest:hamcrest-core:1.3'
     testCompile 'org.hamcrest:hamcrest-library:1.3'


### PR DESCRIPTION
This allows us to start annotating fields, methods, and parameters with
helpful annotations such as `@NonNull` and `@MainThread`. Several newer
Android APIs have already started using these annotations. Using these
types of annotations helps identify potential bugs early in the
development cycle through code inspections and lint (Android Studio is
configured by default to highlight such issues inline).

While this is a `compile` dependency it should be backwards compatible
with older IDEs. This is accomplished for generated AAR and tar archives
by including the annotations in a separate file within the archive;
non-supporting IDEs will simply ignore the file.

See Also:

- https://developer.android.com/studio/write/annotations.html
- https://developer.android.com/reference/android/support/annotation/package-summary.html