### PR TITLE
Catch of exception thrown by Android stopping scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Bug Fixes:
  - Stop running scheduled jobs to do sscans after last consumer unbound. (#702, David G. Young)
+ - Prevent crash caused by internal Android exception when stopping scanning (#724, David G. Young)
 
 ### 2.15 / 2018-07-04
 

--- a/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -196,6 +196,9 @@ class ScanHelper {
             }
         } catch (SecurityException e) {
             LogManager.e(TAG, "SecurityException stopping Android O background scanner");
+        } catch (RuntimeException e) {
+            // Needed to stop a crash caused by internal Android throw.  See issue #701
+            LogManager.e(TAG, "Unexpected runtime exception stopping Android O background scanner", e);
         }
     }
 


### PR DESCRIPTION
This is an attempt to fix #701.   I have not tested that this works, as there are no known ways to reproduce the problem.  It has only been seen in crash logs.