### PR TITLE
Cancel scheduled jobs when setEnableScheduledJobs(false) is called

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -596,6 +596,9 @@ public class BeaconManager {
             LogManager.w(TAG, "Disabling ScanJobs on Android 8+ may disable delivery of "+
                     "beacon callbacks in the background unless a foreground service is active.");
         }
+        if(!enabled && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            ScanJobScheduler.getInstance().cancelSchedule(mContext);
+        }
         mScheduledScanJobsEnabled = enabled;
     }
     


### PR DESCRIPTION
This commit will make sure that scheduled jobs are immediately cancelled upon calling setEnableScheduledJobs(false).  This resolves issue #845 as we were getting duplicate events after starting a foreground service.