### PR TITLE
add warning about disabling scan jobs on Android 8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ### Development
 
 Enhancements:
+ - Add warnings about disabling scheduled scan jobs on Android 8+ (#674, David G. Young)
  - BeaconTransmitter advertisements may be configured as connectable (#683, Michael Harper)
-
+ 
 ### 2.13.1 / 2018-03-05
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.13.1...2.13)

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -548,6 +548,10 @@ public class BeaconManager {
      * otherwise beacon scans may be run only once every 15 minutes in the background, and no low
      * power scans may be performed between scanning cycles.
      *
+     * Setting this value to false will disable ScanJobs when the app is run on Android 8+, which
+     * can prohibit delivery of callbacks when the app is in the background unless the scanning
+     * process is running in a foreground service.
+     *
      * This method may only be called if bind() has not yet been called, otherwise an
      * `IllegalStateException` is thown.
      *
@@ -564,8 +568,13 @@ public class BeaconManager {
                     " availble prior to Android 5.0");
             return;
         }
+        if (enabled && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            LogManager.w(TAG, "Disabling ScanJobs on Android 8+ may disable delivery of "+
+                    "beacon callbacks in the background unless a foreground service is active.");
+        }
         mScheduledScanJobsEnabled = enabled;
     }
+    
     public boolean getScheduledScanJobsEnabled() {
         return mScheduledScanJobsEnabled;
     }


### PR DESCRIPTION
This is a documentation and LogCat warning change to address the concern in  #673 that calling `setEnableScheduledScanJobs(false)` can break functionality on Android 8+