### PR TITLE
Fix bug preventing callbacks after unbind/bind when using scan jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Development
+
+- Fix bug preventing callbacks after unbind/bind when using ScanJobs.  (#765, David G. Young)
+
 ### 2.15.2 / 2018-10-17
 
 - Prevent infrequent out of memory crashes on Android 8+ (#750 Pappas Christodoulos, David G. Young)

--- a/build.gradle
+++ b/build.gradle
@@ -102,8 +102,8 @@ configurations {
 
 dependencies {
     compile fileTree ( dir: 'libs', include: ['*.jar'] )
-    compile 'com.android.support:support-v4:28.0.0-rc02'
-    compile 'com.android.support:support-annotations:28.0.0-rc02'
+    compile 'com.android.support:support-v4:28.0.0'
+    compile 'com.android.support:support-annotations:28.0.0'
 
     testCompile 'com.google.android:android-test:4.1.1.4'
     testCompile('junit:junit:4.12') {

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -461,7 +461,9 @@ public class BeaconManager {
                 else {
                     consumer.unbindService(consumers.get(consumer).beaconServiceConnection);
                 }
+                LogManager.d(TAG, "Before unbind, consumer count is "+consumers.size());
                 consumers.remove(consumer);
+                LogManager.d(TAG, "After unbind, consumer count is "+consumers.size());
                 if (consumers.size() == 0) {
                     // If this is the last consumer to disconnect, the service will exit
                     // release the serviceMessenger.

--- a/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -66,8 +66,8 @@ public class ScanJobScheduler {
     private void ensureNotificationProcessorSetup(Context context) {
         if (mBeaconNotificationProcessor == null) {
             mBeaconNotificationProcessor = new BeaconLocalBroadcastProcessor(context);
-            mBeaconNotificationProcessor.register();
         }
+        mBeaconNotificationProcessor.register();
     }
 
     /**


### PR DESCRIPTION
This fixes a case where callbacks were not delivered after calling unbind/bind on the BeaconManager when using ScanJobs.