### PR TITLE
Cancel schedule jobs after last consumer unbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Development
+
+Bug Fixes:
+ - Stop running scheduled jobs to do sscans after last consumer unbound. (#702, David G. Young)
+
 ### 2.15 / 2018-07-04
 
 Enhancements:

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -463,8 +463,10 @@ public class BeaconManager {
                     mBackgroundMode = false;
                     // If we are using scan jobs, we cancel the active scan job
                     if (mScheduledScanJobsEnabled) {
-                        // TODO: Cancel the active scan job.  Without this is keeps scanning as if
-                        // a consumer is bound.
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                            LogManager.i(TAG, "Cancelling scheduled jobs after unbind of last consumer.");
+                            ScanJobScheduler.getInstance().cancelSchedule(mContext);
+                        }
                     }
                 }
             }
@@ -975,7 +977,9 @@ public class BeaconManager {
     @TargetApi(18)
     private void applyChangesToServices(int type, Region region) throws RemoteException {
         if (mScheduledScanJobsEnabled) {
-            ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
+            }
             return;
         }
         if (serviceMessenger == null) {

--- a/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -92,6 +92,12 @@ public class ScanJobScheduler {
         applySettingsToScheduledJob(context, beaconManager, scanState);
     }
 
+    public void cancelSchedule(Context context) {
+        JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+        jobScheduler.cancel(ScanJob.getImmediateScanJobId(context));
+        jobScheduler.cancel(ScanJob.getPeriodicScanJobId(context));
+    }
+
     // This method appears to be never used, because it is only used by Android O APIs, which
     // must exist on another branch until the SDKs are released.
     public void scheduleAfterBackgroundWakeup(Context context, List<ScanResult> scanResults) {


### PR DESCRIPTION
Before this change, calling BeaconManager.unbind(...) would never stop scheduled scanning jobs if they were in use.  This fixes that so after the last consumer is unbound, all scheduled scan jobs will be cancelled.

Fixes #657