### PR TITLE
Fix runtime crashes reported from the field.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Enhancements:
  - BeaconTransmitter advertisements may be configured as connectable (#683, Michael Harper)
 
+Bug Fixes:
+ - Fix crashes of BluetoothMedic caused by Bluetooth being turned off (#675, David g. Young) 
+
 ### 2.13.1 / 2018-03-05
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.13.1...2.13)


### PR DESCRIPTION
This is an attempt to resolve crashes on the BluetoothMedic reported with in #668 and #672 

Since these crashes were only reported remotely from field devices, steps to reproduce have not been confirmed and solutions are based only on theory -- they have not been verified to fix anything.