### PR TITLE
Fix NPE on RangedBeacon per #638

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Development
 
 Bug Fixes:
- - Fix intermittent NPE on ranging beacons (#716, David G. Young)
+ - Fix intermittent NPE on ranging beacons (#716, Federico Bertoli, David G. Young)
 
 ### 2.15 / 2018-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Development
+
+Bug Fixes:
+ - Fix intermittent NPE on ranging beacons (#638, David G. Young)
+
 ### 2.15 / 2018-07-04
 
 Enhancements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Development
 
 Bug Fixes:
- - Fix intermittent NPE on ranging beacons (#638, David G. Young)
+ - Fix intermittent NPE on ranging beacons (#716, David G. Young)
 
 ### 2.15 / 2018-07-04
 

--- a/src/main/java/org/altbeacon/beacon/service/RangeState.java
+++ b/src/main/java/org/altbeacon/beacon/service/RangeState.java
@@ -71,23 +71,25 @@ public class RangeState implements Serializable {
         synchronized (mRangedBeacons) {
             for (Beacon beacon : mRangedBeacons.keySet()) {
                 RangedBeacon rangedBeacon = mRangedBeacons.get(beacon);
-                if (rangedBeacon.isTracked()) {
-                    rangedBeacon.commitMeasurements(); // calculates accuracy
-                    if (!rangedBeacon.noMeasurementsAvailable()) {
-                        finalizedBeacons.add(rangedBeacon.getBeacon());
+                if (rangedBeacon != null) {
+                    if (rangedBeacon.isTracked()) {
+                        rangedBeacon.commitMeasurements(); // calculates accuracy
+                        if (!rangedBeacon.noMeasurementsAvailable()) {
+                            finalizedBeacons.add(rangedBeacon.getBeacon());
+                        }
                     }
-                }
-                // If we still have useful measurements, keep it around but mark it as not
-                // tracked anymore so we don't pass it on as visible unless it is seen again
-                if (!rangedBeacon.noMeasurementsAvailable() == true) {
-                    //if TrackingCache is enabled, allow beacon to not receive
-                    //measurements for a certain amount of time
-                    if (!sUseTrackingCache || rangedBeacon.isExpired())
-                        rangedBeacon.setTracked(false);
-                    newRangedBeacons.put(beacon, rangedBeacon);
-                }
-                else {
-                    LogManager.d(TAG, "Dumping beacon from RangeState because it has no recent measurements.");
+                    // If we still have useful measurements, keep it around but mark it as not
+                    // tracked anymore so we don't pass it on as visible unless it is seen again
+                    if (!rangedBeacon.noMeasurementsAvailable() == true) {
+                        //if TrackingCache is enabled, allow beacon to not receive
+                        //measurements for a certain amount of time
+                        if (!sUseTrackingCache || rangedBeacon.isExpired())
+                            rangedBeacon.setTracked(false);
+                        newRangedBeacons.put(beacon, rangedBeacon);
+                    }
+                    else {
+                        LogManager.d(TAG, "Dumping beacon from RangeState because it has no recent measurements.");
+                    }
                 }
             }
             mRangedBeacons = newRangedBeacons;

--- a/src/main/java/org/altbeacon/beacon/service/RangeState.java
+++ b/src/main/java/org/altbeacon/beacon/service/RangeState.java
@@ -47,8 +47,8 @@ public class RangeState implements Serializable {
     }
 
     public void addBeacon(Beacon beacon) {
-        if (mRangedBeacons.containsKey(beacon)) {
-            RangedBeacon rangedBeacon = mRangedBeacons.get(beacon);
+        RangedBeacon rangedBeacon = mRangedBeacons.get(beacon);
+        if (rangedBeacon != null) {
             if (LogManager.isVerboseLoggingEnabled()) {
                 LogManager.d(TAG, "adding %s to existing range for: %s", beacon, rangedBeacon);
             }


### PR DESCRIPTION
This NPE probably happens in a race condition where the RangedBeacon is removed by another thread in the middle of the two step process to (1) check if the RangedBeacon is in the collection and (2) pull the RangedBeacon from the collection, causing a NPE in step 2.

This change fixes that problem by making it a one step process.