### PR TITLE
Fix Android 8 crashing apps on background monitoring/ranging data delivery

### DIFF
--- a/src/main/java/org/altbeacon/beacon/BeaconLocalBroadcastProcessor.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconLocalBroadcastProcessor.java
@@ -40,10 +40,10 @@ import java.util.Set;
  * This is used with ScanJob and supports delivering intents even under Android O background
  * restrictions preventing starting a new IntentService.
  *
- * It is not used with the BeaconService, as local broadcast intents cannot be deliverd across
- * different processes which the BeaconService supports.
+ * It is not used with the BeaconService, if running in a separate process, as local broadcast
+ * intents cannot be deliverd across different processes which the BeaconService supports.
  *
- * @see BeaconIntentProcessor for the equivalent use with BeaconService.
+ * @see BeaconIntentProcessor for the equivalent use with BeaconService in a separate process.
  **
  * Internal library class.  Do not use directly from outside the library
  *

--- a/src/main/java/org/altbeacon/beacon/service/Callback.java
+++ b/src/main/java/org/altbeacon/beacon/service/Callback.java
@@ -52,7 +52,7 @@ public class Callback implements Serializable {
      * @return false if it callback cannot be made
      */
     public boolean call(Context context, String dataName, Bundle data) {
-        boolean useLocalBroadcast = BeaconManager.getInstanceForApplication(context).getScheduledScanJobsEnabled();
+        boolean useLocalBroadcast = BeaconManager.getInstanceForApplication(context).isMainProcess();
         boolean success = false;
 
         if(useLocalBroadcast) {


### PR DESCRIPTION
Prior to this change, the library uses an IntentService to deliver ranging and monitoring callbacks from when the main BeaconService is used for scanning.  The problem is that starting this IntentService can be blocked by Android 8, crashing the app when it tries to deliver the callbacks with `java.lang.IllegalStateException: Not allowed to start service Intent` as described in #719.

Normally, this problem does not happen because on Android 8+, scheduled jobs are used to do scanning in the background instead of the `BeaconService`.  However, the library allows you to override this behavior and still use the `BeaconService` on Android 8+, a recommended configuration if you set it up to be  a foreground service so it is not killed by Android in the background.  However, at least in some cases where this is done, it appears that Android still blocks the usage of the `IntentService` to deliver the scanning results.  

This change fixes the above problem by default using the same local broadcast mechanism for delivering results, which will not be blocked by Android 8+.  With this change, the old IntentService mechanism will only be used if the BeaconService is running in a separate process, which requires something other than local broadcasts to deliver results.  

The logs below show the reference app running with a foreground service with this change, with log lines confirming local broadcasts are used to deliver monitoring results.

```
08-11 12:31:00.148 22887-22887/? I/BeaconService: beaconService version 2.15-2-g2305a30-SNAPSHOT is starting up on the main process
08-11 12:31:00.150 22887-22887/? D/BeaconLocalBroadcastProcessor: Register calls: global=1 instance=1
...
08-11 12:31:10.349 22887-22887/org.altbeacon.beaconreference D/RegionMonitoringState: We are newly outside the region because the lastSeenTime of 219003251 was 10120 seconds ago, and that is over the expiration duration of 10000
08-11 12:31:10.349 22887-22887/org.altbeacon.beaconreference D/MonitoringStatus: found a monitor that expired: id1: null id2: null id3: null
08-11 12:31:10.350 22887-22887/org.altbeacon.beaconreference D/Callback: attempting callback via local broadcast intent: org.altbeacon.beacon.monitor_notification
...
08-11 12:31:10.359 22887-22887/org.altbeacon.beaconreference D/IntentHandler: got monitoring data
08-11 12:31:10.360 22887-22887/org.altbeacon.beaconreference D/IntentHandler: Calling monitoring notifier: org.altbeacon.beaconreference.BeaconReferenceApplication@1e7d936
```