### PR TITLE
Fix broken Samsung screen off scans on 8.1+ 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Development
 
+- Samsung screen-off scans on Android 8.1+ fixed.  (#798, David G. Young)
 - Fix bug preventing callbacks after unbind/bind when using ScanJobs.  (#765, David G. Young)
 - Prevent NPE on access CycledLEScanner after OOM on Android 8+.  (#766, David G. Young)
 - Make switching back and forth between a foreground service and scan jobs more reliable


### PR DESCRIPTION
As reported in #769, when the screen on the Samsung Galaxy Note 9 w Android 8.1, scans stop.  The problem is reportedly fixed by adding a non-empty scan filter.  This change tests for that case (Android 8.1+ on a Samsung device) and adds a non-empty scan filter.