### PR TITLE
Configurable scan job ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Development
 
-Bug Fixes:
+Enhancements:
+ - Allow configuring job ids (#645, David G. Young)
+
+ Bug Fixes:
  - Allow scans with screen off on Android 8.1 (#637, David G. Young)
 
 ### 2.13.4 / 2017-12-16

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -30,8 +30,8 @@
 
         <service android:name=".service.ScanJob"
                 android:permission="android.permission.BIND_JOB_SERVICE" >
-            <meta-data android:name="immmediateScanJobId" android:value="208352937" />
-            <meta-data android:name="periodicScanJobId" android:value="208352938" />
+            <meta-data android:name="immmediateScanJobId" android:value="208352939" />
+            <meta-data android:name="periodicScanJobId" android:value="208352940" />
 
         </service>
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -32,7 +32,6 @@
                 android:permission="android.permission.BIND_JOB_SERVICE" >
             <meta-data android:name="immmediateScanJobId" android:value="208352939" />
             <meta-data android:name="periodicScanJobId" android:value="208352940" />
-
         </service>
 
     </application>

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -29,7 +29,12 @@
             />
 
         <service android:name=".service.ScanJob"
-                android:permission="android.permission.BIND_JOB_SERVICE" />
+                android:permission="android.permission.BIND_JOB_SERVICE" >
+            <meta-data android:name="immmediateScanJobId" android:value="208352937" />
+            <meta-data android:name="periodicScanJobId" android:value="208352938" />
+
+        </service>
+
     </application>
 
 </manifest>

--- a/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -153,7 +153,7 @@ public class ScanJobScheduler {
                 // If the next time we want to scan is less than 50ms from the periodic scan cycle, then]
                 // we schedule it for that specific time.
                 LogManager.d(TAG, "Scheduling immediate ScanJob to run in "+millisToNextJobStart+" millis");
-                JobInfo immediateJob = new JobInfo.Builder(ScanJob.IMMEDIATE_SCAN_JOB_ID, new ComponentName(context, ScanJob.class))
+                JobInfo immediateJob = new JobInfo.Builder(ScanJob.getImmediateScanJobId(context), new ComponentName(context, ScanJob.class))
                         .setPersisted(true) // This makes it restart after reboot
                         .setExtras(new PersistableBundle())
                         .setMinimumLatency(millisToNextJobStart)
@@ -168,10 +168,10 @@ public class ScanJobScheduler {
         }
         else {
             LogManager.d(TAG, "Not scheduling an immediate scan because we are in background mode.   Cancelling existing immediate scan.");
-            jobScheduler.cancel(ScanJob.IMMEDIATE_SCAN_JOB_ID);
+            jobScheduler.cancel(ScanJob.getImmediateScanJobId(context));
         }
 
-        JobInfo.Builder periodicJobBuilder = new JobInfo.Builder(ScanJob.PERIODIC_SCAN_JOB_ID, new ComponentName(context, ScanJob.class))
+        JobInfo.Builder periodicJobBuilder = new JobInfo.Builder(ScanJob.getPeriodicScanJobId(context), new ComponentName(context, ScanJob.class))
                 .setPersisted(true) // This makes it restart after reboot
                 .setExtras(new PersistableBundle());
 


### PR DESCRIPTION
The Job Scheduler ScanJobs used in Android 8 has a hard-coded job id of 1 and 2.  Because this job id must be unique per application, this can cause collisions with other app job ids.  This changes the default job ids to be a high integer number, and declares them in AndroidManifest.xml:

```
        <service android:name=".service.ScanJob"
                android:permission="android.permission.BIND_JOB_SERVICE" >
            <meta-data android:name="immmediateScanJobId" android:value="208352939" />
            <meta-data android:name="periodicScanJobId" android:value="208352940" />
        </service>
```

These may be overridden in the app manifest as needed like this: 

```
        <service android:name="org.altbeacon.beacon.service.ScanJob">
            <meta-data android:name="immediateScanJobId" android:value="1000" tools:replace="android:value"/>
            <meta-data android:name="periodicScanJobId" android:value="1001" tools:replace="android:value"/>
        </service>
```

The job ids may also be changed programmatically with: 

```
        ScanJob.setOverridePeriodicScanJobId(100);
        ScanJob.setOverrideImmediateScanJobId(101);
```

However, for third party apps using the library the programmatic syntax should be avoided as it accesses a private API and is not guaranteed to be supported in future releases.

This resolves #582