### PR TITLE
Fix Google Play manifest validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Enhancements:
 
 Bug Fixes:
 
+- Fix Google Play submission errors by no longer using uses-permission-sdk-23 in
+  Manifest (#527, David G. Young)
 - Fix failure to stop scanning when unbinding from service or when the between scan period
   is nonzero. (#507, David G. Young)
 - Fix possible `NullPointerException` with `BackgroundPowerSaver` on devices

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" android:required="false"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:required="false"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-    <uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application>
         <receiver android:name="org.altbeacon.beacon.startup.StartupBroadcastReceiver">


### PR DESCRIPTION
This addresses new Google Play submission errors reported in #520 and #521 when using the library based on a reported conflict between two permission tags.

This changes the library manifest to use 

    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

rather than 

    <uses-permission-sdk23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>

This effectively reverts the change in #296.  The disadvantage is that the permission will now be shown to users at install time on Android 5.x and earlier, even though it is not needed.  But this is a small disadvantage relative to not being able to submit to the Play Store.

If it is important not to request this permission to users on Android 5.x and earlier, then it is possible to not do so by putting this in your app's manifest:

    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
        tools:node="remove"/>
    <uses-permission-sdk23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
