### PR TITLE
Fix ConcurrentModificationException starting passive scan on Android 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Development
+
+Buf Fixes:
+ - Fix ConcurrentModificationException crashing app on Android 8 when monitored regions are
+   changed at the same time the app shifts from active scanning to passive scanning. 
+   (#578, David G. Young)
+
 ### 2.12.2 / 2017-08-31
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.12.1...2.12.2)

--- a/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -17,6 +17,8 @@ import org.altbeacon.beacon.Region;
 import org.altbeacon.beacon.distance.ModelSpecificDistanceCalculator;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.utils.ProcessUtils;
+
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -103,7 +105,9 @@ public class ScanJob extends JobService {
     private void startPassiveScanIfNeeded() {
         LogManager.d(TAG, "Checking to see if we need to start a passive scan");
         boolean insideAnyRegion = false;
-        for (Region region : mScanState.getMonitoringStatus().regions()) {
+        // Clone the collection before iterating to prevent ConcurrentModificationException per #577
+        List<Region> regions = new ArrayList<>(mScanState.getMonitoringStatus().regions());
+        for (Region region : regions) {
             RegionMonitoringState state = mScanState.getMonitoringStatus().stateOf(region);
             if (state != null && state.getInside()) {
                 insideAnyRegion = true;


### PR DESCRIPTION
As described in #577, in some cases a ConcurrentModificationException will cause an app using the library to crash if it modifies the monitored regions at the same time the app begins a passive scan.  This change fixes that. 