### PR TITLE
Fix duplicate raging/monitoring callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### Development
 
+- Prevent duplicate ranging/monitoring callbacks casued by bind/unbind with a service
+  (#745, David G. Young)
+
 ### 2.15.1 / 2018-09-01
 
  - Prevent crash caused by internal Android exception when stopping scanning (#724, David G. Young)

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -320,6 +320,9 @@ public class BeaconService extends Service {
             LogManager.w(TAG, "Not supported prior to API 18.");
             return;
         }
+        if (mBeaconNotificationProcessor != null) {
+            mBeaconNotificationProcessor.unregister();
+        }
         stopForeground(true);
         bluetoothCrashResolver.stop();
         LogManager.i(TAG, "onDestroy called.  stopping scanning");


### PR DESCRIPTION
These were caused by multiple NotificationProcessor registrations when binding and unbinding as described in #735 