### PR TITLE
Allow scans with screen off on Android 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Development
+
+Bug Fixes:
+ - Allow scans with screen off on Android 8.1 (#637, David G. Young)
+
 ### 2.13.4 / 2017-12-16
 
 Bug Fixes:

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -176,6 +176,12 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
         } else {
             LogManager.d(TAG, "starting non-filtered scan in SCAN_MODE_LOW_LATENCY");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();
+            // We create wildcard scan filters that match any advertisement so that we can detect
+            // beacons in foreground mode even if the screen is off.  This is a necessary workaround
+            // for a change in Android 8.1 that blocks scan results when the screen is off unless
+            // there is a scan filter associatd with the scan.  Prior to 8.1, filters could just be
+            // left null.  The wildcard filter matches everything.
+            filters = new ScanFilterUtils().createWildcardScanFilters();
         }
 
         if (settings != null) {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/ScanFilterUtils.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/ScanFilterUtils.java
@@ -26,6 +26,13 @@ public class ScanFilterUtils {
         public byte[] mask;
     }
 
+    public List<ScanFilter> createWildcardScanFilters() {
+        List<ScanFilter> scanFilters = new ArrayList<ScanFilter>();
+        ScanFilter.Builder builder = new ScanFilter.Builder();
+        scanFilters.add(builder.build());
+        return scanFilters;
+    }
+
     public List<ScanFilterData> createScanFilterDataForBeaconParser(BeaconParser beaconParser) {
         ArrayList<ScanFilterData> scanFilters = new ArrayList<ScanFilterData>();
         for (int manufacturer : beaconParser.getHardwareAssistManufacturers()) {


### PR DESCRIPTION
Android 8.1 now blocks scans with the screen off unless there is an associated ScanFilter.  This change adds an empty ScanFilter that matches anything so that results are still returned on Android 8.1 in these conditions.  This addresses #633

I have not tested this on an Android 8.1 device yet as I do not have one handy.  I have only verified that the scans still work with this wildcard filter added on a pre-8.1 device.