### PR TITLE
Adds connectable property to BeaconTransmitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 2.13.2 / 2018-05-08
+
+[Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.13.2...2.13.1)
+
+Enhancements:
+ - BeaconTransmitter advertisements may be configured as connectable (#683, Michael Harper)
+
 ### 2.13.1 / 2018-03-05
 
 [Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.13.1...2.13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,4 @@
-### 2.13.2 / 2018-05-08
-
-[Full Changelog](https://github.com/AltBeacon/android-beacon-library/compare/2.13.2...2.13.1)
+### Development
 
 Enhancements:
  - BeaconTransmitter advertisements may be configured as connectable (#683, Michael Harper)

--- a/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
@@ -1,21 +1,21 @@
 package org.altbeacon.beacon;
 
-import org.altbeacon.beacon.logging.LogManager;
-
 import android.annotation.TargetApi;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothManager;
-import java.nio.ByteOrder;
-import java.nio.ByteBuffer;
-import java.util.UUID;
 import android.bluetooth.le.AdvertiseCallback;
-import android.bluetooth.le.AdvertiseSettings;
 import android.bluetooth.le.AdvertiseData;
+import android.bluetooth.le.AdvertiseSettings;
 import android.bluetooth.le.BluetoothLeAdvertiser;
 import android.content.Context;
 import android.content.pm.PackageManager;
-
 import android.os.ParcelUuid;
+
+import org.altbeacon.beacon.logging.LogManager;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.UUID;
 
 /**
  * Provides a mechanism for transmitting as a beacon.   Requires Android 5.0
@@ -41,6 +41,7 @@ public class BeaconTransmitter {
     private AdvertiseCallback mAdvertisingClientCallback;
     private boolean mStarted;
     private AdvertiseCallback mAdvertiseCallback;
+    private boolean mConnectable = false;
 
     /**
      * Creates a new beacon transmitter capable of transmitting beacons with the format
@@ -125,6 +126,22 @@ public class BeaconTransmitter {
     }
 
     /**
+     * Whether the advertisement should indicate the device is connectable.
+     * @param connectable
+     */
+    public void setConnectable(boolean connectable) {
+        this.mConnectable = connectable;
+    }
+
+    /**
+     * @see #setConnectable(boolean)
+     * @return connectable
+     */
+    public boolean isConnectable() {
+        return mConnectable;
+    }
+
+    /**
      * Starts advertising with fields from the passed beacon
      * @param beacon
      */
@@ -191,7 +208,7 @@ public class BeaconTransmitter {
 
             settingsBuilder.setAdvertiseMode(mAdvertiseMode);
             settingsBuilder.setTxPowerLevel(mAdvertiseTxPowerLevel);
-            settingsBuilder.setConnectable(false);
+            settingsBuilder.setConnectable(mConnectable);
 
             mBluetoothLeAdvertiser.startAdvertising(settingsBuilder.build(), dataBuilder.build(), getAdvertiseCallback());
             LogManager.d(TAG, "Started advertisement with callback: %s", getAdvertiseCallback());

--- a/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
+++ b/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
@@ -2,26 +2,20 @@ package org.altbeacon.beacon.service;
 
 import android.annotation.TargetApi;
 import android.content.Context;
-import android.os.AsyncTask;
 import android.os.Build;
-import android.util.Log;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.Region;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.logging.Loggers;
-import org.altbeacon.beacon.service.scanner.CycledLeScanCallback;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
-import org.robolectric.util.ServiceController;
 
 import java.util.Collection;
-import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.junit.Assert.assertEquals;
 
@@ -88,13 +82,15 @@ public class MonitoringStatusTest {
     @Test
     public void allowsAccessToRegionsAfterRestore() throws Exception {
         Context context = ShadowApplication.getInstance().getApplicationContext();
+        BeaconManager beaconManager = BeaconManager.getInstanceForApplication(context);
+        MonitoringStatus.getInstanceForApplication(context).clear();
         MonitoringStatus monitoringStatus = new MonitoringStatus(context);
         for (int i = 0; i < 50; i++) {
             Region region = new Region(""+i, null, null, null);
             monitoringStatus.addRegion(region, null);
         }
         monitoringStatus.saveMonitoringStatusIfOn();
-        BeaconManager beaconManager = BeaconManager.getInstanceForApplication(context);
+        MonitoringStatus.getInstanceForApplication(context).restoreMonitoringStatus();
         Collection<Region> regions = beaconManager.getMonitoredRegions();
         assertEquals("beaconManager should return restored regions", 50, regions.size());
     }


### PR DESCRIPTION
Being able to set a beacon advertisement as "connectable" causes 3
additional bytes to be prepended to the advertisement PDU.

The value of these 3 bytes are: `0x02011a`.

They are:
1. PDU length (02)
2. PDU type (01)
3. Payload (1a)

These 3 bytes are present in an iBeacon advertisement on iOS. However,
they do not appear in the equivalent advertisement on Android using
`BeaconTransmitter` without setting the `AdvertiseSettings` to
"connectable."

Ref #141.