### PR TITLE
Try to prevent crash due to `DeadObjectException`

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/Callback.java
+++ b/src/main/java/org/altbeacon/beacon/service/Callback.java
@@ -66,13 +66,22 @@ public class Callback implements Serializable {
         if(intent == null){
             initializeIntent();
         }
+        boolean success = false;
         if (intent != null) {
             LogManager.d(TAG, "attempting callback via intent: %s", intent.getComponent());
             intent.putExtra(dataName, data);
-            context.startService(intent);
-            return true;
+            try {
+                context.startService(intent);
+                success = true;
+            } catch (Exception e) {
+                LogManager.e(
+                        TAG,
+                        "Failed attempting to start service: " + intent.getComponent().flattenToString(),
+                        e
+                );
+            }
         }
-        return false;
+        return success;
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
This catches a possible crash caused by a `DeadObjectException` which can potentially occur when processing scan data.

This comes from some old crash reports that were related to an older ABL release. This had been patched in a separate local branch to mitigate the issue. After applying it we stopped receiving the 2nd hand reports of the crashes. Unfortunately, we never received details on which devices or OS builds the original crash was happening on.

Either way this seems like a safe patch to apply without side effects.

<details>
<summary>Original Crash Stack Trace</summary>

```
Fatal Exception: java.lang.RuntimeException: Failure from system
       at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1365)
       at android.app.ContextImpl.startService(ContextImpl.java:1306)
       at android.content.ContextWrapper.startService(ContextWrapper.java:606)
       at org.altbeacon.beacon.service.Callback.call(Callback.java:60)
       at org.altbeacon.beacon.service.BeaconService.processRangeData(BeaconService.java:360)
       at org.altbeacon.beacon.service.BeaconService.access$300(BeaconService.java:69)
       at org.altbeacon.beacon.service.BeaconService$1.onCycleEnd(BeaconService.java:320)
       at org.altbeacon.beacon.service.scanner.CycledLeScanner.finishScanCycle(CycledLeScanner.java:241)
       at org.altbeacon.beacon.service.scanner.CycledLeScanner.scheduleScanCycleStop(CycledLeScanner.java:233)
       at org.altbeacon.beacon.service.scanner.CycledLeScanner$1.run(CycledLeScanner.java:229)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:158)
       at android.app.ActivityThread.main(ActivityThread.java:7225)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
Caused by android.os.DeadObjectException: Transaction failed on small parcel; remote process probably died
       at android.os.BinderProxy.transactNative(Binder.java)
       at android.os.BinderProxy.transact(Binder.java:503)
       at android.app.ActivityManagerProxy.startService(ActivityManagerNative.java:4398)
       at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1348)
       at android.app.ContextImpl.startService(ContextImpl.java:1306)
       at android.content.ContextWrapper.startService(ContextWrapper.java:606)
       at org.altbeacon.beacon.service.Callback.call(Callback.java:60)
       at org.altbeacon.beacon.service.BeaconService.processRangeData(BeaconService.java:360)
       at org.altbeacon.beacon.service.BeaconService.access$300(BeaconService.java:69)
       at org.altbeacon.beacon.service.BeaconService$1.onCycleEnd(BeaconService.java:320)
       at org.altbeacon.beacon.service.scanner.CycledLeScanner.finishScanCycle(CycledLeScanner.java:241)
       at org.altbeacon.beacon.service.scanner.CycledLeScanner.scheduleScanCycleStop(CycledLeScanner.java:233)
       at org.altbeacon.beacon.service.scanner.CycledLeScanner$1.run(CycledLeScanner.java:229)
       at android.os.Handler.handleCallback(Handler.java:739)
       at android.os.Handler.dispatchMessage(Handler.java:95)
       at android.os.Looper.loop(Looper.java:158)
       at android.app.ActivityThread.main(ActivityThread.java:7225)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1230)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1120)
```
</details>

Because this was related to an older crash and there haven't been any other reported issues with this type of call stack I wasn't going to add anything into the change log for it.