### PR TITLE
Fix thread leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Prevent NPE on access CycledLEScanner after OOM on Android 8+.  (#766, David G. Young)
 - Prevent NPE on start scan. (#780, Adrián Nieto Rodríguez)
+- Fix thread leak leading to OOM Exceptions when using ScanJobs (#785, David G. Young)
 
 ### 2.15.2 / 2018-10-17
 

--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -335,6 +335,7 @@ public class BeaconService extends Service {
             mScanHelper.getCycledScanner().destroy();
         }
         mScanHelper.getMonitoringStatus().stopStatusPreservation();
+        mScanHelper.terminateThreads();
     }
 
     @Override

--- a/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -160,6 +160,7 @@ public class ScanJob extends JobService {
         mStopHandler.removeCallbacksAndMessages(null);
         stopScanning();
         startPassiveScanIfNeeded();
+        mScanHelper.terminateThreads();
 
         return false;
     }


### PR DESCRIPTION
This fixes the thread leak reported in #781 by terminating the ExecutorService threads used to parse beacon packets.  The thread termination now happens whenever the ScanJob or BeaconService is stopped.