### PR TITLE
Crash fix: bluetoothCrashResolver is used only in versions before Lollipop

### DIFF
--- a/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -330,7 +330,9 @@ public class BeaconService extends Service {
         if (mBeaconNotificationProcessor != null) {
             mBeaconNotificationProcessor.unregister();
         }
-        bluetoothCrashResolver.stop();
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            bluetoothCrashResolver.stop();
+        }
         LogManager.i(TAG, "onDestroy called.  stopping scanning");
         handler.removeCallbacksAndMessages(null);
 


### PR DESCRIPTION
BeaconService shutdown causes a crash on newer Androids because it tried to stop bluetoothCrashResolver which is only initialized in Android versions before Lollipop.