### PR TITLE
 Fix buildscript for release builds and upload to jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         //noinspection GradleDependency
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
         //noinspection GradleDependency
         classpath 'org.jfrog.buildinfo:build-info-extractor-gradle:3.0.3'
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,4 @@
 include ':lib'
 //include ':demo'
-//rootProject.name="android-beacon-library"
+project(":lib").name = "android-beacon-library"
 //include ':app'


### PR DESCRIPTION
Two changes to get release builds working:

Provides a project name for the lib folder so aar artifact gets named properly
Upgrades the jfrog plugin to work with latest gradle for binray uploads