### PR TITLE
Fix stack overflow caused by scanPeriod of 0s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Development
+
+Bug Fixes:
+
+- Fix stack overflow caused by scan period of zero seconds, caused by 2.12 upgrade of existing
+  apps.  (#572, David G. Young)
+
 ### 2.12.1 / 2017-08-16
 
 Bug Fixes:

--- a/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -171,8 +171,7 @@ public class ScanJob extends JobService {
             mScanHelper.getCycledScanner().stop();
             return false;
         }
-        // to test
-        // delete file in data/data/org.altbeacon.beaconreference/files/android-beacon-library-scan-state
+
         if (mScanHelper.getRangedRegionState().size() > 0 || mScanHelper.getMonitoringStatus().regions().size() > 0) {
             mScanHelper.getCycledScanner().start();
             return true;


### PR DESCRIPTION
When upgrading an existing app to 2.12 the ScanState serialization file would not yet exist.  Then when the app ran for the first time, it would find a missing file when deserializing it, yielding a scan period of 0.  This would then cause a stackoverflow constantly stopping and starting scans.  This was reported in #571.

The fix is to check if the scan period is zero and if so, immediately quit the scan job.  A test showing the fix works is in the log below.

```
$ adb logcat | grep ScanJob
08-27 16:07:42.219  1125  1125 I ActivityManager: Start proc 15083:org.altbeacon.beaconreference/u0a236 for service org.altbeacon.beaconreference/org.altbeacon.beacon.service.ScanJob
08-27 16:07:42.631 15083 15083 I ScanJob : Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@608a65e
08-27 16:07:42.638 15083 15083 D ScanJob : Processing 0 queued scan resuilts
08-27 16:07:42.638 15083 15083 D ScanJob : Done processing queued scan resuilts
08-27 16:07:42.638 15083 15083 I ScanJob : scanJob version 2.12.1-2-gd170b8c-SNAPSHOT is starting up on the main process
08-27 16:07:42.679 15083 15083 E ScanState: 	at org.altbeacon.beacon.service.ScanJob.restartScanning(ScanJob.java:150)
08-27 16:07:42.679 15083 15083 E ScanState: 	at org.altbeacon.beacon.service.ScanJob.startScanning(ScanJob.java:200)
08-27 16:07:42.679 15083 15083 E ScanState: 	at org.altbeacon.beacon.service.ScanJob.onStartJob(ScanJob.java:77)
08-27 16:07:42.806 15083 15083 W ScanJob : Starting scan with scan period of zero.  Exiting ScanJob.
```