### PR TITLE
Fix CME in ModelSpecificDistanceCalculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### Development
 
 Bug Fixes:
- - Fix ConcurrentModifictionExceptions starting ScanJobs.  (#584, David G. Young)
-
+ - Fix ConcurrentModifictionExceptions starting ScanJobs.  (#584, #588, David G. Young)
+ - Fix NullPointerException when BluetoothLeScanner cannot be obtained.
+   (#583, David G. Young)
 ### 2.12.2 / 2017-08-31
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.12.1...2.12.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Development
+
+Bug Fixes:
+ - Fix ConcurrentModifictionExceptions starting ScanJobs.  (#584, David G. Young)
+
 ### 2.12.2 / 2017-08-31
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.12.1...2.12.2)

--- a/src/main/java/org/altbeacon/beacon/distance/ModelSpecificDistanceCalculator.java
+++ b/src/main/java/org/altbeacon/beacon/distance/ModelSpecificDistanceCalculator.java
@@ -269,7 +269,7 @@ public class ModelSpecificDistanceCalculator implements DistanceCalculator {
     }
 
     private void buildModelMap(String jsonString) throws JSONException {
-        mModelMap = new HashMap<AndroidModel, DistanceCalculator>();
+        HashMap<AndroidModel, DistanceCalculator> map = new HashMap<AndroidModel, DistanceCalculator>();
         JSONObject jsonObject = new JSONObject(jsonString);
         JSONArray array = jsonObject.getJSONArray("models");
         for (int i = 0; i < array.length(); i++) {
@@ -290,19 +290,20 @@ public class ModelSpecificDistanceCalculator implements DistanceCalculator {
                     new CurveFittedDistanceCalculator(coefficient1,coefficient2,coefficient3);
 
             AndroidModel androidModel = new AndroidModel(version, buildNumber, model, manufacturer);
-            mModelMap.put(androidModel, distanceCalculator);
+            map.put(androidModel, distanceCalculator);
             if (defaultFlag) {
                 mDefaultModel = androidModel;
             }
         }
+        mModelMap = map;
     }
 
     private void loadDefaultModelMap() {
-        mModelMap = new HashMap<AndroidModel, DistanceCalculator>();
         try {
             buildModelMap(stringFromFilePath(CONFIG_FILE));
         }
         catch (Exception e) {
+            mModelMap = new HashMap<AndroidModel, DistanceCalculator>();
             LogManager.e(e, TAG, "Cannot build model distance calculations");
         }
     }

--- a/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
+++ b/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -141,7 +142,7 @@ public class MonitoringStatus {
 
     private void restoreOrInitializeMonitoringStatus() {
         long millisSinceLastMonitor = System.currentTimeMillis() - getLastMonitoringStatusUpdateTime();
-        mRegionsStatesMap = new HashMap<Region, RegionMonitoringState>();
+        mRegionsStatesMap = new ConcurrentHashMap<Region, RegionMonitoringState>();
         if (!mStatePreservationIsOn) {
             LogManager.d(TAG, "Not restoring monitoring state because persistence is disabled");
         }
@@ -179,10 +180,17 @@ public class MonitoringStatus {
             try {
                 outputStream = mContext.openFileOutput(STATUS_PRESERVATION_FILE_NAME, MODE_PRIVATE);
                 objectOutputStream = new ObjectOutputStream(outputStream);
-                objectOutputStream.writeObject(getRegionsStateMap());
-
+                Map<Region,RegionMonitoringState> map = getRegionsStateMap();
+                // Must convert ConcurrentHashMap to HashMap becasue attempting to serialize
+                // ConcurrentHashMap throws a java.io.NotSerializableException
+                HashMap<Region,RegionMonitoringState> serializableMap = new HashMap<Region,RegionMonitoringState>();
+                for (Region region : map.keySet()) {
+                    serializableMap.put(region, map.get(region));
+                }
+                objectOutputStream.writeObject(serializableMap);
             } catch (IOException e) {
-                LogManager.e(TAG, "Error while saving monitored region states to file. %s ", e.getMessage());
+                LogManager.e(TAG, "Error while saving monitored region states to file ", e);
+                e.printStackTrace(System.err);
             } finally {
                 if (null != outputStream) {
                     try {

--- a/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -6,6 +6,7 @@ import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
@@ -185,7 +186,10 @@ class ScanHelper {
             } else if (!bluetoothAdapter.isEnabled()) {
                 LogManager.w(TAG, "BluetoothAdapter is not enabled");
             } else {
-                bluetoothAdapter.getBluetoothLeScanner().stopScan(getScanCallbackIntent());
+               BluetoothLeScanner scanner =  bluetoothAdapter.getBluetoothLeScanner();
+               if (scanner != null) {
+                   scanner.stopScan(getScanCallbackIntent());
+               }
             }
         } catch (SecurityException e) {
             LogManager.e(TAG, "SecurityException stopping Android O background scanner");

--- a/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.util.Log;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.Region;
@@ -30,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 18)
 public class MonitoringStatusTest {
+    private static final String TAG = MonitoringStatusTest.class.getSimpleName();
     @Before
     public void before() {
         org.robolectric.shadows.ShadowLog.stream = System.err;


### PR DESCRIPTION
Simple fix to address the ConcurrentModificationException long reported in #56, and once thought fixed.  This change avoids another case by writing the class' instance of modell map in an atomic way.