### PR TITLE
Fix leaked NotificationProcessor in ScanJobsScheduler

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -96,6 +96,10 @@ public class ScanJobScheduler {
         JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
         jobScheduler.cancel(ScanJob.getImmediateScanJobId(context));
         jobScheduler.cancel(ScanJob.getPeriodicScanJobId(context));
+
+        if (mBeaconNotificationProcessor != null) {
+            mBeaconNotificationProcessor.unregister();
+        }
     }
 
     // This method appears to be never used, because it is only used by Android O APIs, which


### PR DESCRIPTION
This caused multiple `NotificationProcessor` registrations when binding and unbinding.

This PR and #745 will completely fix #735