### PR TITLE
Fix `RunningAverageRssiFilter.setSampleExpirationMilliseconds`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Bug Fixes:
 
 - Fix failure to stop scanning when unbinding from service or when the between scan period
   is nonzero. (#507, David G. Young)
+- Fix inability to use `RunningAverageRssiFilter.setSampleExpirationMilliseconds(...)` (#523,
+  David G. Young)
 
 ### 2.10 / 2017-04-21
 

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     testCompile('org.mockito:mockito-core:1.10.19') {
         exclude group: 'org.hamcrest'
     }
+    compile 'com.android.support:support-annotations:25.3.1'
 }
 
 apply plugin: 'idea'

--- a/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -29,8 +29,6 @@ public class RangedBeacon {
         } catch (Exception e) {
             LogManager.e(TAG, "Could not construct RssiFilterImplClass %s", BeaconManager.getRssiFilterImplClass().getName());
         }
-
-        RunningAverageRssiFilter.setSampleExpirationMilliseconds(sampleExpirationMilliseconds);
         updateBeacon(beacon);
     }
 
@@ -76,6 +74,7 @@ public class RangedBeacon {
     //kept here for backward compatibility
     public static void setSampleExpirationMilliseconds(long milliseconds) {
         sampleExpirationMilliseconds = milliseconds;
+        RunningAverageRssiFilter.setSampleExpirationMilliseconds(sampleExpirationMilliseconds);
     }
 
     public static void setMaxTrackinAge(int maxTrackinAge) {

--- a/src/main/java/org/altbeacon/beacon/service/RunningAverageRssiFilter.java
+++ b/src/main/java/org/altbeacon/beacon/service/RunningAverageRssiFilter.java
@@ -17,7 +17,7 @@ public class RunningAverageRssiFilter implements RssiFilter {
 
     private static final String TAG = "RunningAverageRssiFilter";
     public static final long DEFAULT_SAMPLE_EXPIRATION_MILLISECONDS = 20000; /* 20 seconds */
-    private static long sampleExpirationMilliseconds = DEFAULT_SAMPLE_EXPIRATION_MILLISECONDS;
+    protected static long sampleExpirationMilliseconds = DEFAULT_SAMPLE_EXPIRATION_MILLISECONDS;
     private ArrayList<Measurement> mMeasurements = new ArrayList<Measurement>();
 
     @Override

--- a/src/main/java/org/altbeacon/beacon/service/RunningAverageRssiFilter.java
+++ b/src/main/java/org/altbeacon/beacon/service/RunningAverageRssiFilter.java
@@ -1,6 +1,8 @@
 package org.altbeacon.beacon.service;
 
 import android.os.SystemClock;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
 
 import org.altbeacon.beacon.logging.LogManager;
 
@@ -17,7 +19,7 @@ public class RunningAverageRssiFilter implements RssiFilter {
 
     private static final String TAG = "RunningAverageRssiFilter";
     public static final long DEFAULT_SAMPLE_EXPIRATION_MILLISECONDS = 20000; /* 20 seconds */
-    protected static long sampleExpirationMilliseconds = DEFAULT_SAMPLE_EXPIRATION_MILLISECONDS;
+    private static long sampleExpirationMilliseconds = DEFAULT_SAMPLE_EXPIRATION_MILLISECONDS;
     private ArrayList<Measurement> mMeasurements = new ArrayList<Measurement>();
 
     @Override
@@ -81,4 +83,8 @@ public class RunningAverageRssiFilter implements RssiFilter {
         sampleExpirationMilliseconds = newSampleExpirationMilliseconds;
     }
 
+    @RestrictTo(Scope.TESTS)
+    static long getSampleExpirationMilliseconds() {
+        return sampleExpirationMilliseconds;
+    }
 }

--- a/src/test/java/org/altbeacon/beacon/service/RunningAverageRssiFilterTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/RunningAverageRssiFilterTest.java
@@ -25,7 +25,7 @@ public class RunningAverageRssiFilterTest {
         Beacon beacon = new Beacon.Builder().setId1("1").build();
         RunningAverageRssiFilter.setSampleExpirationMilliseconds(33l);
         RangedBeacon rb = new RangedBeacon(beacon);
-        assertEquals("RunningAverageRssiFilter sampleExprirationMilliseconds should not be altered by constructing RangedBeacon", 33l, RunningAverageRssiFilter.sampleExpirationMilliseconds);
+        assertEquals("RunningAverageRssiFilter sampleExprirationMilliseconds should not be altered by constructing RangedBeacon", 33l, RunningAverageRssiFilter.getSampleExpirationMilliseconds());
     }
 
     @Test
@@ -35,7 +35,7 @@ public class RunningAverageRssiFilterTest {
         Beacon beacon = new Beacon.Builder().setId1("1").build();
         RangedBeacon.setSampleExpirationMilliseconds(33l);
         RangedBeacon rb = new RangedBeacon(beacon);
-        assertEquals("RunningAverageRssiFilter sampleExprirationMilliseconds should not be altered by constructing RangedBeacon", 33l, RunningAverageRssiFilter.sampleExpirationMilliseconds);
+        assertEquals("RunningAverageRssiFilter sampleExprirationMilliseconds should not be altered by constructing RangedBeacon", 33l, RunningAverageRssiFilter.getSampleExpirationMilliseconds());
     }
 
 }

--- a/src/test/java/org/altbeacon/beacon/service/RunningAverageRssiFilterTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/RunningAverageRssiFilterTest.java
@@ -1,5 +1,6 @@
 package org.altbeacon.beacon.service;
 
+import org.altbeacon.beacon.Beacon;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -17,4 +18,24 @@ public class RunningAverageRssiFilterTest {
         filter.addMeasurement(-50);
         assertEquals("First measurement should be -50", String.valueOf(filter.calculateRssi()), "-50.0");
     }
+    @Test
+    public void rangedBeaconDoesNotOverrideSampleExpirationMillisecondsText() {
+        RangedBeacon.setSampleExpirationMilliseconds(20000);
+        RunningAverageRssiFilter.setSampleExpirationMilliseconds(20000);
+        Beacon beacon = new Beacon.Builder().setId1("1").build();
+        RunningAverageRssiFilter.setSampleExpirationMilliseconds(33l);
+        RangedBeacon rb = new RangedBeacon(beacon);
+        assertEquals("RunningAverageRssiFilter sampleExprirationMilliseconds should not be altered by constructing RangedBeacon", 33l, RunningAverageRssiFilter.sampleExpirationMilliseconds);
+    }
+
+    @Test
+    public void legacySetSampleExpirationMillisecondsWorksText() {
+        RangedBeacon.setSampleExpirationMilliseconds(20000);
+        RunningAverageRssiFilter.setSampleExpirationMilliseconds(20000);
+        Beacon beacon = new Beacon.Builder().setId1("1").build();
+        RangedBeacon.setSampleExpirationMilliseconds(33l);
+        RangedBeacon rb = new RangedBeacon(beacon);
+        assertEquals("RunningAverageRssiFilter sampleExprirationMilliseconds should not be altered by constructing RangedBeacon", 33l, RunningAverageRssiFilter.sampleExpirationMilliseconds);
+    }
+
 }


### PR DESCRIPTION
The ability to configure this setting was broken as reported in https://github.com/AltBeacon/android-beacon-library-reference/issues/30.  This change makes the API work as intended so the documentation is correct.