### PR TITLE
Prevent scanning being left on after unbind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Development
+
+Bug Fixes:
+- Turn off scanning after unbind, which was previously left on forever in some cases.
+  (#569, David G. Young)
+
 ### 2.12.1 / 2017-08-16
 
 Bug Fixes:


### PR DESCRIPTION
This resolves a case of scans being left on (forever) after unbind is called on the BeaconManager as reported in #567.

The problem was that scanning may not be stopped at the end of a scan cycle (for the case of avoiding too many scans per minute on Android 7+, or for keeping scans going because multiple packet detections are available.)  This addresses that by setting a flag if scanning is left on for one of these cases and then explicitly stopping it at the end of the cycle.

A test run that shows this in operation is shown in the log sequence below.  The fix is triggered on the line that says "Stopping scanning previously left on".

This test run used the reference app with this modification in the application class:

```
        Log.d(TAG, "Starting scanning for 20 seconds");

          beaconManager.bind(new BeaconConsumer() {
              @Override
              public void onBeaconServiceConnect() {
                  try {
                      Log.d(TAG, "Connected");
                      beaconManager.startRangingBeaconsInRegion(BEACON_REGION);
                      final Handler handler = new Handler();
                      final BeaconConsumer consumer = this;
                      handler.postDelayed(new Runnable() {
                          @Override
                          public void run() {
                              Log.d(TAG, "Unbinding after 20 seconds!  Will scans be left on?");
                              beaconManager.unbind(consumer);
                          }
                      }, 20000);
                  } catch (RemoteException e) {
                      e.printStackTrace();
                  }
              }

              @Override
              public Context getApplicationContext() {
                  return BeaconReferenceApplication.this.getApplicationContext();
              }

              @Override
              public void unbindService(ServiceConnection connection) {
                  BeaconReferenceApplication.this.unbindService(connection);
              }

              @Override
              public boolean bindService(Intent intent, ServiceConnection connection, int mode) {
                  return BeaconReferenceApplication.this.bindService(intent, connection, mode);
              }
          });

```

```
08-24 18:08:12.210 30230 30230 D BeaconReferenceApp: Starting scanning for 20 seconds
08-24 18:08:12.212 30230 30230 D BeaconManager: This consumer is not bound.  Binding now: org.altbeacon.beaconreference.BeaconReferenceApplication$1@c71b46e
08-24 18:08:12.347 30230 30230 I CycledLeScanner: This is Android 5.0.  We are using new scanning APIs
08-24 18:08:12.459 30230 30230 D BeaconReferenceApp: Connected
08-24 18:08:12.525 30230 30230 D CycledLeScanner: start called
08-24 18:08:12.527 30230 30230 D CycledLeScanner: starting a new scan cycle
08-24 18:08:12.528 30230 30230 D CycledLeScanner: starting a new bluetooth le scan
...
08-24 18:08:32.444 30230 30230 D CycledLeScannerForLollipop: got record
08-24 18:08:32.461 30230 30230 D BeaconReferenceApp: Unbinding after 20 seconds!  Will scans be left on?
08-24 18:08:32.478 30230 30230 D CycledLeScanner: stop called
08-24 18:08:32.478 30230 30230 D CycledLeScanner: disabling scan
08-24 18:08:32.481 30230 30230 D CycledLeScanner: Done with scan cycle
08-24 18:08:32.482 30230 30244 D CycledLeScannerForLollipop: Stopping LE scan on scan handler
08-24 18:08:32.492 30230 30230 D CycledLeScanner: Scanning disabled. 
08-24 18:08:32.492 30230 30230 D CycledLeScanner: cancel wakeup alarm: PendingIntent{3ef0da9: android.os.BinderProxy@ca87f2e}
08-24 18:08:32.496 30230 30230 D CycledLeScanner: Set a wakeup alarm to go off in 9223372036787404974 ms: PendingIntent{3ef0da9: android.os.BinderProxy@ca87f2e}
08-24 18:08:32.497 30230 30230 D CycledLeScanner: Stopping scanning previously left on.
08-24 18:08:32.499 30230 30230 D CycledLeScanner: stopping bluetooth le scan
08-24 18:08:32.499 30230 30230 D CycledLeScannerForLollipop: Stopping scan
08-24 18:08:32.501 30230 30230 D CycledLeScanner: Destroying
08-24 18:08:32.502 30230 30244 D CycledLeScannerForLollipop: Stopping LE scan on scan handler
08-24 18:08:32.505 30230 30244 D CycledLeScanner: Quitting scan thread
```