### PR TITLE
Don't restart scanning if device detects duplicate advertisements per scan 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 ### Development
 
+Enhancements:
+
+- Don't restart BLE scanning periodically if the library confrims device can detect duplicate
+  advertisements in a single scan, leading to more reliable detections with short scan cycles
+  (#456, David G. Young)
+
 Bug Fixes:
 
 - Deprecate misspelled methods `removeMonitoreNotifier` and
   `setRegionStatePeristenceEnabled` in favor of correctly spelled alternatives.
   (#461, Marco Salis)
-
 
 ### 2.9.2 / 2016-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bug Fixes:
   `setRegionStatePeristenceEnabled` in favor of correctly spelled alternatives.
   (#461, Marco Salis)
 
+
 ### 2.9.2 / 2016-11-22
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.9.1...2.9.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Enhancements:
 
 - Don't restart BLE scanning periodically if the library confrims device can detect duplicate
   advertisements in a single scan, leading to more reliable detections with short scan cycles
-  (#456, David G. Young)
+  (#491, David G. Young)
 
 Bug Fixes:
 

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -50,6 +50,7 @@ import org.altbeacon.beacon.distance.ModelSpecificDistanceCalculator;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.service.scanner.CycledLeScanCallback;
 import org.altbeacon.beacon.service.scanner.CycledLeScanner;
+import org.altbeacon.beacon.service.scanner.DistinctPacketDetector;
 import org.altbeacon.beacon.service.scanner.NonBeaconLeScanCallback;
 import org.altbeacon.beacon.startup.StartupBroadcastReceiver;
 import org.altbeacon.bluetooth.BluetoothCrashResolver;
@@ -90,7 +91,8 @@ public class BeaconService extends Service {
     private boolean mBackgroundFlag = false;
     private ExtraDataBeaconTracker mExtraDataBeaconTracker;
     private ExecutorService mExecutor;
-
+    private final DistinctPacketDetector mDistinctPacketDetector = new DistinctPacketDetector();
+    
     /*
      * The scan period is how long we wait between restarting the BLE advertisement scans
      * Each time we restart we only see the unique advertisements once (e.g. unique beacons)
@@ -359,6 +361,7 @@ public class BeaconService extends Service {
 
         @Override
         public void onCycleEnd() {
+            mDistinctPacketDetector.clearDetections();
             monitoringStatus.updateNewlyOutside();
             processRangeData();
             // If we want to use simulated scanning data, do it here.  This is used for testing in an emulator
@@ -479,6 +482,13 @@ public class BeaconService extends Service {
             }
             if (beacon != null) {
                 mDetectionTracker.recordDetection();
+                if (!mCycledScanner.getDistinctPacketsDetectedPerScan()) {
+                    if (!mDistinctPacketDetector.isPacketDistinct(scanData.device.getAddress(),
+                            scanData.scanRecord)) {
+                        LogManager.i(TAG, "Non-distinct packets detected in a single scan.  Restarting scans unecessary.");
+                        mCycledScanner.setDistinctPacketsDetectedPerScan(true);
+                    }
+                }
                 trackedBeaconsPacketCount++;
                 processBeaconFromScan(beacon);
             } else {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -20,7 +20,6 @@ import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.startup.StartupBroadcastReceiver;
 import org.altbeacon.bluetooth.BluetoothCrashResolver;
-
 import java.util.Date;
 
 @TargetApi(18)
@@ -53,6 +52,7 @@ public abstract class CycledLeScanner {
     protected boolean mBackgroundFlag = false;
     protected boolean mRestartNeeded = false;
 
+    private boolean mDistinctPacketsDetectedPerScan = false;
     private static final long ANDROID_N_MIN_SCAN_CYCLE_MILLIS = 6000l;
 
     protected CycledLeScanner(Context context, long scanPeriod, long betweenScanPeriod, boolean backgroundFlag, CycledLeScanCallback cycledLeScanCallback, BluetoothCrashResolver crashResolver) {
@@ -165,6 +165,14 @@ public abstract class CycledLeScanner {
         }
     }
 
+    public boolean getDistinctPacketsDetectedPerScan() {
+        return mDistinctPacketsDetectedPerScan;
+    }
+
+    public void setDistinctPacketsDetectedPerScan(boolean detected) {
+        mDistinctPacketsDetectedPerScan = detected;
+    }
+
     public void destroy() {
         mScanThread.quit();
     }
@@ -271,26 +279,40 @@ public abstract class CycledLeScanner {
             if (mScanning) {
                 if (getBluetoothAdapter() != null) {
                     if (getBluetoothAdapter().isEnabled()) {
-                        long now = System.currentTimeMillis();
-                        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
-                                mBetweenScanPeriod+mScanPeriod < ANDROID_N_MIN_SCAN_CYCLE_MILLIS &&
-                                now-mLastScanStopTime < ANDROID_N_MIN_SCAN_CYCLE_MILLIS) {
-                            // As of Android N, only 5 scans may be started in a 30 second period (6
-                            // seconds per cycle)  otherwise they are blocked.  So we check here to see
-                            // if the scan period is 6 seconds or less, and if we last stopped scanning
-                            // fewer than 6 seconds ag and if so, we simply do not stop scanning
-                            LogManager.d(TAG, "Not stopping scan because this is Android N and we" +
-                                    " keep scanning for a minimum of 6 seconds at a time. "+
-                                    "We will stop in "+(ANDROID_N_MIN_SCAN_CYCLE_MILLIS-(now-mLastScanStopTime))+" millisconds.");
+                        // Determine if we need to restart scanning.  Restarting scanning is only
+                        // needed on devices incapable of detecting multiple distinct BLE advertising
+                        // packets in a single cycle, typically older Android devices (e.g. Nexus 4)
+                        // On such devices, it is necessary to stop scanning and restart to detect
+                        // multiple beacon packets in the same scan, allowing collection of multiple
+                        // rssi measurements.  Restarting however, causes brief detection dropouts
+                        // so it is best avoided.  If we know the device has detected to distinct
+                        // packets in the same cycle, we will not restart scanning and just keep it
+                        // going.
+                        if (!getDistinctPacketsDetectedPerScan()) {
+                            long now = System.currentTimeMillis();
+                            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+                                    mBetweenScanPeriod+mScanPeriod < ANDROID_N_MIN_SCAN_CYCLE_MILLIS &&
+                                    now-mLastScanStopTime < ANDROID_N_MIN_SCAN_CYCLE_MILLIS) {
+                                // As of Android N, only 5 scans may be started in a 30 second period (6
+                                // seconds per cycle)  otherwise they are blocked.  So we check here to see
+                                // if the scan period is 6 seconds or less, and if we last stopped scanning
+                                // fewer than 6 seconds ag and if so, we simply do not stop scanning
+                                LogManager.d(TAG, "Not stopping scan because this is Android N and we" +
+                                        " keep scanning for a minimum of 6 seconds at a time. "+
+                                        "We will stop in "+(ANDROID_N_MIN_SCAN_CYCLE_MILLIS-(now-mLastScanStopTime))+" millisconds.");
+                            }
+                            else {
+                                try {
+                                    LogManager.d(TAG, "stopping bluetooth le scan");
+                                    finishScan();
+                                    mLastScanStopTime = now;
+                                } catch (Exception e) {
+                                    LogManager.w(e, TAG, "Internal Android exception scanning for beacons");
+                                }
+                            }
                         }
                         else {
-                            try {
-                                LogManager.d(TAG, "stopping bluetooth le scan");
-                                finishScan();
-                                mLastScanStopTime = now;
-                            } catch (Exception e) {
-                                LogManager.w(e, TAG, "Internal Android exception scanning for beacons");
-                            }
+                            LogManager.d(TAG, "Not stopping scanning.  Device capable of multiple indistinct detections per scan.");
                         }
 
                         mLastScanCycleEndTime = SystemClock.elapsedRealtime();

--- a/src/main/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetector.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetector.java
@@ -1,0 +1,43 @@
+package org.altbeacon.beacon.service.scanner;
+
+import android.util.Log;
+
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by dyoung on 4/8/17.
+ *
+ * This class tracks whether multiple distinct BLE packets have been seen, with the purpose of
+ * determining if the Android device supports detecting multiple distinct packets in a single scan.
+ * Some older devices are not capable of this (e.g. Nexus 4, Moto G1), so detecting multiple packets
+ * requires stopping and restarting scanning on these devices.  This allows detecting if that is
+ * neessary
+ */
+public class DistinctPacketDetector {
+    // Sanity limit for the number of packets to track, so we don't use too much memory
+    private static final int MAX_PACKETS_TO_TRACK = 1000;
+    protected Set<ByteBuffer> mDistinctPacketsDetected = new HashSet<ByteBuffer>();
+
+    public void clearDetections() {
+        mDistinctPacketsDetected.clear();
+    }
+
+    public boolean isPacketDistinct(String originMacAddress, byte[] scanRecord) {
+        byte[] macBytes = originMacAddress.getBytes();
+        ByteBuffer buffer = ByteBuffer.allocate(macBytes.length+scanRecord.length);
+        buffer.put(macBytes);
+        buffer.put(scanRecord);
+        buffer.rewind(); // rewind puts position back to beginning so .equals and .hashCode work
+
+        boolean distinct = !mDistinctPacketsDetected.contains(buffer);
+        if (mDistinctPacketsDetected.size() == MAX_PACKETS_TO_TRACK) {
+            return mDistinctPacketsDetected.contains(buffer);
+        }
+        else {
+            return mDistinctPacketsDetected.add(buffer);
+        }
+    }
+
+}

--- a/src/test/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetectorTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetectorTest.java
@@ -1,0 +1,57 @@
+package org.altbeacon.beacon.service.scanner;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Config(sdk = 18)
+
+@RunWith(RobolectricTestRunner.class)
+public class DistinctPacketDetectorTest {
+    @BeforeClass
+    public static void testSetup() {
+    }
+
+    @AfterClass
+    public static void testCleanup() {
+
+    }
+
+    @Test
+    public void testSecondDuplicatePacketIsNotDistinct() throws Exception {
+        DistinctPacketDetector dpd = new DistinctPacketDetector();
+        dpd.isPacketDistinct("01:02:03:04:05:06", new byte[] {0x01, 0x02});
+        boolean secondResult = dpd.isPacketDistinct("01:02:03:04:05:06", new byte[] {0x01, 0x02});
+        assertFalse("second call with same packet should not be distinct", secondResult);
+    }
+
+    @Test
+    public void testSecondNonDuplicatePacketIsDistinct() throws Exception {
+        DistinctPacketDetector dpd = new DistinctPacketDetector();
+        dpd.isPacketDistinct("01:02:03:04:05:06", new byte[] {0x01, 0x02});
+        boolean secondResult = dpd.isPacketDistinct("01:02:03:04:05:06", new byte[] {0x03, 0x04});
+        assertTrue("second call with different packet should be distinct", secondResult);
+    }
+
+    @Test
+    public void testSamePacketForDifferentMacIsDistinct() throws Exception {
+        DistinctPacketDetector dpd = new DistinctPacketDetector();
+        dpd.isPacketDistinct("01:02:03:04:05:06", new byte[] {0x01, 0x02});
+        boolean secondResult = dpd.isPacketDistinct("01:01:01:01:01:01", new byte[] {0x01, 0x02});
+        assertTrue("second packet with different mac should be distinct", secondResult);
+    }
+
+    @Test
+    public void clearingDetectionsPreventsDistinctDetection() throws Exception {
+        DistinctPacketDetector dpd = new DistinctPacketDetector();
+        dpd.isPacketDistinct("01:02:03:04:05:06", new byte[] {0x01, 0x02});
+        dpd.clearDetections();
+        boolean secondResult = dpd.isPacketDistinct("01:02:03:04:05:06", new byte[] {0x01, 0x02});
+        assertTrue("second call with same packet after clear should be distinct", secondResult);
+    }
+
+}


### PR DESCRIPTION
**Background:** 

Restarting scanning (stopping and immediately restarting) is necessary on many older Android devices like the Nexus 4 and Moto G because once they detect a distinct BLE packet in a scan, subsequent detections do not get a scan callback.  Stopping scanning and restarting clears this out, allowing subsequent detection of identical advertisements.

On most newer devices, however, this is not necessary, and multiple callbacks are given for identical packets detected in a single scan.   Because the library has no simple way of knowing whether the device can detect duplicate advertisements per scan, scanning is restarted regardless.

**Change**

This adds a detection of duplicate identical advertisements in a single scan.   If duplicates are ever detected, scans are no longer restarted.

**Benefits**

The primary benefit of this change is that **there will no longer be brief dropouts in detections when scans are stopped and restarted**, causing advertisement packets and detections to be missed as described in #473.  This change will allow **much shorter scan intervals while keeping detections reliable**.  A secondary benefit may be some power savings with some bluetooth chipsets, although this savings has not been confirmed or characterized.

**Typical Impact on New Devices**

The flag indicating whether or not a device supports multiple detections per scan is not persisted, so it is effectively cleared on restart.  On devices supporting multiple detections per scan, restarting scanning will still happen.  For default library settings and beacons transmitting at 10 Hz, this determination will happen within a second or two, causing restarts to quickly cease.  

**Typical Impact on Old Devices**

Older devices not supporting multiple detections per scan will see no change, aside from some extra processing done to track distinct packets in each scan cycle.   This extra processing is worth the tradeoff, especially as the number of such devices shrinks.

Text on Android 7.0 with beacon turned on at  04-08 14:43

```
$ adb logcat | grep stopping

04-08 14:42:55.881 16746 16746 D CycledLeScanner: stopping bluetooth le scan
04-08 14:42:56.999 16746 16746 D CycledLeScanner: Not stopping scan because this is Android N and we keep scanning for a minimum of 6 seconds at a time. We will stop in 4882 millisconds.
04-08 14:42:58.102 16746 16746 D CycledLeScanner: Not stopping scan because this is Android N and we keep scanning for a minimum of 6 seconds at a time. We will stop in 3779 millisconds.
04-08 14:42:59.206 16746 16746 D CycledLeScanner: Not stopping scan because this is Android N and we keep scanning for a minimum of 6 seconds at a time. We will stop in 2675 millisconds.
04-08 14:43:00.313 16746 16746 D CycledLeScanner: Not stopping scan because this is Android N and we keep scanning for a minimum of 6 seconds at a time. We will stop in 1569 millisconds.
04-08 14:43:01.471 16746 16746 D CycledLeScanner: Not stopping scan because this is Android N and we keep scanning for a minimum of 6 seconds at a time. We will stop in 410 millisconds.
04-08 14:43:02.472 16746 16746 D CycledLeScanner: Not stopping scanning.  Device capable of multiple indistinct detections per scan.
04-08 14:43:03.585 16746 16746 D CycledLeScanner: Not stopping scanning.  Device capable of multiple indistinct detections per scan.
```