### PR TITLE
Add warning about setting short scan periods on Android 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Development
+
+Enhancements:
+ - Add warning about setting short scan periods on Android 8 (#677, David G. Young)
+
 ### 2.13.1 / 2018-03-05
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.13.1...2.13)

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -259,6 +259,11 @@ public class BeaconManager {
      */
     public void setBackgroundBetweenScanPeriod(long p) {
         backgroundBetweenScanPeriod = p;
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                backgroundBetweenScanPeriod < 15*60*1000 /* 15 min */) {
+            LogManager.w(TAG, "Setting a short backgroundBetweenScanPeriod has no effect on "+
+                    "Android 8+, which is limited to scanning every ~15 minutes");
+        }
     }
 
     /**


### PR DESCRIPTION
This addresses the issue reported in #671, where a developer was surprised that ranging callbacks did not come in when the backgroundBetweenScanPeriod was set to a short interval on Android 8+.  This change adds a warning in the logs saying that setting such a short scan period will not work.

This is not a fix, but will hopefully increase the visibility of this Android 8 limitation to users of the library.

