### PR TITLE
disable BluetoothCrashResolver if Android version is 5.0 or higher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Development
+
+ - Disable BluetoothCrashResolver on Android 5+ as a it is not helpful can can create log noise.
+   (#768, David G. Young)
+
 ### 2.15.2 / 2018-10-17
 
 - Prevent infrequent out of memory crashes on Android 8+ (#750 Pappas Christodoulos, David G. Young)

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -197,8 +197,10 @@ public class BeaconService extends Service {
     @MainThread
     @Override
     public void onCreate() {
-        bluetoothCrashResolver = new BluetoothCrashResolver(this);
-        bluetoothCrashResolver.start();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            bluetoothCrashResolver = new BluetoothCrashResolver(this);
+            bluetoothCrashResolver.start();
+        }
 
         mScanHelper = new ScanHelper(this);
         if (mScanHelper.getCycledScanner() == null) {


### PR DESCRIPTION
As reported in #760, some devices with Android 5.x will get stuck in crash recovery.  The BluetoothCrashResolver is only designed to help a problem known to be in 4.3.x and 4.4.x so there is no point in leaving it enabled on 5.x or higher.    This change disables it.
