### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Bug Fixes:
  - Allow scans with screen off on Android 8.1 (#637, David G. Young)
 
-### 2.13.4 / 2017-12-16
+### 2.12.4 / 2017-12-16
 
 Bug Fixes:
  - Fix performance problems when using identifiers 3-15 bytes caused by


### PR DESCRIPTION
Change 2.13.4 to 2.12.4, which is the version that it actually appears to be.

Hey y'all, so I just spent a while confused about adding 2.13.4 to my project and it didn't seem to exist. Since the previous project version in the CHANGELOG is 2.12.4 are you sure that you didn't mean 2.12.4? :)