### PR TITLE
Scan documentation update and stop scan bug fix

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -37,8 +37,10 @@ import android.os.Binder;
 import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
+import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 
 import org.altbeacon.beacon.Beacon;
@@ -145,9 +147,16 @@ public class BeaconService extends Service {
         private final WeakReference<BeaconService> mService;
 
         IncomingHandler(BeaconService service) {
+            /*
+             * Explicitly state this uses the main thread. Without this we defer to where the
+             * service instance is initialized/created; which is usually the main thread anyways.
+             * But by being explicit we document our code design expectations for where things run.
+             */
+            super(Looper.getMainLooper());
             mService = new WeakReference<BeaconService>(service);
         }
 
+        @MainThread
         @Override
         public void handleMessage(Message msg) {
             BeaconService service = mService.get();
@@ -206,7 +215,7 @@ public class BeaconService extends Service {
      */
     final Messenger mMessenger = new Messenger(new IncomingHandler(this));
 
-
+    @MainThread
     @Override
     public void onCreate() {
         bluetoothCrashResolver = new BluetoothCrashResolver(this);
@@ -294,6 +303,7 @@ public class BeaconService extends Service {
         return false;
     }
 
+    @MainThread
     @Override
     public void onDestroy() {
         LogManager.e(TAG, "onDestroy()");
@@ -330,6 +340,7 @@ public class BeaconService extends Service {
     /**
      * methods for clients
      */
+    @MainThread
     public void startRangingBeaconsInRegion(Region region, Callback callback) {
         synchronized (rangedRegionState) {
             if (rangedRegionState.containsKey(region)) {
@@ -342,6 +353,7 @@ public class BeaconService extends Service {
         mCycledScanner.start();
     }
 
+    @MainThread
     public void stopRangingBeaconsInRegion(Region region) {
         int rangedRegionCount;
         synchronized (rangedRegionState) {
@@ -355,6 +367,7 @@ public class BeaconService extends Service {
         }
     }
 
+    @MainThread
     public void startMonitoringBeaconsInRegion(Region region, Callback callback) {
         LogManager.d(TAG, "startMonitoring called");
         monitoringStatus.addRegion(region, callback);
@@ -362,6 +375,7 @@ public class BeaconService extends Service {
         mCycledScanner.start();
     }
 
+    @MainThread
     public void stopMonitoringBeaconsInRegion(Region region) {
         LogManager.d(TAG, "stopMonitoring called");
         monitoringStatus.removeRegion(region);
@@ -371,6 +385,7 @@ public class BeaconService extends Service {
         }
     }
 
+    @MainThread
     public void setScanPeriods(long scanPeriod, long betweenScanPeriod, boolean backgroundFlag) {
         mCycledScanner.setScanPeriods(scanPeriod, betweenScanPeriod, backgroundFlag);
     }

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanCallback.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanCallback.java
@@ -1,11 +1,18 @@
 package org.altbeacon.beacon.service.scanner;
 
 import android.bluetooth.BluetoothDevice;
+import android.support.annotation.MainThread;
 
 /**
+ * Android API agnostic Bluetooth scan callback wrapper.
+ * <p>
+ * Since Android bluetooth scan callbacks occur on the main thread it is expected that these
+ * callbacks will also occur on the main thread.
+ *
  * Created by dyoung on 10/6/14.
  */
+@MainThread
 public interface CycledLeScanCallback {
-    public void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord);
-    public void onCycleEnd();
+    void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord);
+    void onCycleEnd();
 }

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -1,7 +1,6 @@
 package org.altbeacon.beacon.service.scanner;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
@@ -125,6 +124,7 @@ public abstract class CycledLeScanner {
      * between LOW_POWER_MODE vs. LOW_LATENCY_MODE
      * @param backgroundFlag
      */
+    @MainThread
     public void setScanPeriods(long scanPeriod, long betweenScanPeriod, boolean backgroundFlag) {
         LogManager.d(TAG, "Set scan periods called with %s, %s Background mode must have changed.",
                 scanPeriod, betweenScanPeriod);
@@ -165,6 +165,7 @@ public abstract class CycledLeScanner {
         }
     }
 
+    @MainThread
     public void start() {
         LogManager.d(TAG, "start called");
         mScanningEnabled = true;
@@ -175,7 +176,7 @@ public abstract class CycledLeScanner {
         }
     }
 
-    @SuppressLint("NewApi")
+    @MainThread
     public void stop() {
         LogManager.d(TAG, "stop called");
         mScanningEnabled = false;
@@ -194,6 +195,7 @@ public abstract class CycledLeScanner {
         mDistinctPacketsDetectedPerScan = detected;
     }
 
+    @MainThread
     public void destroy() {
         LogManager.d(TAG, "Destroying");
         // We cannot quit the thread used by the handler until queued Runnables have been processed,
@@ -218,7 +220,7 @@ public abstract class CycledLeScanner {
 
     protected abstract void startScan();
 
-    @SuppressLint("NewApi")
+    @MainThread
     protected void scanLeDevice(final Boolean enable) {
         try {
             mScanCyclerStarted = true;
@@ -285,6 +287,7 @@ public abstract class CycledLeScanner {
         }
     }
 
+    @MainThread
     protected void scheduleScanCycleStop() {
         // Stops scanning after a pre-defined scan period.
         long millisecondsUntilStop = mScanCycleStopTime - SystemClock.elapsedRealtime();
@@ -308,6 +311,7 @@ public abstract class CycledLeScanner {
 
     protected abstract void finishScan();
 
+    @MainThread
     private void finishScanCycle() {
         LogManager.d(TAG, "Done with scan cycle");
         try {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -230,7 +230,7 @@ public abstract class CycledLeScanner {
             if (getBluetoothAdapter() == null) {
                 LogManager.e(TAG, "No Bluetooth adapter.  beaconService cannot scan.");
             }
-            if (enable) {
+            if (mScanningEnabled && enable) {
                 if (deferScanIfNeeded()) {
                     return;
                 }
@@ -283,6 +283,9 @@ public abstract class CycledLeScanner {
                 mScanCyclerStarted = false;
                 stopScan();
                 mLastScanCycleEndTime = SystemClock.elapsedRealtime();
+                // Clear any queued schedule tasks as we're done scanning
+                mScanHandler.removeCallbacksAndMessages(null);
+                finishScanCycle();
             }
         }
         catch (SecurityException e) {
@@ -294,7 +297,7 @@ public abstract class CycledLeScanner {
     protected void scheduleScanCycleStop() {
         // Stops scanning after a pre-defined scan period.
         long millisecondsUntilStop = mScanCycleStopTime - SystemClock.elapsedRealtime();
-        if (millisecondsUntilStop > 0) {
+        if (mScanningEnabled && millisecondsUntilStop > 0) {
             LogManager.d(TAG, "Waiting to stop scan cycle for another %s milliseconds",
                     millisecondsUntilStop);
             if (mBackgroundFlag) {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
@@ -5,6 +5,8 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.os.SystemClock;
+import android.support.annotation.MainThread;
+import android.support.annotation.WorkerThread;
 
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.bluetooth.BluetoothCrashResolver;
@@ -36,6 +38,7 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
                 setWakeUpAlarm();
             }
             mHandler.postDelayed(new Runnable() {
+                @MainThread
                 @Override
                 public void run() {
                     scanLeDevice(true);
@@ -65,6 +68,7 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
         final BluetoothAdapter.LeScanCallback leScanCallback = getLeScanCallback();
         mScanHandler.removeCallbacksAndMessages(null);
         mScanHandler.post(new Runnable() {
+            @WorkerThread
             @Override
             public void run() {
                 try {
@@ -85,6 +89,7 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
         final BluetoothAdapter.LeScanCallback leScanCallback = getLeScanCallback();
         mScanHandler.removeCallbacksAndMessages(null);
         mScanHandler.post(new Runnable() {
+            @WorkerThread
             @Override
             public void run() {
                 try {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -10,6 +10,8 @@ import android.bluetooth.le.ScanSettings;
 import android.content.Context;
 import android.os.ParcelUuid;
 import android.os.SystemClock;
+import android.support.annotation.MainThread;
+import android.support.annotation.WorkerThread;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
@@ -134,6 +136,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                 setWakeUpAlarm();
             }
             mHandler.postDelayed(new Runnable() {
+                @MainThread
                 @Override
                 public void run() {
                     scanLeDevice(true);
@@ -190,6 +193,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
         final ScanCallback scanCallback = getNewLeScanCallback();
         mScanHandler.removeCallbacksAndMessages(null);
         mScanHandler.post(new Runnable() {
+            @WorkerThread
             @Override
             public void run() {
                 try {
@@ -220,6 +224,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
         final ScanCallback scanCallback = getNewLeScanCallback();
         mScanHandler.removeCallbacksAndMessages(null);
         mScanHandler.post(new Runnable() {
+            @WorkerThread
             @Override
             public void run() {
                 try {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -280,7 +280,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
     private ScanCallback getNewLeScanCallback() {
         if (leScanCallback == null) {
             leScanCallback = new ScanCallback() {
-
+                @MainThread
                 @Override
                 public void onScanResult(int callbackType, ScanResult scanResult) {
                     if (LogManager.isVerboseLoggingEnabled()) {
@@ -299,6 +299,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     }
                 }
 
+                @MainThread
                 @Override
                 public void onBatchScanResults(List<ScanResult> results) {
                     LogManager.d(TAG, "got batch records");
@@ -311,6 +312,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     }
                 }
 
+                @MainThread
                 @Override
                 public void onScanFailed(int errorCode) {
                     switch (errorCode) {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/NonBeaconLeScanCallback.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/NonBeaconLeScanCallback.java
@@ -1,6 +1,7 @@
 package org.altbeacon.beacon.service.scanner;
 
 import android.bluetooth.BluetoothDevice;
+import android.support.annotation.WorkerThread;
 
 /**
  * Allows an implementation to see non-Beacon BLE devices as they are scanned.
@@ -23,6 +24,7 @@ import android.bluetooth.BluetoothDevice;
  *  }
  * </code></pre>
  */
+@WorkerThread
 public interface NonBeaconLeScanCallback {
     /**
      * NOTE: This method is NOT called on the main UI thread.


### PR DESCRIPTION
This is a follow up to #507 

## Bug Fix

- Fix where scanner thread is quit

  This fixes what I believe was a simply copy-paste error regarding how the scanner thread is quit. This uses the scanner thread handler, instead of the main thread handler, to schedule the `quit` operation. This way any queued scan jobs (such as a stop) complete before we quit the thread. This is what the comment states, but wasn't what the code implemented.

## Behavior Modification

Fix scan stop when bound but no monitored / ranged regions.

This adds a guard to ensure that we only attempt any further scans when the scan cycler is started. This helps ensure the cycler has terminated scanning for the case where all regions have been removed but the service is still bound. In this case only `stop` will be called (instead of both `stop` and `destroy`). When this happens there are two potential scheduled tasks still queued:

- `scanLeDevice(true)` from `deferScanIfNeeded`
- `scheduleScanCycleStop`

Which potential task is queued is based on if we were in an active scan period or a between scan period when `stop` was called. In the case of a between scan period the `deferScanIfNeeded` _will_ cause a faux scanning cycle to start up again when it ends (scanning won't actually start, but all flags and internal state appear as if it is running). It will run for one more scan cycle before it terminates in `finishScanCycle`. Similarly, if we are in an active scan period the scheduled job for finishing the scan cycle will continue for the duration of the scan period.

## Documentation / Annotations

This helps to try explaining how / when the various internal handlers should be used. This is important to help developers understand various threading flow orders, race conditions, and resource contention problems. As part of the documentation this adds `MainThread` and `WorkerThread` annotations to the deferred `Runnable` tasks' `run` methods.

This makes the current implicit assumption that the scan cycler is started/stopped on the main thread explicit. This helps quickly inform developers what the callback expectations are in regards to race conditions and state safety.

In order to verify this we need to trace the `start`/`stop`/`destroy` calls back to the service. The service's core methods `onCreate` and `onDestroy` are called on the main thread (see links below). This means the service creates it's `mMessenger` on the main thread, which creates the `IncomingHandler` on the main thread which binds to the main looper. However, the `IncomingHandler` class itself leaves the looper unspecified relying on looper for the thread which creates it.

As we did in #430, this modifies `IncomingHandler` to explicitly use the main looper as a future proofing mechanism. This way we can ensure this implicit expectation doesn't change or at least make it obvious when troubleshooting cases where someone expects it to have changed. Similarly, this adds the main thread annotation to it's `handleMessage` implementation.

Working from here we can confirm that the only places where the beacon monitoring/ranging is updated is from the main thread through the `IncomingHandler`. As the `IncomingHandler` is the main communication channel for the service we transfer the main thread expectation to the associated ranging/monitoring methods. _If_ someone decides to call these methods directly on the service these annotations help the IDEs check/document that such calls are expected from the main thread.

With all of that documented we can now confidently state that the scan cycler's `start`, `stop`, and `destroy` are also meant to be called from the main thread. As `start` and `stop` both call `scanLeDevice` we can start tracing any other threading expectations for it. We already know it's called from the main thread through deferred jobs. This leaves the `finishScanCycle` as the last call site.

`finishScanCycle` is only called from `scheduleScanCycleStop`. As this method name implies it's called through a deferred job on the main thread. It is also called the "first" time in `scanLeDevice`. Thus we've shown that `scanLeDevice`, `finishScanCycle`, and `scheduleScanCycleStop` are expected to run on the main thread.

## See Also

- https://developer.android.com/reference/android/os/Handler.html#Handler%28%29
- https://developer.android.com/training/multiple-threads/communicate-ui.html
- https://developer.android.com/reference/android/app/Service.html
- https://developer.android.com/guide/components/services.html
- #430
- https://developer.android.com/studio/write/annotations.html#thread-annotations