### PR TITLE
Fix bugs with  nonzero foreground betweenScanPeriod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### Development
+
+Enhancements:
+
+Bug Fixes:
+
+ - Fix "Scanning too frequently" error with non-zero betweenScanPeriod
+   and scanPeriod+betweenScanPeriod < 6000, and full-power scanning
+   staying on for foreground scans with a non-zero betweenScanPeriod
+   (#555, David G. Young)
+
+
 ### 2.12 / 2017-08-07
 
 Enhancements:

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -157,7 +157,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             return;
         }
         List<ScanFilter> filters = new ArrayList<ScanFilter>();
-        ScanSettings settings;
+        ScanSettings settings = null;
 
         if (!mMainScanCycleActive) {
             // Only scan between cycles if the between can cycle time > 6 seconds.  A shorter low
@@ -170,14 +170,16 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                         mBeaconManager.getBeaconParsers());
             }
             else {
-                LogManager.d(TAG, "not scanning between cycles because the between scan cycle is too short.");
+                LogManager.d(TAG, "aborting scan between cycles because the between scan cycle is too short.");
             }
         } else {
             LogManager.d(TAG, "starting non-filtered scan in SCAN_MODE_LOW_LATENCY");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();
         }
 
-        postStartLeScan(filters, settings);
+        if (settings != null) {
+            postStartLeScan(filters, settings);
+        }
     }
 
     @Override

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -159,11 +159,19 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
         List<ScanFilter> filters = new ArrayList<ScanFilter>();
         ScanSettings settings;
 
-        if (mBackgroundFlag && !mMainScanCycleActive) {
-            LogManager.d(TAG, "starting filtered scan in SCAN_MODE_LOW_POWER");
-            settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
-            filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
-                    mBeaconManager.getBeaconParsers());
+        if (!mMainScanCycleActive) {
+            // Only scan between cycles if the between can cycle time > 6 seconds.  A shorter low
+            // power scan is unlikely to be useful, and might trigger a "scanning too frequently"
+            // error on Android N.
+            if (mBetweenScanPeriod > 6000l) {
+                LogManager.d(TAG, "starting filtered scan in SCAN_MODE_LOW_POWER");
+                settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
+                filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
+                        mBeaconManager.getBeaconParsers());
+            }
+            else {
+                LogManager.d(TAG, "not scanning between cycles because the between scan cycle is too short.");
+            }
         } else {
             LogManager.d(TAG, "starting non-filtered scan in SCAN_MODE_LOW_LATENCY");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();


### PR DESCRIPTION
This fixes "Scanning too frequently" error with non-zero betweenScanPeriod and scanPeriod+betweenScanPeriod < 6000, and full-power scanning  staying on for foreground scans with a non-zero betweenScanPeriod.

See here for more details about the problem:  https://github.com/AltBeacon/android-beacon-library/issues/554#issuecomment-321019248