### PR TITLE
Restart scanning after bluetooth is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Bug Fixes:
 
 - Fix failure to stop scanning when unbinding from service or when the between scan period
   is nonzero. (#507, David G. Young)
+- Fix failure to restart scanning in some cases after bluetooth has been off but then is turned
+  back on. (#519, David G. Young)
 
 ### 2.10 / 2017-04-21
 

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -327,6 +327,7 @@ public abstract class CycledLeScanner {
                         mLastScanCycleEndTime = SystemClock.elapsedRealtime();
                     } else {
                         LogManager.d(TAG, "Bluetooth is disabled.  Cannot scan for beacons.");
+                        mRestartNeeded = true;
                     }
                 }
                 mNextScanCycleStartTime = getNextScanStartTime();


### PR DESCRIPTION
This is a fix for #518 which reports that scanning gets stuck in an off state under certain conditions when bluetooth has been turned off and turned back on.

The problem exists in 2.10 but not 2.9.It is caused by the fact that we generally leave scanning on all the time as of 2.10, and if bluetooth is turned off, we need to know to restart scanning when bluetooth is back on.  This was not an issue in 2.9 and earlier because we always stopped and restarted scanning every second or so in the foreground.

The following tests show that the problem exists in 2.10 and master, but not after the change in this branch.

```
==== 2.10 =====

$ adb logcat  | grep -e "beacon detected"  -e "bluetooth is off" -e "Bluetooth is disabled"  -e "starting non-filtered scan"

05-30 23:47:51.694  6709  6709 D CycledLeScannerForLollipop: starting non-filtered scan in SCAN_MODE_LOW_LATENCY
05-30 23:47:52.320  6709  6755 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:52.416  6709  6740 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:52.526  6709  6748 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:52.610  6709  6757 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:52.741  6709  6740 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:52.806  6709  6748 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:54.552  6709  6741 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:54.957  6709  6744 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon

-- bluetooth disabled --

05-30 23:47:55.011  6709  6709 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:47:55.171  6709  6755 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:56.073  6709  6759 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:47:56.117  6709  6709 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:47:57.221  6709  6709 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:47:58.325  6709  6709 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:47:59.431  6709  6709 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:48:00.536  6709  6709 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:48:01.640  6709  6709 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.

-- bluetooth enabled (no more output) --


==== master (2.11-beta1) =====

$ adb logcat  | grep -e "beacon detected"  -e "bluetooth is off" -e "Bluetooth is disabled"  -e "starting non-filtered scan"

05-30 23:50:00.923  5087  5087 D CycledLeScannerForLollipop: starting non-filtered scan in SCAN_MODE_LOW_LATENCY
05-30 23:50:01.626  5087  5280 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:01.793  5087  5282 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:01.975  5087  5252 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:07.222  5087  5281 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:07.586  5087  5280 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:08.486  5087  5252 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:09.817  5087  5281 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:09.843  5087  5283 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:09.844  5087  5284 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:11.245  5087  5283 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:12.032  5087  5282 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:12.179  5087  5279 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:12.236  5087  5280 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:12.335  5087  5284 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:12.512  5087  5279 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:12.629  5087  5280 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-30 23:50:12.773  5087  5284 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon

-- bluetooth disabled --

05-30 23:50:13.123  5087  5087 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:50:14.231  5087  5087 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:50:15.336  5087  5087 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:50:16.445  5087  5087 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:50:17.550  5087  5087 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-30 23:50:18.656  5087  5087 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.

-- bluetooth enabled (no more output) --


==== with this PR ====

$ adb logcat  | grep -e "beacon detected"  -e "bluetooth is off" -e "Bluetooth is disabled"  -e "starting non-filtered scan"

05-31 00:08:54.203 21268 21268 D CycledLeScannerForLollipop: starting non-filtered scan in SCAN_MODE_LOW_LATENCY
05-31 00:08:57.306 21268 21377 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:57.337 21268 21382 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:58.331 21268 21401 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:58.636 21268 21382 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:59.414 21268 21403 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:59.455 21268 21376 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:59.682 21268 21381 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:59.830 21268 21382 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:59.856 21268 21403 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:08:59.948 21268 21376 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:00.046 21268 21377 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:01.111 21268 21402 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:01.173 21268 21376 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:01.474 21268 21381 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:01.636 21268 21382 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:01.673 21268 21401 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:01.975 21268 21403 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon

-- bluetooth disabled --

05-31 00:09:01.994 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:01.994 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:03.098 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:03.098 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:04.206 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:04.206 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:05.314 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:05.314 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:06.418 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:06.418 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:07.524 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.
05-31 00:09:07.524 21268 21268 D CycledLeScanner: Bluetooth is disabled.  Cannot scan for beacons.

-- bluetooth enabled --

05-31 00:09:08.630 21268 21268 D CycledLeScannerForLollipop: starting non-filtered scan in SCAN_MODE_LOW_LATENCY
05-31 00:09:24.545 21268 21377 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:24.583 21268 21381 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:25.806 21268 21382 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
05-31 00:09:26.005 21268 21402 D BeaconService: beacon detected : id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: 1 id3: 1 type altbeacon
```
