### PR TITLE
Fix crash parsing malformed Eddystone-URL packet 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Bug Fixes:
  - Fixes inability to detect on some 5.x Samsung Devices without scan filters. (#693, David G. Young)
  - Fix inverted logic for "disable ScanJob" warning (#700, Marcel Schnelle)
+ - Fix crash on scanning an Eddystone-URL packet with a negative-length URL. (#703, David G. Young)
 
 ### 2.14 / 2018-05-17
 

--- a/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -516,7 +516,13 @@ public class BeaconParser implements Serializable {
                         }
                         // If this is a variable length identifier, we truncate it to the size that
                         // is available in the packet
-                        Identifier identifier = Identifier.fromBytes(bytesToProcess, mIdentifierStartOffsets.get(i) + startByte, pduToParse.getEndIndex()+1, mIdentifierLittleEndianFlags.get(i));
+                        int start = mIdentifierStartOffsets.get(i) + startByte;
+                        int end = pduToParse.getEndIndex()+1;
+                        if (end <= start) {
+                            LogManager.d(TAG, "PDU is too short for identifer.  Packet is malformed");
+                            return null;
+                        }
+                        Identifier identifier = Identifier.fromBytes(bytesToProcess, start, end, mIdentifierLittleEndianFlags.get(i));
                         identifiers.add(identifier);
                     }
                     else if (endIndex > pduToParse.getEndIndex() && !mAllowPduOverflow) {

--- a/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
+++ b/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 
 @Config(sdk = 18)
 
@@ -156,6 +157,19 @@ public class GattBeaconTest {
         assertEquals("URL should be decompressed successfully", "https://goo.gl/hqBXE1", urlString);
     }
 
+
+    @Test
+    public void doesNotCrashOnMalformedEddystoneBeacon() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        LogManager.setLogger(Loggers.verboseLogger());
+        LogManager.setVerboseLoggingEnabled(true);
+        LogManager.d("GattBeaconTest", "Parsing malformed packet");
+        byte[] bytes = hexStringToByteArray("0201060303aafe0416aafe100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-20v");
+        LogManager.d("xxx", "------");
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        assertNull("GattBeacon should be null when not parsed successfully", gattBeacon);
+    }
 
 
 


### PR DESCRIPTION
This crash was reported in the field via @mharper  when a malformed Eddystone-URL packet was detected with a packet so short that the URL length would effectively be negative.  Because the library allows variable length Eddystone-URL identifiers, it did not have protections on a minimum length.

The fix is to enforce that the length must at least be 1, and to fail parsing the packet if it is not.

`06-13 07:50:53.081 788 829 E ScanHelper: Exception while parsing scan data 0201060303aafe0416aafe100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 from device null with parser s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-20v`

@mharper, this look good to you?

