### PR TITLE
Fix crash on scanning as foreground service 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Development
+
+- Fix crash on starting scanning with a forground service configured when multiple BeaconConsumer
+  instances bound.  (#828, David G. Young)
 
 ### 2.16 / 2019-02-10
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -429,8 +429,14 @@ public class BeaconManager {
                     Intent intent = new Intent(consumer.getApplicationContext(), BeaconService.class);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                             this.getForegroundServiceNotification() != null) {
-                        LogManager.i(TAG, "Starting foreground beacon scanning service.");
-                        mContext.startForegroundService(intent);
+                        if (isAnyConsumerBound()) {
+                            LogManager.i(TAG, "Not starting foreground beacon scanning" +
+                                    " service.  A consumer is already bound, so it should be started");
+                        }
+                        else {
+                            LogManager.i(TAG, "Starting foreground beacon scanning service.");
+                            mContext.startForegroundService(intent);
+                        }
                     }
                     else {
                     }


### PR DESCRIPTION
This fixes a crash on starting scanning as a foreground service when there are more than one BeaconConsumers bound to BeaconManager.   Reported in #816  