### PR TITLE
Make service stopping more reliable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Development
+
+- Make switching back and forth between a foreground service and scan jobs more reliable
+(#767, David G. Young)
+
 ### 2.15.2 / 2018-10-17
 
 - Prevent infrequent out of memory crashes on Android 8+ (#750 Pappas Christodoulos, David G. Young)

--- a/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -893,7 +893,9 @@ public class BeaconManager {
 
     protected void syncSettingsToService() {
         if (mScheduledScanJobsEnabled) {
-            ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
+            }
             return;
         }
         try {

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -306,9 +306,11 @@ public class BeaconService extends Service {
         return mMessenger.getBinder();
     }
 
+    // called when the last bound client calls unbind
     @Override
     public boolean onUnbind(Intent intent) {
-        LogManager.i(TAG, "unbinding");
+        LogManager.i(TAG, "unbinding so destroying self");
+        this.stopSelf();
         return false;
     }
 

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -310,6 +310,7 @@ public class BeaconService extends Service {
     @Override
     public boolean onUnbind(Intent intent) {
         LogManager.i(TAG, "unbinding so destroying self");
+        this.stopForeground(true);
         this.stopSelf();
         return false;
     }
@@ -325,7 +326,6 @@ public class BeaconService extends Service {
         if (mBeaconNotificationProcessor != null) {
             mBeaconNotificationProcessor.unregister();
         }
-        stopForeground(true);
         bluetoothCrashResolver.stop();
         LogManager.i(TAG, "onDestroy called.  stopping scanning");
         handler.removeCallbacksAndMessages(null);

--- a/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -166,6 +166,9 @@ public class ScanJob extends JobService {
 
     private void stopScanning() {
         mInitialized = false;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mScanHelper.stopAndroidOBackgroundScan();
+        }
         mScanHelper.getCycledScanner().stop();
         mScanHelper.getCycledScanner().destroy();
         LogManager.d(TAG, "Scanning stopped");


### PR DESCRIPTION
Several changes to make the library behave properly when starting and stopping a foreground service on Android O+, and properly switching back to scan jobs when the foreground service is not active.

* Add a stopSelf() call when the last consumer is unbound from the scanning service to attempt to make service destruction (and force stopping scanning) more reliable.  Call stopForeground() before the call to stopSelf() to prevent a crash.
* Stop intent based scanning whenever stopping the ScanJob, so it is not left on (potentially launching  Scan Jobs again on detection even when the BeaconService is active in the foreground).
