### PR TITLE
Log more specific error message on scan failure

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -307,8 +307,39 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                 }
 
                 @Override
-                public void onScanFailed(int i) {
-                    LogManager.e(TAG, "Scan Failed");
+                public void onScanFailed(int errorCode) {
+                    switch (errorCode) {
+                        case SCAN_FAILED_ALREADY_STARTED:
+                            LogManager.e(
+                                    TAG,
+                                    "Scan failed: a BLE scan with the same settings is already started by the app"
+                            );
+                            break;
+                        case SCAN_FAILED_APPLICATION_REGISTRATION_FAILED:
+                            LogManager.e(
+                                    TAG,
+                                    "Scan failed: app cannot be registered"
+                            );
+                            break;
+                        case SCAN_FAILED_FEATURE_UNSUPPORTED:
+                            LogManager.e(
+                                    TAG,
+                                    "Scan failed: power optimized scan feature is not supported"
+                            );
+                            break;
+                        case SCAN_FAILED_INTERNAL_ERROR:
+                            LogManager.e(
+                                    TAG,
+                                    "Scan failed: internal error"
+                            );
+                            break;
+                        default:
+                            LogManager.e(
+                                    TAG,
+                                    "Scan failed with unknown error (errorCode=" + errorCode + ")"
+                            );
+                            break;
+                    }
                 }
             };
         }


### PR DESCRIPTION
On occasion I noticed a "Scan Failed" in the logs. This improves the logged error message to report the associated reason based on the error code. If it's an error we don't know about it includes the error code in the message for further research.