### PR TITLE
Fix failure to stop scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Enhancements:
 
 Bug Fixes:
 
-- TODO
+- Fix failure to stop scanning when unbinding from service or when the between scan period
+  is nonzero. (#507, David G. Young)
 
 ### 2.10 / 2017-04-21
 

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -157,6 +157,8 @@ public abstract class CycledLeScanner {
         mScanningEnabled = false;
         if (mScanCyclerStarted) {
             scanLeDevice(false);
+            LogManager.d(TAG, "forcing scanning to stop even for devices capable of multiple detections per cycle");
+            stopScan();
         } else {
             LogManager.d(TAG, "scanning already stopped");
         }
@@ -285,7 +287,7 @@ public abstract class CycledLeScanner {
                         // so it is best avoided.  If we know the device has detected to distinct
                         // packets in the same cycle, we will not restart scanning and just keep it
                         // going.
-                        if (!getDistinctPacketsDetectedPerScan()) {
+                        if (!getDistinctPacketsDetectedPerScan() || mBetweenScanPeriod != 0) {
                             long now = SystemClock.elapsedRealtime();
                             if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
                                     mBetweenScanPeriod+mScanPeriod < ANDROID_N_MIN_SCAN_CYCLE_MILLIS &&

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -223,6 +223,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             @Override
             public void run() {
                 try {
+                    LogManager.d(TAG, "Stopping LE scan on scan handler");
                     scanner.stopScan(scanCallback);
                 } catch (IllegalStateException e) {
                     LogManager.w(TAG, "Cannot stop scan. Bluetooth may be turned off.");


### PR DESCRIPTION
This fixes a failure to stop BLE scanning in two scenarios caused by #491:

1. When there is a nonzero between scan period.
2. When the unbind() is called on the BeaconManager to stop the BeaconService.

This was reported here:  http://stackoverflow.com/questions/43835705/how-to-properly-stop-scanning-beacon-using-android-beacon-library-altbeacon/43836157#43836157


Testing on Nexus 5X, showing logs after a call to
`BeaconReferenceApplication.this.unbindService(connection);`

Without change (note beacon packets are detected after service stops):

```
05-10 10:55:42.262 31353-31353/org.altbeacon.beaconreference E/BeaconService: onDestroy()
05-10 10:55:42.263 31353-31353/org.altbeacon.beaconreference D/BluetoothCrashResolver: stopped listening for BluetoothAdapter events
05-10 10:55:42.264 31353-31353/org.altbeacon.beaconreference D/BluetoothCrashResolver: Wrote 0 Bluetooth addresses
05-10 10:55:42.264 31353-31353/org.altbeacon.beaconreference I/BeaconService: onDestroy called.  stopping scanning
05-10 10:55:42.264 31353-31353/org.altbeacon.beaconreference D/CycledLeScanner: stop called
05-10 10:55:42.265 31353-31353/org.altbeacon.beaconreference D/CycledLeScanner: disabling scan
05-10 10:55:43.087 31353-31353/org.altbeacon.beaconreference D/CycledLeScannerForLollipop: got record
05-10 10:55:43.089 31353-32074/org.altbeacon.beaconreference D/BeaconParser: Ignoring pdu type 01
05-10 10:55:43.090 31353-32074/org.altbeacon.beaconreference D/BeaconParser: Processing pdu type FF: 02011a07ff4c0010020b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 with startIndex: 5, endIndex: 10
05-10 10:55:43.090 31353-32074/org.altbeacon.beaconreference D/BeaconParser: This is not a matching Beacon advertisement. (Was expecting 02 15.  The bytes I see are: 02011a07ff4c0010020b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```

With change (note no beacon packets are detected after service stops):

```
05-10 10:52:43.784 26067-26067/org.altbeacon.beaconreference E/BeaconService: onDestroy()
05-10 10:52:43.785 26067-26067/org.altbeacon.beaconreference D/BluetoothCrashResolver: stopped listening for BluetoothAdapter events
05-10 10:52:43.786 26067-26067/org.altbeacon.beaconreference D/BluetoothCrashResolver: Wrote 0 Bluetooth addresses
05-10 10:52:43.787 26067-26067/org.altbeacon.beaconreference I/BeaconService: onDestroy called.  stopping scanning
05-10 10:52:43.787 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: stop called
05-10 10:52:43.787 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: disabling scan
05-10 10:52:43.789 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: forcing scanning to stop even for devices capable of multiple detections per cycle
05-10 10:52:43.791 26067-26122/org.altbeacon.beaconreference D/BluetoothAdapter: STATE_ON
05-10 10:52:44.756 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: Waiting to stop scan cycle for another 98 milliseconds
05-10 10:52:44.855 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: Done with scan cycle
05-10 10:52:44.856 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: Scanning disabled.  No ranging or monitoring regions are active.
05-10 10:52:44.856 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: cancel wakeup alarm: PendingIntent{4e22e7d: android.os.BinderProxy@261172}
05-10 10:52:44.862 26067-26067/org.altbeacon.beaconreference D/CycledLeScanner: Set a wakeup alarm to go off in 9223372036722221393 ms: PendingIntent{4e22e7d: android.os.BinderProxy@261172}
```



