### PR TITLE
Continuous Scanning While in Foreground on Android 8

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -7,11 +7,9 @@ import android.bluetooth.le.ScanRecord;
 import android.bluetooth.le.ScanResult;
 import android.os.Build;
 import android.os.Handler;
-import android.support.annotation.NonNull;
 
 import org.altbeacon.beacon.Beacon;
 import org.altbeacon.beacon.BeaconManager;
-import org.altbeacon.beacon.BeaconLocalBroadcastProcessor;
 import org.altbeacon.beacon.BuildConfig;
 import org.altbeacon.beacon.Region;
 import org.altbeacon.beacon.distance.ModelSpecificDistanceCalculator;
@@ -43,7 +41,7 @@ public class ScanJob extends JobService {
         a second immediate scan job to kick off when scanning gets started or settings changed.
         Once the periodic one gets run, the immediate is cancelled.
      */
-    public static final int IMMMEDIATE_SCAN_JOB_ID = 2;
+    public static final int IMMEDIATE_SCAN_JOB_ID = 2;
 
     private ScanState mScanState;
     private Handler mStopHandler = new Handler();
@@ -53,8 +51,8 @@ public class ScanJob extends JobService {
     @Override
     public boolean onStartJob(final JobParameters jobParameters) {
         mScanHelper = new ScanHelper(this);
-        if (jobParameters.getJobId() == IMMMEDIATE_SCAN_JOB_ID) {
-            LogManager.i(TAG, "Running immdiate scan job: instance is "+this);
+        if (jobParameters.getJobId() == IMMEDIATE_SCAN_JOB_ID) {
+            LogManager.i(TAG, "Running immediate scan job: instance is "+this);
         }
         else {
             LogManager.i(TAG, "Running periodic scan job: instance is "+this);
@@ -85,13 +83,19 @@ public class ScanJob extends JobService {
             mStopHandler.postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    LogManager.i(TAG, "Scan job runtime expired");
+                    LogManager.i(TAG, "Scan job runtime expired: " + ScanJob.this);
                     stopScanning();
                     mScanState.save();
-
-                    startPassiveScanIfNeeded();
-
                     ScanJob.this.jobFinished(jobParameters , false);
+
+                    // need to execute this after the current block or Android stops this job prematurely
+                    mStopHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            scheduleNextScan();
+                        }
+                    });
+
                 }
             }, mScanState.getScanJobRuntimeMillis());
         }
@@ -100,6 +104,16 @@ public class ScanJob extends JobService {
             ScanJob.this.jobFinished(jobParameters , false);
         }
         return true;
+    }
+
+    private void scheduleNextScan(){
+        if(!mScanState.getBackgroundMode()){
+            // immediately reschedule scan if running in foreground
+            LogManager.d(TAG, "In foreground mode, schedule next scan");
+            ScanJobScheduler.getInstance().forceScheduleNextScan(ScanJob.this);
+        } else {
+            startPassiveScanIfNeeded();
+        }
     }
 
     private void startPassiveScanIfNeeded() {
@@ -130,15 +144,16 @@ public class ScanJob extends JobService {
     @Override
     public boolean onStopJob(JobParameters params) {
         if (params.getJobId() == PERIODIC_SCAN_JOB_ID) {
-            LogManager.i(TAG, "onStopJob called for periodic scan");
+            LogManager.i(TAG, "onStopJob called for periodic scan " + this);
         }
         else {
-            LogManager.i(TAG, "onStopJob called for immediate scan");
+            LogManager.i(TAG, "onStopJob called for immediate scan " + this);
         }
         // Cancel the stop timer.  The OS is stopping prematurely
         mStopHandler.removeCallbacksAndMessages(null);
         stopScanning();
         startPassiveScanIfNeeded();
+
         return false;
     }
 


### PR DESCRIPTION
When the library is in foreground mode, and the job expires, immediately schedule the next job.  This should give virtually constant scanning when in the foreground, matching behavior of using the BeaconService before Android O.

Ref: https://github.com/AltBeacon/android-beacon-library/issues/605

Tested on Nexus 5X with Android 7/8
Also passed unit tests in gradle build.