### PR TITLE
Allow forcing long scans on Android N

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 Enhancements:
 
+- Add ability to circumvent prohibition against scans running for > 30 minutes on Android N.
+  (#529, David G. Young)
 - Add support for running the beacon scanning service in a separate process and working with
   application setups that have more than one process. (#479, David G. Young)
 

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -245,7 +245,8 @@ public class BeaconService extends Service {
 
         try {
             PackageItemInfo info = this.getPackageManager().getServiceInfo(new ComponentName(this, BeaconService.class), PackageManager.GET_META_DATA);
-            if (info.metaData.get("longScanForcingEnabled").toString().equals("true")) {
+            if (info != null && info.metaData != null && info.metaData.get("longScanForcingEnabled") != null &&
+                    info.metaData.get("longScanForcingEnabled").toString().equals("true")) {
                 LogManager.i(TAG, "longScanForcingEnabled to keep scans going on Android N for > 30 minutes");
                 mCycledScanner.setLongScanForcingEnabled(true);
             }

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -246,7 +246,7 @@ public class BeaconService extends Service {
         try {
             PackageItemInfo info = this.getPackageManager().getServiceInfo(new ComponentName(this, BeaconService.class), PackageManager.GET_META_DATA);
             if (info.metaData.get("longScanForcingEnabled").toString().equals("true")) {
-                LogManager.i(TAG, "longScanForcingEnabled from AndroidManifest");
+                LogManager.i(TAG, "longScanForcingEnabled to keep scans going on Android N for > 30 minutes");
                 mCycledScanner.setLongScanForcingEnabled(true);
             }
         } catch (PackageManager.NameNotFoundException e) {}

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -29,9 +29,12 @@ import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.app.Service;
 import android.bluetooth.BluetoothDevice;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageItemInfo;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Binder;
 import android.os.Build;
@@ -239,6 +242,14 @@ public class BeaconService extends Service {
             ProcessUtils processUtils = new ProcessUtils(this);
             LogManager.i(TAG, "beaconService PID is "+processUtils.getPid()+" with process name "+processUtils.getProcessName());
         }
+
+        try {
+            PackageItemInfo info = this.getPackageManager().getServiceInfo(new ComponentName(this, BeaconService.class), PackageManager.GET_META_DATA);
+            if (info.metaData.get("longScanForcingEnabled").toString().equals("true")) {
+                LogManager.i(TAG, "longScanForcingEnabled from AndroidManifest");
+                mCycledScanner.setLongScanForcingEnabled(true);
+            }
+        } catch (PackageManager.NameNotFoundException e) {}
 
         reloadParsers();
 


### PR DESCRIPTION
Android N introduced a restriction that any Bluetooth LE scan running for over 30 minutes would be converted to an "opportunistic" scan, effectively meaning it is disabled unless some other app is scanning.  This is intended to save battery, but affects beacon scanning in this library as described in #526.

While this makes sense in general, there are some cases where it is reasonable to override this behavior.  Examples include a wall-powered Android Things  device meant to be a full-time beacon scanner, or a phone app that ranges in the foreground for the case where the user leaves the app up and running for > 30 minutes.

This change circumvents this restriction by stopping scanning at the last opportunity before the 30 minute period is hit, and letting scanning restart on the next scan cycle.  This effectively restarts the 30 minute timeout.

By default, forcing long scans is not enabled.  The mechanism to enable it is to add an entry like the following to ApplicationManifest.xml:

        <service android:name="org.altbeacon.beacon.service.BeaconService"
                 tools:node="replace">
            <meta-data android:name="longScanForcingEnabled" android:value="true"/>
        </service>

The "longScanForcingEnabled" meta-data is the element that enables this.  

This mechanism of enabling long scans is a bit awkward, but I have made it this way for two reasons:

1. It is relatively rare that an app would need to do this, and I hate to clutter the BeaconManager with yet another configuration setting and worry about synchronizing where needed.

2. I don't think it should be *too* easy to turn this on, as it effectively circumvents a power-saving mechanism in Android that is generally wise.  Making it harder to configure may lead developers to think about what they are doing a little more.

The following log excerpt (with debug logging enabled in the library) shows how this behaves when enabled and an app is running in the foreground for > 30 minutes:

```
$ adb logcat | grep -e "We are already scanning" | grep -e "Android N"
06-16 22:28:21.029 27915 27915 I BeaconService: longScanForcingEnabled to keep scans going on Android N for > 30 minutes
06-16 22:28:24.574 27915 27915 D CycledLeScanner: We are already scanning and have been for 1108 millis
06-16 22:28:25.683 27915 27915 D CycledLeScanner: We are already scanning and have been for 2217 millis
06-16 22:28:26.787 27915 27915 D CycledLeScanner: We are already scanning and have been for 3321 millis
...
06-16 22:58:46.683 27915 27915 D CycledLeScanner: We are already scanning and have been for 1795605 millis
06-16 22:58:47.793 27915 27915 D CycledLeScanner: We are already scanning and have been for 1796715 millis
06-16 22:58:48.902 27915 27915 D CycledLeScanner: We are already scanning and have been for 1797824 millis
06-16 22:58:50.022 27915 27915 D CycledLeScanner: The next scan cycle would go over the Android N max duration.
06-16 22:58:50.022 27915 27915 D CycledLeScanner: Stopping scan to prevent Android N scan timeout.
06-16 22:58:51.148 27915 27915 D CycledLeScanner: We are already scanning and have been for 1108 millis
06-16 22:58:52.255 27915 27915 D CycledLeScanner: We are already scanning and have been for 2215 millis
06-16 22:58:53.361 27915 27915 D CycledLeScanner: We are already scanning and have been for 3321 millis
```
