### PR TITLE
Preserve RSSI expiration  on ranged beacon commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Bug Fixes:
  - Fix performance problems when using identifiers 3-15 bytes caused by
    Identifier#toHexString(). (#615, David G. Young)
+ - Fix regression with `RunningAverageRssiFilter.setSampleExpirationMilliseconds`
+   being overwritten when committing ranged beacon measurements. (#629, Aaron Kromer)
 
 ### 2.12.3 / 2017-10-14
 

--- a/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -45,7 +45,6 @@ public class RangedBeacon implements Serializable {
 
     // Done at the end of each cycle before data are sent to the client
     public void commitMeasurements() {
-        RunningAverageRssiFilter.setSampleExpirationMilliseconds(sampleExpirationMilliseconds);
          if (!getFilter().noMeasurementsAvailable()) {
              double runningAverage = getFilter().calculateRssi();
              mBeacon.setRunningAverageRssi(runningAverage);

--- a/src/test/java/org/altbeacon/beacon/service/RunningAverageRssiFilterTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/RunningAverageRssiFilterTest.java
@@ -29,6 +29,21 @@ public class RunningAverageRssiFilterTest {
     }
 
     @Test
+    public void regressionCheckRangedBeaconCommitDoesNotOverrideSampleExpirationMilliseconds() {
+        RangedBeacon.setSampleExpirationMilliseconds(20000);
+        RunningAverageRssiFilter.setSampleExpirationMilliseconds(20000);
+        Beacon beacon = new Beacon.Builder().setId1("1").build();
+        RangedBeacon rb = new RangedBeacon(beacon);
+        RunningAverageRssiFilter.setSampleExpirationMilliseconds(33l);
+        rb.commitMeasurements();
+        assertEquals(
+                "RunningAverageRssiFilter sampleExprirationMilliseconds should not be altered by committing RangedBeacon",
+                33l,
+                RunningAverageRssiFilter.getSampleExpirationMilliseconds()
+        );
+    }
+
+    @Test
     public void legacySetSampleExpirationMillisecondsWorksText() {
         RangedBeacon.setSampleExpirationMilliseconds(20000);
         RunningAverageRssiFilter.setSampleExpirationMilliseconds(20000);


### PR DESCRIPTION
This fixes #627 which is a regression of AltBeacon/android-beacon-library#523 (AltBeacon/android-beacon-library-reference#30). It was introduced in commit f084042efa3264ba (PR AltBeacon/android-beacon-library#484) where the `RunningAverageRssiFilter` has it's value constantly reset after every cycle in [`RangedBeacon#commitMeasurements`](https://github.com/AltBeacon/android-beacon-library/commit/f084042efa3264ba673814eec88ce591f1ac66df#diff-65311818bc092d4192549ca6a7932a8aR50).