### PR TITLE
Fix ConcurrentModificationException on RegionState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### Development
 
 Bug Fixes:
- - Fix ConcurrentModifictionExceptions starting ScanJobs.  (#584, #588 David G. Young)
-
+ - Fix ConcurrentModifictionExceptions starting ScanJobs.  (#584, #588, David G. Young)
+ - Fix NullPointerException when BluetoothLeScanner cannot be obtained.
+   (#583, David G. Young)
 ### 2.12.2 / 2017-08-31
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.12.1...2.12.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Development
 
 Bug Fixes:
- - Fix ConcurrentModifictionExceptions starting ScanJobs.  (#584, David G. Young)
+ - Fix ConcurrentModifictionExceptions starting ScanJobs.  (#584, #588 David G. Young)
 
 ### 2.12.2 / 2017-08-31
 

--- a/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
+++ b/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
@@ -15,11 +15,11 @@ import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -141,7 +141,8 @@ public class MonitoringStatus {
 
     private void restoreOrInitializeMonitoringStatus() {
         long millisSinceLastMonitor = System.currentTimeMillis() - getLastMonitoringStatusUpdateTime();
-        mRegionsStatesMap = new HashMap<Region, RegionMonitoringState>();
+        mRegionsStatesMap = new ConcurrentHashMap<Region, RegionMonitoringState>() {
+        };
         if (!mStatePreservationIsOn) {
             LogManager.d(TAG, "Not restoring monitoring state because persistence is disabled");
         }

--- a/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -6,6 +6,7 @@ import android.app.PendingIntent;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.bluetooth.BluetoothManager;
+import android.bluetooth.le.BluetoothLeScanner;
 import android.bluetooth.le.ScanFilter;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
@@ -185,7 +186,10 @@ class ScanHelper {
             } else if (!bluetoothAdapter.isEnabled()) {
                 LogManager.w(TAG, "BluetoothAdapter is not enabled");
             } else {
-                bluetoothAdapter.getBluetoothLeScanner().stopScan(getScanCallbackIntent());
+               BluetoothLeScanner scanner =  bluetoothAdapter.getBluetoothLeScanner();
+               if (scanner != null) {
+                   scanner.stopScan(getScanCallbackIntent());
+               }
             }
         } catch (SecurityException e) {
             LogManager.e(TAG, "SecurityException stopping Android O background scanner");

--- a/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
@@ -4,6 +4,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.AsyncTask;
 import android.os.Build;
+import android.util.Log;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.Region;
@@ -30,6 +31,7 @@ import static org.junit.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 18)
 public class MonitoringStatusTest {
+    private static final String TAG = MonitoringStatusTest.class.getSimpleName();
     @Before
     public void before() {
         org.robolectric.shadows.ShadowLog.stream = System.err;


### PR DESCRIPTION
Apps that dynamically change regions frequently are apt to get a ConcurrentModificationException when ScanJobs serialize these monitored regions.   This change fixes that by storing the regions in a ConcurrentHashMap.