### PR TITLE
Fix flawed logic on BeaconManager#isBound

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -484,7 +484,8 @@ public class BeaconManager {
         synchronized(consumers) {
             // Annotation doesn't guarantee we get a non-null, but raising an NPE here is excessive
             //noinspection ConstantConditions
-            return consumer != null && consumers.get(consumer) != null && (serviceMessenger != null);
+            return consumer != null && consumers.get(consumer) != null &&
+                    (mScheduledScanJobsEnabled || serviceMessenger != null);
         }
     }
 
@@ -495,7 +496,8 @@ public class BeaconManager {
      */
     public boolean isAnyConsumerBound() {
         synchronized(consumers) {
-            return consumers.isEmpty() && (serviceMessenger != null);
+            return !consumers.isEmpty() &&
+                    (mScheduledScanJobsEnabled || serviceMessenger != null);
         }
     }
 


### PR DESCRIPTION
This addresses the issue reported in #613 where isBound and isAnyConsumerBound don't work with schedule jobs (Android 8+ default).  This also reportedly caused trouble in #641.

This is a proposed replacement for pull request #600

@hashbrown  and @carlonzo, both of you proposed fixes for this problem, so any comments are welcome.