### PR TITLE
Minor updates

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -487,13 +487,13 @@ public class BeaconService extends Service {
             this.scanRecord = scanRecord;
         }
 
-        int rssi;
+        final int rssi;
 
         @NonNull
-        BluetoothDevice device;
+        final BluetoothDevice device;
 
         @NonNull
-        byte[] scanRecord;
+        final byte[] scanRecord;
     }
 
     private class ScanProcessor extends AsyncTask<ScanData, Void, Void> {

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -518,7 +518,7 @@ public class BeaconService extends Service {
                 if (!mCycledScanner.getDistinctPacketsDetectedPerScan()) {
                     if (!mDistinctPacketDetector.isPacketDistinct(scanData.device.getAddress(),
                             scanData.scanRecord)) {
-                        LogManager.i(TAG, "Non-distinct packets detected in a single scan.  Restarting scans unecessary.");
+                        LogManager.i(TAG, "Non-distinct packets detected in a single scan.  Restarting scans unnecessary.");
                         mCycledScanner.setDistinctPacketsDetectedPerScan(true);
                     }
                 }

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -39,6 +39,7 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.os.Message;
 import android.os.Messenger;
+import android.support.annotation.NonNull;
 
 import org.altbeacon.beacon.Beacon;
 import org.altbeacon.beacon.BeaconManager;
@@ -93,7 +94,7 @@ public class BeaconService extends Service {
     private ExtraDataBeaconTracker mExtraDataBeaconTracker;
     private ExecutorService mExecutor;
     private final DistinctPacketDetector mDistinctPacketDetector = new DistinctPacketDetector();
-    
+
     /*
      * The scan period is how long we wait between restarting the BLE advertisement scans
      * Each time we restart we only see the unique advertisements once (e.g. unique beacons)
@@ -476,15 +477,22 @@ public class BeaconService extends Service {
     }
 
 
-    private class ScanData {
-        public ScanData(BluetoothDevice device, int rssi, byte[] scanRecord) {
+    /**
+     * <strong>This class is not thread safe.</strong>
+     */
+    private static class ScanData {
+        ScanData(@NonNull BluetoothDevice device, int rssi, @NonNull byte[] scanRecord) {
             this.device = device;
             this.rssi = rssi;
             this.scanRecord = scanRecord;
         }
 
         int rssi;
+
+        @NonNull
         BluetoothDevice device;
+
+        @NonNull
         byte[] scanRecord;
     }
 
@@ -502,7 +510,7 @@ public class BeaconService extends Service {
             ScanData scanData = params[0];
             Beacon beacon = null;
 
-            for (BeaconParser parser : BeaconService.this.beaconParsers) {
+            for (BeaconParser parser : beaconParsers) {
                 beacon = parser.fromScanData(scanData.scanRecord,
                         scanData.rssi, scanData.device);
 

--- a/src/main/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetector.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetector.java
@@ -22,7 +22,7 @@ public class DistinctPacketDetector {
     private static final int MAX_PACKETS_TO_TRACK = 1000;
 
     @NonNull
-    private Set<ByteBuffer> mDistinctPacketsDetected = new HashSet<>();
+    private final Set<ByteBuffer> mDistinctPacketsDetected = new HashSet<>();
 
     public void clearDetections() {
         mDistinctPacketsDetected.clear();

--- a/src/main/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetector.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/DistinctPacketDetector.java
@@ -1,6 +1,6 @@
 package org.altbeacon.beacon.service.scanner;
 
-import android.util.Log;
+import android.support.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.util.HashSet;
@@ -8,30 +8,33 @@ import java.util.Set;
 
 /**
  * Created by dyoung on 4/8/17.
- *
+ * <p>
  * This class tracks whether multiple distinct BLE packets have been seen, with the purpose of
  * determining if the Android device supports detecting multiple distinct packets in a single scan.
  * Some older devices are not capable of this (e.g. Nexus 4, Moto G1), so detecting multiple packets
  * requires stopping and restarting scanning on these devices.  This allows detecting if that is
- * neessary
+ * necessary.
+ * <p>
+ * <strong>This class is not thread safe.</strong>
  */
 public class DistinctPacketDetector {
     // Sanity limit for the number of packets to track, so we don't use too much memory
     private static final int MAX_PACKETS_TO_TRACK = 1000;
-    protected Set<ByteBuffer> mDistinctPacketsDetected = new HashSet<ByteBuffer>();
+
+    @NonNull
+    private Set<ByteBuffer> mDistinctPacketsDetected = new HashSet<>();
 
     public void clearDetections() {
         mDistinctPacketsDetected.clear();
     }
 
-    public boolean isPacketDistinct(String originMacAddress, byte[] scanRecord) {
+    public boolean isPacketDistinct(@NonNull String originMacAddress, @NonNull byte[] scanRecord) {
         byte[] macBytes = originMacAddress.getBytes();
         ByteBuffer buffer = ByteBuffer.allocate(macBytes.length+scanRecord.length);
         buffer.put(macBytes);
         buffer.put(scanRecord);
         buffer.rewind(); // rewind puts position back to beginning so .equals and .hashCode work
 
-        boolean distinct = !mDistinctPacketsDetected.contains(buffer);
         if (mDistinctPacketsDetected.size() == MAX_PACKETS_TO_TRACK) {
             return mDistinctPacketsDetected.contains(buffer);
         }


### PR DESCRIPTION
No functionality change here. This simply cleans up some unused statements, spelling, and adds in nullability annotations. The nullability annotations help Android Studio better catch potential development time errors based on object presence assumptions.

This includes a simple comment addition about the thread safety of the classes. These classes are only used in one location currently. It's easier to manage thread safety as necessary in the encapsulating class. So this simply documents that this class isn't thread safe (i.e.  it's up to the client to ensure thread safety as necessary).