### PR TITLE
Don't start scanning service if BLE unsupported

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -296,6 +296,10 @@ public class BeaconManager {
             LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
             return;
         }
+        if (!mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
+            LogManager.w(TAG, "This device does not support bluetooth LE.  Will not start beacon scanning.");
+            return;
+        }
         synchronized (consumers) {
             ConsumerInfo newConsumerInfo = new ConsumerInfo();
             ConsumerInfo alreadyBoundConsumerInfo = consumers.putIfAbsent(consumer, newConsumerInfo);

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -271,17 +271,10 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public boolean checkAvailability() throws BleNotAvailableException {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
+        if (!isBleAvailable()) {
             throw new BleNotAvailableException("Bluetooth LE not supported by this device");
         }
-        if (!mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
-            throw new BleNotAvailableException("Bluetooth LE not supported by this device");
-        } else {
-            if (((BluetoothManager) mContext.getSystemService(Context.BLUETOOTH_SERVICE)).getAdapter().isEnabled()) {
-                return true;
-            }
-        }
-        return false;
+        return ((BluetoothManager) mContext.getSystemService(Context.BLUETOOTH_SERVICE)).getAdapter().isEnabled();
     }
 
     /**
@@ -292,8 +285,8 @@ public class BeaconManager {
      * @param consumer the <code>Activity</code> or <code>Service</code> that will receive the callback when the service is ready.
      */
     public void bind(BeaconConsumer consumer) {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
             return;
         }
         if (!mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
@@ -322,8 +315,8 @@ public class BeaconManager {
      * @param consumer the <code>Activity</code> or <code>Service</code> that no longer needs to use the service.
      */
     public void unbind(BeaconConsumer consumer) {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
             return;
         }
         synchronized (consumers) {
@@ -395,8 +388,9 @@ public class BeaconManager {
      * @see #setBackgroundBetweenScanPeriod(long p)
      */
     public void setBackgroundMode(boolean backgroundMode) {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
+            return;
         }
         mBackgroundModeUninitialized = false;
         if (backgroundMode != mBackgroundMode) {
@@ -612,8 +606,8 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void startRangingBeaconsInRegion(Region region) throws RemoteException {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
             return;
         }
         if (serviceMessenger == null) {
@@ -640,8 +634,8 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void stopRangingBeaconsInRegion(Region region) throws RemoteException {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
             return;
         }
         if (serviceMessenger == null) {
@@ -675,8 +669,8 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void startMonitoringBeaconsInRegion(Region region) throws RemoteException {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
             return;
         }
         if (serviceMessenger == null) {
@@ -703,8 +697,8 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void stopMonitoringBeaconsInRegion(Region region) throws RemoteException {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
             return;
         }
         if (serviceMessenger == null) {
@@ -725,8 +719,8 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void updateScanPeriods() throws RemoteException {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not supported prior to API 18.  Method invocation will be ignored");
+        if (!isBleAvailable()) {
+            LogManager.w(TAG, "Method invocation will be ignored.");
             return;
         }
         if (serviceMessenger == null) {
@@ -897,6 +891,18 @@ public class BeaconManager {
 
     public void setNonBeaconLeScanCallback(NonBeaconLeScanCallback callback) {
         mNonBeaconLeScanCallback = callback;
+    }
+
+    private boolean isBleAvailable() {
+        boolean available = false;
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            LogManager.w(TAG, "Bluetooth LE not supported prior to API 18.");
+        } else if (!mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
+            LogManager.w(TAG, "This device does not support bluetooth LE.");
+        } else {
+            available = true;
+        }
+        return available;
     }
 
     private long getScanPeriod() {


### PR DESCRIPTION
If BLE is unsupported on a device, there is no point in starting the scanning service.  The library has long refused to start the scanning service if on a pre-Android 18 device (which does not support BLE APIs).  So the effects of not starting the scanning service at startup under this similar condition are well known and already in the wild.

This may prevent a stackoverflow crash reported in  #472, which was believed to happen on a device with Android 4.3+ but no BLE support.

