### PR TITLE
Refactor away `mScanDeferredBefore` flag

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -81,49 +81,47 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
         long millisecondsUntilStart = mNextScanCycleStartTime - SystemClock.elapsedRealtime();
         if (millisecondsUntilStart > 0) {
             mMainScanCycleActive = false;
-            if (true) {
-                long secsSinceLastDetection = SystemClock.elapsedRealtime() -
-                        DetectionTracker.getInstance().getLastDetectionTime();
-                // If we have seen a device recently
-                // devices should behave like pre-Android L devices, because we don't want to drain battery
-                // by continuously delivering packets for beacons visible in the background
-                if (mScanDeferredBefore == false) {
-                    if (secsSinceLastDetection > BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
-                        mBackgroundLScanStartTime = SystemClock.elapsedRealtime();
-                        mBackgroundLScanFirstDetectionTime = 0l;
-                        LogManager.d(TAG, "This is Android L. Doing a filtered scan for the background.");
+            long secsSinceLastDetection = SystemClock.elapsedRealtime() -
+                    DetectionTracker.getInstance().getLastDetectionTime();
+            // If we have seen a device recently
+            // devices should behave like pre-Android L devices, because we don't want to drain battery
+            // by continuously delivering packets for beacons visible in the background
+            if (mScanDeferredBefore == false) {
+                if (secsSinceLastDetection > BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
+                    mBackgroundLScanStartTime = SystemClock.elapsedRealtime();
+                    mBackgroundLScanFirstDetectionTime = 0l;
+                    LogManager.d(TAG, "This is Android L. Doing a filtered scan for the background.");
 
-                        // On Android L, between scan cycles do a scan with a filter looking for any beacon
-                        // if we see one of those beacons, we need to deliver the results
-                        startScan();
-                    } else {
-                        // TODO: Consider starting a scan with delivery based on the filters *NOT* being seen
-                        // This API is now available in Android M
-                        LogManager.d(TAG, "This is Android L, but we last saw a beacon only %s "
-                                + "ago, so we will not keep scanning in background.",
-                                secsSinceLastDetection);
-                    }
+                    // On Android L, between scan cycles do a scan with a filter looking for any beacon
+                    // if we see one of those beacons, we need to deliver the results
+                    startScan();
+                } else {
+                    // TODO: Consider starting a scan with delivery based on the filters *NOT* being seen
+                    // This API is now available in Android M
+                    LogManager.d(TAG, "This is Android L, but we last saw a beacon only %s "
+                            + "ago, so we will not keep scanning in background.",
+                            secsSinceLastDetection);
                 }
-                if (mBackgroundLScanStartTime > 0l) {
-                    // if we are in here, we have detected beacons recently in a background L scan
-                    if (DetectionTracker.getInstance().getLastDetectionTime() > mBackgroundLScanStartTime) {
-                        if (mBackgroundLScanFirstDetectionTime == 0l) {
-                            mBackgroundLScanFirstDetectionTime = DetectionTracker.getInstance().getLastDetectionTime();
-                        }
-                        if (SystemClock.elapsedRealtime() - mBackgroundLScanFirstDetectionTime
-                                >= BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
-                            // if we are in here, it has been more than 10 seconds since we detected
-                            // a beacon in background L scanning mode.  We need to stop scanning
-                            // so we do not drain battery
-                            LogManager.d(TAG, "We've been detecting for a bit.  Stopping Android L background scanning");
-                            stopScan();
-                            mBackgroundLScanStartTime = 0l;
-                        }
-                        else {
-                            // report the results up the chain
-                            LogManager.d(TAG, "Delivering Android L background scanning results");
-                            mCycledLeScanCallback.onCycleEnd();
-                        }
+            }
+            if (mBackgroundLScanStartTime > 0l) {
+                // if we are in here, we have detected beacons recently in a background L scan
+                if (DetectionTracker.getInstance().getLastDetectionTime() > mBackgroundLScanStartTime) {
+                    if (mBackgroundLScanFirstDetectionTime == 0l) {
+                        mBackgroundLScanFirstDetectionTime = DetectionTracker.getInstance().getLastDetectionTime();
+                    }
+                    if (SystemClock.elapsedRealtime() - mBackgroundLScanFirstDetectionTime
+                            >= BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
+                        // if we are in here, it has been more than 10 seconds since we detected
+                        // a beacon in background L scanning mode.  We need to stop scanning
+                        // so we do not drain battery
+                        LogManager.d(TAG, "We've been detecting for a bit.  Stopping Android L background scanning");
+                        stopScan();
+                        mBackgroundLScanStartTime = 0l;
+                    }
+                    else {
+                        // report the results up the chain
+                        LogManager.d(TAG, "Delivering Android L background scanning results");
+                        mCycledLeScanCallback.onCycleEnd();
                     }
                 }
             }

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -86,7 +86,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             // If we have seen a device recently
             // devices should behave like pre-Android L devices, because we don't want to drain battery
             // by continuously delivering packets for beacons visible in the background
-            if (mScanDeferredBefore == false) {
+            if (!mScanDeferredBefore) {
                 if (secsSinceLastDetection > BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
                     mBackgroundLScanStartTime = SystemClock.elapsedRealtime();
                     mBackgroundLScanFirstDetectionTime = 0l;
@@ -130,7 +130,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             // Don't actually wait until the next scan time -- only wait up to 1 second.  This
             // allows us to start scanning sooner if a consumer enters the foreground and expects
             // results more quickly.
-            if (mScanDeferredBefore == false && mBackgroundFlag) {
+            if (!mScanDeferredBefore && mBackgroundFlag) {
                 setWakeUpAlarm();
             }
             mHandler.postDelayed(new Runnable() {


### PR DESCRIPTION
This is the result of several refactor steps which set out to improve the clarity between the relation ship of the flags `mScanDeferredBefore`, `mMainScanCycleActive`, and the `deferScanIfNeeded` method. This ultimately results in the removal of the `mScanDeferredBefore` flag.

Refactor Steps
--------------

1. Extract defer check into boolean flag

   ```diff
   @@ -79,7 +79,8 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
        protected boolean deferScanIfNeeded() {
            // This method is called to see if it is time to start a scan
            long millisecondsUntilStart = mNextScanCycleStartTime - SystemClock.elapsedRealtime();
   -        if (millisecondsUntilStart > 0) {
   +        final boolean deferScan = millisecondsUntilStart > 0;
   +        if (deferScan) {
                mMainScanCycleActive = false;
                long secsSinceLastDetection = SystemClock.elapsedRealtime() -
                        DetectionTracker.getInstance().getLastDetectionTime();
   @@ -141,9 +142,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                    }
                }, millisecondsUntilStart > 1000 ? 1000 : millisecondsUntilStart);
                mScanDeferredBefore = true;
   -            return true;
   -        }
   -        else {
   +        } else {
                if (mBackgroundLScanStartTime > 0l) {
                    stopScan();
                    mBackgroundLScanStartTime = 0;
   @@ -151,7 +150,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                mScanDeferredBefore = false;
                mMainScanCycleActive = true;
            }
   -        return false;
   +        return deferScan;
        }
   ```

   Tracing through all of the branches the only places where the method exits are these two spots. Both returns are essentially from either of the main conditional branches. We can simplify this to a single return after the conditional as long as we preserve the return flag. By using a local variable for the flag we make it a bit more clear what each conditional branch is doing and how that relates to the method return value.
2. Extract setting of flag to improve clarity

   ```diff
   @@ -141,15 +141,14 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                        scanLeDevice(true);
                    }
                }, millisecondsUntilStart > 1000 ? 1000 : millisecondsUntilStart);
   -            mScanDeferredBefore = true;
            } else {
                if (mBackgroundLScanStartTime > 0l) {
                    stopScan();
                    mBackgroundLScanStartTime = 0;
                }
   -            mScanDeferredBefore = false;
                mMainScanCycleActive = true;
            }
   +        mScanDeferredBefore = deferScan;
            return deferScan;
        }
   ```

   Explicitly show that `mScanDeferredBefore` stores the return value of the most recent call. Any time we can extract out logic which simply represents a conditional branch state we reduce the cognitive overhead of the code.

   We _must_ set `mScanDeferredBefore` after main conditional because we need to reference the prior value within the truthy branch.
3. Extract setting of flag to improve clarity

   ```diff
   @@ -80,8 +80,8 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
            // This method is called to see if it is time to start a scan
            long millisecondsUntilStart = mNextScanCycleStartTime - SystemClock.elapsedRealtime();
            final boolean deferScan = millisecondsUntilStart > 0;
   +        mMainScanCycleActive = !deferScan;
            if (deferScan) {
   -            mMainScanCycleActive = false;
                long secsSinceLastDetection = SystemClock.elapsedRealtime() -
                        DetectionTracker.getInstance().getLastDetectionTime();
                // If we have seen a device recently
   @@ -146,7 +146,6 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                    stopScan();
                    mBackgroundLScanStartTime = 0;
                }
   -            mMainScanCycleActive = true;
            }
            mScanDeferredBefore = deferScan;
            return deferScan;
   ```

   Explicitly show that `mMainScanCycleActive` stores the opposite of if the scan is deferred. We _must_ set `mMainScanCycleActive` before the main conditional because we need to reference the current value in `startScan` which _may_ be called from within the conditional branch. This is why the first thing the truthy branch does is set it to `false`.

   Any time we can extract out logic which simply represents a conditional branch state we reduce the cognitive overhead of the code.
4. Drop `mScanDeferredBefore` flag

   ```diff
   @@ -30,7 +30,6 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
        private ScanCallback leScanCallback;
        private long mBackgroundLScanStartTime = 0l;
        private long mBackgroundLScanFirstDetectionTime = 0l;
   -    private boolean mScanDeferredBefore = false;
        private boolean mMainScanCycleActive = false;
        private final BeaconManager mBeaconManager;

   @@ -80,6 +79,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
            // This method is called to see if it is time to start a scan
            long millisecondsUntilStart = mNextScanCycleStartTime - SystemClock.elapsedRealtime();
            final boolean deferScan = millisecondsUntilStart > 0;
   +        final boolean scanDeferredBefore = !mMainScanCycleActive;
            mMainScanCycleActive = !deferScan;
            if (deferScan) {
                long secsSinceLastDetection = SystemClock.elapsedRealtime() -
   @@ -87,7 +87,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                // If we have seen a device recently
                // devices should behave like pre-Android L devices, because we don't want to drain battery
                // by continuously delivering packets for beacons visible in the background
   -            if (!mScanDeferredBefore) {
   +            if (!scanDeferredBefore) {
                    if (secsSinceLastDetection > BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
                        mBackgroundLScanStartTime = SystemClock.elapsedRealtime();
                        mBackgroundLScanFirstDetectionTime = 0l;
   @@ -131,7 +131,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                // Don't actually wait until the next scan time -- only wait up to 1 second.  This
                // allows us to start scanning sooner if a consumer enters the foreground and expects
                // results more quickly.
   -            if (!mScanDeferredBefore && mBackgroundFlag) {
   +            if (!scanDeferredBefore && mBackgroundFlag) {
                    setWakeUpAlarm();
                }
                mHandler.postDelayed(new Runnable() {
   @@ -147,7 +147,6 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                    mBackgroundLScanStartTime = 0;
                }
            }
   -        mScanDeferredBefore = deferScan;
            return deferScan;
        }
   ```

   The `mScanDeferredBefore` and `mMainScanCycleActive` flags *always* mirror each other at the start and end of `deferScanIfNeeded`. The `mMainScanCycleActive` is accessed from `deferScanIfNeeded` and `startScan`, but the `mScanDeferredBefore` flag is only used by `deferScanIfNeeded`. Both of these flags are only set within `deferScanIfNeeded`.

   Taking all of that into account this converts `mScanDeferredBefore` to a local variable which mirrors the value of `mMainScanCycleActive` at the start of `deferScanIfNeeded`.
5. Invert local prior scan state flag

   ```diff
   @@ -79,7 +79,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
            // This method is called to see if it is time to start a scan
            long millisecondsUntilStart = mNextScanCycleStartTime - SystemClock.elapsedRealtime();
            final boolean deferScan = millisecondsUntilStart > 0;
   -        final boolean scanDeferredBefore = !mMainScanCycleActive;
   +        final boolean scanActiveBefore = mMainScanCycleActive;
            mMainScanCycleActive = !deferScan;
            if (deferScan) {
                long secsSinceLastDetection = SystemClock.elapsedRealtime() -
   @@ -87,7 +87,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                // If we have seen a device recently
                // devices should behave like pre-Android L devices, because we don't want to drain battery
                // by continuously delivering packets for beacons visible in the background
   -            if (!scanDeferredBefore) {
   +            if (scanActiveBefore) {
                    if (secsSinceLastDetection > BACKGROUND_L_SCAN_DETECTION_PERIOD_MILLIS) {
                        mBackgroundLScanStartTime = SystemClock.elapsedRealtime();
                        mBackgroundLScanFirstDetectionTime = 0l;
   @@ -131,7 +131,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                // Don't actually wait until the next scan time -- only wait up to 1 second.  This
                // allows us to start scanning sooner if a consumer enters the foreground and expects
                // results more quickly.
   -            if (!scanDeferredBefore && mBackgroundFlag) {
   +            if (scanActiveBefore && mBackgroundFlag) {
                    setWakeUpAlarm();
                }
                mHandler.postDelayed(new Runnable() {
   ```

   All of the places we use `scanDeferredBefore` are conditional on the flag being `false`. Another way to look at this is we enter those branches when the opposite of the flag is `true`. This local flag itself is the opposite of the value of `mMainScanCycleActive` at the start of the method.

   This changes the name of the local flag to better reflect what it represents. This improves the branch expression and eliminates the double negative mental dance one needs to make to understand the control flow.
