### PR TITLE
Eliminate extra scan stop call

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -158,10 +158,8 @@ public abstract class CycledLeScanner {
         mScanningEnabled = false;
         if (mScanCyclerStarted) {
             scanLeDevice(false);
-        }
-        if (mBluetoothAdapter != null) {
-            stopScan();
-            mLastScanCycleEndTime = SystemClock.elapsedRealtime();
+        } else {
+            LogManager.d(TAG, "scanning already stopped");
         }
     }
 


### PR DESCRIPTION
In `CycledLeScanner` the bluetooth adapter is only ever set to a non-`null` value. Additionally, the call to `scanLeDevice(false)` runs it's sad path branch regardless of if the bluetooth adapter has been set. This branch includes a call to `stopScan()` and also sets the `mLastScanCycleEndTime` time.

This means that when the cycler has been running the first call to `stop()` will call `scanLeDevice(false)` from the positive branch of the `mScanCyclerStarted` check. This will stop the scan and set the time field. Then, since the bluetooth adapter will never be `null`, a second call to `stopScan()` will occur resulting in unnecessary work; work that will happen in a already stopped state - which may be unexpected.

After this, any subsequent calls to `stop()` will incorrectly reset the cycler end time (I say "incorrectly" because the cycler was not running and thus did not just end). Additionally, as in the previous case this will cause additional work to happen in the stopped state.

This change isn't noted in the changelog as I don't believe it causes any noticeable external behavior changes (there are no external callbacks or other events which are sent). This is just a simplification of logic and reduction in unnecessary CPU workload.