### PR TITLE
Prevent OutOfMemoryError Crash on Android 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Development
 
+- Prevent infrequent out of memory crashes on Android 8+ (#750 Pappas Christodoulos, David G. Young)
 - Prevent duplicate ranging/monitoring callbacks casued by bind/unbind with a service
   (#748, Adrián Nieto Rodríguez, #745, David G. Young)
 

--- a/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -129,8 +129,9 @@ class ScanHelper {
             new ScanHelper.ScanProcessor(nonBeaconLeScanCallback).executeOnExecutor(mExecutor,
                     new ScanHelper.ScanData(device, rssi, scanRecord));
         } catch (RejectedExecutionException e) {
-
             LogManager.w(TAG, "Ignoring scan result because we cannot keep up.");
+        } catch (OutOfMemoryError e) {
+            LogManager.w(TAG, "Ignoring scan result because we cannot start a thread to keep up.");
         }
     }
 


### PR DESCRIPTION
The root cause of the crash is the inability to start a new thread needed to scan for beacons when an Intent-based scan returns results and launches the app in the background via a ScanJob.  This was reported in #589.

The fix is to simply catch the OutOfMemory error in two places where the thread is started, and log the error condition.  This will let the app try again on the next opportunity (probably the next ScanJob run 15 minutes later) to start a scan.

It's still unclear why this happens at all.  This should not be necessary.