### PR TITLE
fix nullpointer bug

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -30,6 +30,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.os.IBinder;
 import android.os.Message;
 import android.os.Messenger;
@@ -1086,10 +1087,10 @@ public class BeaconManager {
     private void verifyServiceDeclaration() {
         final PackageManager packageManager = mContext.getPackageManager();
         final Intent intent = new Intent(mContext, BeaconService.class);
-        List resolveInfo =
+        List<ResolveInfo> resolveInfo =
                 packageManager.queryIntentServices(intent,
                         PackageManager.MATCH_DEFAULT_ONLY);
-        if (resolveInfo.size() == 0) {
+        if (resolveInfo != null && resolveInfo.size() == 0) {
             throw new ServiceNotDeclaredException();
         }
     }


### PR DESCRIPTION
`
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.util.ArraySet.size()' on a null object reference
at android.content.Intent.writeToParcel(Intent.java:8765)
at android.content.pm.IPackageManager$Stub$Proxy.queryIntentServices(IPackageManager.java:3422)
at android.app.ApplicationPackageManager.queryIntentServicesAsUser(ApplicationPackageManager.java:966)
at android.app.ApplicationPackageManager.queryIntentServices(ApplicationPackageManager.java:980)
at org.altbeacon.beacon.BeaconManager.verifyServiceDeclaration(BeaconManager.java:917)
at org.altbeacon.beacon.BeaconManager.(BeaconManager.java:252)
at org.altbeacon.beacon.BeaconManager.getInstanceForApplication(BeaconManager.java:244)
at org.altbeacon.beacon.startup.StartupBroadcastReceiver.onReceive(StartupBroadcastReceiver.java:21)
`