### PR TITLE
Fix intermittent scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Bug Fixes:
 - Deprecate misspelled methods `removeMonitoreNotifier` and
   `setRegionStatePeristenceEnabled` in favor of correctly spelled alternatives.
   (#461, Marco Salis)
+- Fix bug causing brief scan dropouts after starting a scan after a long period
+  of inactivity (i.e. startup and background-foreground transitions) due to
+  Android N scan limits (#489, Aaron Kromer)
 
 
 ### 2.9.2 / 2016-11-22

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -32,7 +32,6 @@ public abstract class CycledLeScanner {
     private long mLastScanCycleEndTime = 0l;
     protected long mNextScanCycleStartTime = 0l;
     private long mScanCycleStopTime = 0l;
-    private long mLastScanStopTime = 0l;
 
     private boolean mScanning;
     protected boolean mScanningPaused;
@@ -274,20 +273,19 @@ public abstract class CycledLeScanner {
                         long now = SystemClock.elapsedRealtime();
                         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
                                 mBetweenScanPeriod+mScanPeriod < ANDROID_N_MIN_SCAN_CYCLE_MILLIS &&
-                                now-mLastScanStopTime < ANDROID_N_MIN_SCAN_CYCLE_MILLIS) {
+                                now-mLastScanCycleStartTime < ANDROID_N_MIN_SCAN_CYCLE_MILLIS) {
                             // As of Android N, only 5 scans may be started in a 30 second period (6
                             // seconds per cycle)  otherwise they are blocked.  So we check here to see
                             // if the scan period is 6 seconds or less, and if we last stopped scanning
                             // fewer than 6 seconds ag and if so, we simply do not stop scanning
                             LogManager.d(TAG, "Not stopping scan because this is Android N and we" +
                                     " keep scanning for a minimum of 6 seconds at a time. "+
-                                    "We will stop in "+(ANDROID_N_MIN_SCAN_CYCLE_MILLIS-(now-mLastScanStopTime))+" millisconds.");
+                                    "We will stop in "+(ANDROID_N_MIN_SCAN_CYCLE_MILLIS-(now-mLastScanCycleStartTime))+" millisconds.");
                         }
                         else {
                             try {
                                 LogManager.d(TAG, "stopping bluetooth le scan");
                                 finishScan();
-                                mLastScanStopTime = now;
                             } catch (Exception e) {
                                 LogManager.w(e, TAG, "Internal Android exception scanning for beacons");
                             }

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -271,7 +271,7 @@ public abstract class CycledLeScanner {
             if (mScanning) {
                 if (getBluetoothAdapter() != null) {
                     if (getBluetoothAdapter().isEnabled()) {
-                        long now = System.currentTimeMillis();
+                        long now = SystemClock.elapsedRealtime();
                         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
                                 mBetweenScanPeriod+mScanPeriod < ANDROID_N_MIN_SCAN_CYCLE_MILLIS &&
                                 now-mLastScanStopTime < ANDROID_N_MIN_SCAN_CYCLE_MILLIS) {


### PR DESCRIPTION
Using the prior scan end time to calculate when we can stop the current scan cycle causes an immediate scan stop under two conditions:

- this is the first scan cycle
- scanning has been stopped for longer than 6 seconds (a more generalized case of the first scan cycle)

The simple solution is to always check the scan start time. It will always be true, since only one scan can happen at a time, that the previous stop value is less than the start value. Thus the start value plus the minimum Android N scan time will always be greater than the last stop time equivalent. This guarantees that with normal continuous scan cycling there will be no more than five scans.