### PR TITLE
Use scan filters only with 8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,8 @@ allprojects {
 }
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.3'
 
     defaultConfig {
         // Unfortunately 'com.android.support:appcompat-v7:26.0.0'
@@ -69,7 +69,7 @@ android {
         // But since only 0.8% of Android devices have < SDK 14 as of Une 2017, this will become
         // the new min version for this library in order to target Android O
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName version
         consumerProguardFiles 'proguard-rules.pro'
@@ -102,7 +102,7 @@ configurations {
 
 dependencies {
     compile fileTree ( dir: 'libs', include: ['*.jar'] )
-    compile 'com.android.support:support-v4:26.0.0'
+    compile 'com.android.support:support-v4:27.0.0'
     compile 'com.android.support:support-annotations:26.0.0'
 
     testCompile('junit:junit:4.12') {

--- a/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -9,6 +9,7 @@ import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.ParcelUuid;
 import android.os.SystemClock;
 import android.support.annotation.MainThread;
@@ -183,7 +184,11 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             // for a change in Android 8.1 that blocks scan results when the screen is off unless
             // there is a scan filter associatd with the scan.  Prior to 8.1, filters could just be
             // left null.  The wildcard filter matches everything.
-            filters = new ScanFilterUtils().createWildcardScanFilters();
+            // We only add these filters on 8.1+ devices, because adding scan filters has been reported
+            // to cause scan failures on some Samsung devices with Android 5.x
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+                filters = new ScanFilterUtils().createWildcardScanFilters();
+            }
         }
 
         if (settings != null) {


### PR DESCRIPTION
Attempts to fix scan failures on older devices reported in #691 by modifying the change from #637 to only use scan filters on devices with Android 8.1+