### PR TITLE
Suppress file not found on scan state deserialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Development
+
+Bug Fixes:
+ - Suppress error log on ScanState deserialization if file does not exist yet.
+   (#570, David G. Young)
+
+
 ### 2.12.1 / 2017-08-16
 
 Bug Fixes:

--- a/src/main/java/org/altbeacon/beacon/service/ScanState.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanState.java
@@ -13,6 +13,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
+import java.io.FileNotFoundException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -143,8 +144,10 @@ public class ScanState implements Serializable {
                 objectInputStream = new ObjectInputStream(inputStream);
                 scanState = (ScanState) objectInputStream.readObject();
                 scanState.mContext = context;
-                ;
-            } catch (IOException | ClassNotFoundException | ClassCastException e) {
+            } catch (FileNotFoundException fnfe) {
+                LogManager.w(TAG, "Serialized ScanState does not exist.  This may be normal on first run.");
+            }
+            catch (IOException | ClassNotFoundException | ClassCastException e) {
                 if (e instanceof InvalidClassException) {
                     LogManager.d(TAG, "Serialized ScanState has wrong class. Just ignoring saved state...");
                 }


### PR DESCRIPTION
Fixes #568 showing an ugly stack trace during normal operations on first run of an app when the serialization file does not exist yet.