### PR TITLE
WIP: Use hardware filters for faster exit detections

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         //noinspection GradleDependency
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
         //noinspection GradleDependency

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -600,6 +600,9 @@ public class BeaconManager {
             LogManager.w(TAG, "Disabling ScanJobs on Android 8+ may disable delivery of "+
                     "beacon callbacks in the background unless a foreground service is active.");
         }
+        if(!enabled && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            ScanJobScheduler.getInstance().cancelSchedule(mContext);
+        }
         mScheduledScanJobsEnabled = enabled;
     }
     

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -56,6 +56,8 @@ import org.altbeacon.beacon.service.SettingsData;
 import org.altbeacon.beacon.service.StartRMData;
 import org.altbeacon.beacon.service.scanner.NonBeaconLeScanCallback;
 import org.altbeacon.beacon.simulator.BeaconSimulator;
+import org.altbeacon.beacon.startup.StartupBroadcastReceiver;
+import org.altbeacon.beacon.utils.DozeDetector;
 import org.altbeacon.beacon.utils.ProcessUtils;
 
 import java.util.ArrayList;
@@ -333,6 +335,8 @@ public class BeaconManager {
          }
         this.beaconParsers.add(new AltBeaconParser());
         setScheduledScanJobsEnabledDefault();
+        new DozeDetector().registerDozeCallbacks(mContext, new StartupBroadcastReceiver());
+
     }
 
     /***

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -356,11 +356,15 @@ class ScanHelper {
             // We also might have a spurious exit here is we fail to detect a beacon in one cycle
             // after resuming from a between scan period.  We could debounce this with ranging just
             // like is common to do with iOS
-            boolean dozeMode = new DozeDetector().isInDozeMode(mContext);
-            if (dozeMode) {
-                LogManager.w(TAG, "We are in doze mode.  Suppressing unreliable ranging/monitoring state changes.");
+            boolean suppressStatechanges = false;
+            boolean fullDozeMode = new DozeDetector().isInFullDozeMode(mContext);
+            if (mBeaconManager.getForegroundServiceNotification() == null) {
+                if (fullDozeMode) {
+                    LogManager.w(TAG, "We are in full doze mode without a foreground service.  Suppressing unreliable ranging/monitoring state changes.");
+                    suppressStatechanges = true;
+                }
             }
-            else {
+            if (!suppressStatechanges) {
                 mDistinctPacketDetector.clearDetections();
                 mMonitoringStatus.updateNewlyOutside();
                 processRangeData();

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -186,13 +186,15 @@ class ScanHelper {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     void startAndroidOBackgroundScan(Set<BeaconParser> beaconParsers, int scanCallbackType) {
-        ScanSettings.Builder builder =  (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER))
+        ScanSettings.Builder builder =  (new ScanSettings.Builder())
                 .setCallbackType(scanCallbackType);
         if (scanCallbackType == ScanSettings.CALLBACK_TYPE_FIRST_MATCH) {
+            builder.setScanMode(ScanSettings.SCAN_MODE_LOW_POWER);
             builder.setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT);
             builder.setMatchMode(ScanSettings.MATCH_MODE_AGGRESSIVE);
         }
         else {
+            builder.setScanMode(ScanSettings.SCAN_MODE_LOW_POWER);
             builder.setNumOfMatches(ScanSettings.MATCH_NUM_ONE_ADVERTISEMENT);
             builder.setMatchMode(ScanSettings.MATCH_MODE_STICKY);
         }

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -60,6 +60,7 @@ public class ScanJob extends JobService {
             LogManager.e(TAG, "Cannot allocate a scanner to look for beacons.  System resources are low.");
             return false;
         }
+        ScanJobScheduler.getInstance().ensureNotificationProcessorSetup(getApplicationContext());
         if (jobParameters.getJobId() == getImmediateScanJobId(this)) {
             LogManager.i(TAG, "Running immediate scan job: instance is "+this);
         }

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -6,6 +6,7 @@ import android.app.job.JobService;
 import android.bluetooth.le.ScanRecord;
 import android.bluetooth.le.ScanResult;
 import android.bluetooth.le.ScanSettings;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.pm.PackageItemInfo;
@@ -19,6 +20,8 @@ import org.altbeacon.beacon.BuildConfig;
 import org.altbeacon.beacon.Region;
 import org.altbeacon.beacon.distance.ModelSpecificDistanceCalculator;
 import org.altbeacon.beacon.logging.LogManager;
+import org.altbeacon.beacon.startup.StartupBroadcastReceiver;
+import org.altbeacon.beacon.utils.DozeDetector;
 import org.altbeacon.beacon.utils.ProcessUtils;
 
 import java.util.ArrayList;
@@ -149,7 +152,7 @@ public class ScanJob extends JobService {
         else {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 LogManager.d(TAG, "We are outside regions.  Starting a filtered O scan for all pattern finds.");
-                mScanHelper.startAndroidOBackgroundScan(mScanState.getBeaconParsers(), ScanSettings.CALLBACK_TYPE_ALL_MATCHES);
+                mScanHelper.startAndroidOBackgroundScan(mScanState.getBeaconParsers(), ScanSettings.CALLBACK_TYPE_FIRST_MATCH);
             }
             else {
                 LogManager.d(TAG, "This is not Android O.  No scanning between cycles when using ScanJob");
@@ -170,7 +173,6 @@ public class ScanJob extends JobService {
         stopScanning();
         startPassiveScanIfNeeded();
         mScanHelper.terminateThreads();
-
         return false;
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -63,6 +63,9 @@ public class ScanJob extends JobService {
             LogManager.e(TAG, "Cannot allocate a scanner to look for beacons.  System resources are low.");
             return false;
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mScanHelper.stopAndroidOBackgroundScan();
+        }
         ScanJobScheduler.getInstance().ensureNotificationProcessorSetup(getApplicationContext());
         if (jobParameters.getJobId() == getImmediateScanJobId(this)) {
             LogManager.i(TAG, "Running immediate scan job: instance is "+this);
@@ -178,9 +181,6 @@ public class ScanJob extends JobService {
 
     private void stopScanning() {
         mInitialized = false;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            mScanHelper.stopAndroidOBackgroundScan();
-        }
         if (mScanHelper.getCycledScanner() != null) {
             mScanHelper.getCycledScanner().stop();
             mScanHelper.getCycledScanner().destroy();
@@ -211,9 +211,6 @@ public class ScanJob extends JobService {
 
     // Returns true of scanning actually was started, false if it did not need to be
     private boolean restartScanning() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            mScanHelper.stopAndroidOBackgroundScan();
-        }
         long scanPeriod = mScanState.getBackgroundMode() ? mScanState.getBackgroundScanPeriod() : mScanState.getForegroundScanPeriod();
         long betweenScanPeriod = mScanState.getBackgroundMode() ? mScanState.getBackgroundBetweenScanPeriod() : mScanState.getForegroundBetweenScanPeriod();
         if (mScanHelper.getCycledScanner() != null) {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -108,6 +108,11 @@ public class ScanJobScheduler {
         if (scanResults != null) {
             mBackgroundScanResultQueue.addAll(scanResults);
         }
+        else {
+            // we have been woken up in the background by no scan results, which means that the
+            // ble pattern lock has been lost.
+            LogManager.d(TAG, "BLE pattern lock lost");
+        }
         synchronized (this) {
             // We typically get a bunch of calls in a row here, separated by a few millis.  Only do this once.
             if (System.currentTimeMillis() - mScanJobScheduleTime > MIN_MILLIS_BETWEEN_SCAN_JOB_SCHEDULING) {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -7,6 +7,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.os.Build;
 import android.os.PersistableBundle;
+import android.os.PowerManager;
 import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -113,10 +114,17 @@ public class ScanJobScheduler {
             // ble pattern lock has been lost.
             LogManager.d(TAG, "BLE pattern lock lost");
         }
+        boolean dozeMode = false;
+        PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+        if (pm.isPowerSaveMode()) {
+            LogManager.d(TAG, "We are in doze mode.");
+            dozeMode = true;
+        }
+
         synchronized (this) {
             // We typically get a bunch of calls in a row here, separated by a few millis.  Only do this once.
             if (System.currentTimeMillis() - mScanJobScheduleTime > MIN_MILLIS_BETWEEN_SCAN_JOB_SCHEDULING) {
-                LogManager.d(TAG, "scheduling an immediate scan job because last did "+(System.currentTimeMillis() - mScanJobScheduleTime)+"seconds ago.");
+                LogManager.d(TAG, "scheduling an immediate scan job because last did "+(System.currentTimeMillis() - mScanJobScheduleTime)+" seconds ago."+(dozeMode ? "(This should not get executed because we are in doze mode.)" : ""));
                 mScanJobScheduleTime = System.currentTimeMillis();
             }
             else {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -64,7 +64,7 @@ public class ScanJobScheduler {
     private ScanJobScheduler() {
     }
 
-    private void ensureNotificationProcessorSetup(Context context) {
+    void ensureNotificationProcessorSetup(Context context) {
         if (mBeaconNotificationProcessor == null) {
             mBeaconNotificationProcessor = new BeaconLocalBroadcastProcessor(context);
         }

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -21,6 +21,7 @@ import android.support.annotation.WorkerThread;
 
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.logging.LogManager;
+import org.altbeacon.beacon.service.MonitoringStatus;
 import org.altbeacon.beacon.startup.StartupBroadcastReceiver;
 import org.altbeacon.bluetooth.BluetoothCrashResolver;
 
@@ -217,6 +218,7 @@ public abstract class CycledLeScanner {
         mScanningEnabled = true;
         if (!mScanCyclerStarted) {
             scanLeDevice(true);
+
         } else {
             LogManager.d(TAG, "scanning already started");
         }
@@ -312,6 +314,7 @@ public abstract class CycledLeScanner {
                                         try {
                                             if (android.os.Build.VERSION.SDK_INT < 23 || checkLocationPermission()) {
                                                 mCurrentScanStartTime = SystemClock.elapsedRealtime();
+                                                MonitoringStatus.getInstanceForApplication(mContext).markScanLastStarted();
                                                 startScan();
                                             }
                                         } catch (Exception e) {
@@ -342,6 +345,7 @@ public abstract class CycledLeScanner {
                 LogManager.d(TAG, "disabling scan");
                 mScanning = false;
                 mScanCyclerStarted = false;
+                MonitoringStatus.getInstanceForApplication(mContext).markScanLastStopped();
                 stopScan();
                 mCurrentScanStartTime = 0l;
                 mLastScanCycleEndTime = SystemClock.elapsedRealtime();

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -17,6 +17,7 @@ import android.support.annotation.WorkerThread;
 import android.support.v4.content.LocalBroadcastManager;
 
 import org.altbeacon.beacon.BeaconManager;
+import org.altbeacon.beacon.Region;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.service.DetectionTracker;
 import org.altbeacon.bluetooth.BluetoothCrashResolver;
@@ -175,7 +176,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             LogManager.d(TAG, "starting filtered scan in SCAN_MODE_LOW_POWER");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
             filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
-                          mBeaconManager.getBeaconParsers());
+                          mBeaconManager.getBeaconParsers(), new ArrayList<Region>(mBeaconManager.getMonitoredRegions()));
         } else {
             LogManager.d(TAG, "starting a scan in SCAN_MODE_LOW_LATENCY");
             settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)).build();
@@ -194,7 +195,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     // manufacturer codes.  See #769 for details.
                     LogManager.d(TAG, "Using a non-empty scan filter since this is Samsung 8.1+");
                     filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
-                            mBeaconManager.getBeaconParsers());
+                            mBeaconManager.getBeaconParsers(), new ArrayList<Region>(mBeaconManager.getMonitoredRegions()));
                 }
                 else {
                     LogManager.d(TAG, "Using an empty scan filter since this is 8.1+ on Non-Samsung");

--- a/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -7,9 +7,11 @@ import android.bluetooth.le.ScanSettings;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.RequiresApi;
 
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.BeaconManager;
@@ -39,8 +41,13 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
                 if (errorCode != -1) {
                     LogManager.w(TAG, "Passive background scan failed.  Code; "+errorCode);
                 }
-                ArrayList<ScanResult> scanResults = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
-                ScanJobScheduler.getInstance().scheduleAfterBackgroundWakeup(context, scanResults);
+                if (intent.getBooleanExtra("match-lost", false)) {
+                    ScanJobScheduler.getInstance().scheduleAfterBackgroundWakeup(context, null);
+                }
+                else {
+                    ArrayList<ScanResult> scanResults = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
+                    ScanJobScheduler.getInstance().scheduleAfterBackgroundWakeup(context, scanResults);
+                }
             }
             else if (intent.getBooleanExtra("wakeup", false)) {
                 LogManager.d(TAG, "got wake up intent");

--- a/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -55,7 +55,17 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
         if (beaconManager.isAnyConsumerBound() || beaconManager.getScheduledScanJobsEnabled()) {
             int bleCallbackType = intent.getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, -1); // e.g. ScanSettings.CALLBACK_TYPE_FIRST_MATCH
             if (bleCallbackType != -1) {
-                LogManager.d(TAG, "Passive background scan callback type: "+bleCallbackType);
+                String  bleCallbackTypeString = ""+bleCallbackType;
+                if (bleCallbackType == ScanSettings.CALLBACK_TYPE_FIRST_MATCH) {
+                    bleCallbackTypeString = "CALLBACK_TYPE_FIRST_MATCH)";
+                }
+                if (bleCallbackType == ScanSettings.CALLBACK_TYPE_MATCH_LOST) {
+                    bleCallbackTypeString = "CALLBACK_TYPE_MATCH_LOST";
+                }
+                if (bleCallbackType == ScanSettings.CALLBACK_TYPE_ALL_MATCHES) {
+                    bleCallbackTypeString = "CALLBACK_TYPE_ALL_MATCHES";
+                }
+                LogManager.d(TAG, "Passive background scan callback type: "+bleCallbackTypeString);
                 LogManager.d(TAG, "Got Android O background scan via intent");
                 int errorCode = intent.getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, -1); // e.g.  ScanCallback.SCAN_FAILED_INTERNAL_ERROR
                 if (errorCode != -1) {

--- a/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
+++ b/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
@@ -1,0 +1,77 @@
+package org.altbeacon.beacon.utils;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.PowerManager;
+
+import org.altbeacon.beacon.logging.LogManager;
+import org.altbeacon.beacon.startup.StartupBroadcastReceiver;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class DozeDetector {
+    private static final String TAG = DozeDetector.class.getSimpleName();
+
+    public boolean isInDozeMode(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+            if (pm == null) {
+                LogManager.d(TAG, "Can't get PowerManager to check doze mode.");
+                return false;
+            }
+            try {
+                Method isLightDeviceIdleModeMethod = pm.getClass().getDeclaredMethod("isLightDeviceIdleMode");
+                boolean result =  (boolean)isLightDeviceIdleModeMethod.invoke(pm);
+                LogManager.d(TAG, "Doze mode? pm.isLightDeviceIdleMode: " + result);
+                return result;
+            } catch (IllegalAccessException | InvocationTargetException  | NoSuchMethodException e) {
+                LogManager.d(TAG, "Reflection failed for isLightDeviceIdleMode: " + e.toString(), e);
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                LogManager.d(TAG, "Doze mode? pm.isDeviceIdleMode()="+pm.isDeviceIdleMode());
+                if (pm.isDeviceIdleMode()) {
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+            LogManager.d(TAG, "Doze mode? pm.isPowerSaveMode()="+pm.isPowerSaveMode());
+            return pm.isPowerSaveMode();
+        }
+        else {
+            LogManager.d(TAG, "We can't be in doze mode as we are pre-Android M");
+        }
+        return false;
+    }
+
+    public void registerDozeCallbacks(Context context, BroadcastReceiver receiver) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED);
+        context.registerReceiver(receiver, filter);
+
+        filter = new IntentFilter();
+        filter.addAction(getLightIdleModeChangeAction());
+        context.registerReceiver(receiver, filter);
+    }
+
+    public String getLightIdleModeChangeAction() {
+        String action = "android.os.action.LIGHT_DEVICE_IDLE_MODE_CHANGE";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                Object reflectionAction =PowerManager.class.getField("ACTION_LIGHT_DEVICE_IDLE_MODE_CHANGED").get(null);
+                if (reflectionAction != null && reflectionAction instanceof String) {
+                    action = (String) reflectionAction;
+                }
+            } catch (Exception e) {
+                LogManager.d(TAG, "Cannot get LIGHT_DEVICE_IDLE_MODE_CHANGE action: " + e.toString(), e);
+            }
+        }
+        return action;
+    }
+
+}

--- a/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
+++ b/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
@@ -16,30 +16,41 @@ public class DozeDetector {
     private static final String TAG = DozeDetector.class.getSimpleName();
 
     public boolean isInDozeMode(Context context) {
+        return isInFullDozeMode(context) == true || isInLightDozeMode(context) == true;
+    }
+    public boolean isInLightDozeMode(Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-            if (pm == null) {
-                LogManager.d(TAG, "Can't get PowerManager to check doze mode.");
-                return false;
-            }
             try {
                 Method isLightDeviceIdleModeMethod = pm.getClass().getDeclaredMethod("isLightDeviceIdleMode");
                 boolean result =  (boolean)isLightDeviceIdleModeMethod.invoke(pm);
-                LogManager.d(TAG, "Doze mode? pm.isLightDeviceIdleMode: " + result);
+                LogManager.d(TAG, "Light Doze mode? pm.isLightDeviceIdleMode: " + result);
                 return result;
             } catch (IllegalAccessException | InvocationTargetException  | NoSuchMethodException e) {
                 LogManager.d(TAG, "Reflection failed for isLightDeviceIdleMode: " + e.toString(), e);
             }
+        }
+        else {
+            LogManager.d(TAG, "We can't be in doze mode as we are pre-Android M");
+        }
+        return false;
+    }
+    public boolean isInFullDozeMode(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+
+            if (pm == null) {
+                LogManager.d(TAG, "Can't get PowerManager to check doze mode.");
+                return false;
+            }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                LogManager.d(TAG, "Doze mode? pm.isDeviceIdleMode()="+pm.isDeviceIdleMode());
+                LogManager.d(TAG, "Full Doze mode? pm.isDeviceIdleMode()="+pm.isDeviceIdleMode());
                 if (pm.isDeviceIdleMode()) {
                     return true;
                 }
-                else {
-                    return false;
-                }
             }
+
             LogManager.d(TAG, "Doze mode? pm.isPowerSaveMode()="+pm.isPowerSaveMode());
             return pm.isPowerSaveMode();
         }

--- a/lib/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -1,5 +1,7 @@
 package org.altbeacon.beacon;
 
+import android.util.Log;
+
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.logging.Loggers;
 import org.junit.Test;
@@ -303,6 +305,24 @@ public class BeaconParserTest {
         byte[] bytes = p.getBeaconAdvertisementData(beacon);
         assertEquals("First byte of url should be in position 3", 0x02, bytes[2]);
     }
+
+    @Test
+    public void testCanGetIdentifierPrefixForAltBeaconRegion() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        BeaconManager.setDebug(true);
+        Region region = new Region("myRegion", Identifier.parse("2f234454-cf6d-4a0f-adf2-f4911ba9ffa6"), null, null);
+        BeaconParser p = new BeaconParser().
+                setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
+        byte[] bytes = p.getPrefixAdvertisementData(region);
+        assertEquals("length should be 16", 16, bytes.length);
+        for (int i = 0; i < bytes.length; i++) {
+            Log.d("TEST", String.format("%02X", bytes[i]));
+        }
+        assertEquals("first byte should be start of uuid", (byte) 0x2f, bytes[0]);
+        assertEquals("last byte should be end of uuid", (byte) 0xa6,  bytes[15]);
+    }
+
+
     @Test
     public void doesNotCashWithOverflowingByteCodeComparisonOnPdu() {
         // Test for https://github.com/AltBeacon/android-beacon-library/issues/323

--- a/lib/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
@@ -1,30 +1,22 @@
 package org.altbeacon.beacon.service.scanner;
 
 
-import android.bluetooth.le.ScanFilter;
-import android.content.Context;
 
 import org.altbeacon.beacon.AltBeaconParser;
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.BeaconParser;
-import org.altbeacon.beacon.service.scanner.ScanFilterUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import org.mockito.Mockito;
 
 @Config(sdk = 28)
 
@@ -46,7 +38,7 @@ public class ScanFilterUtilsTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         BeaconParser parser = new AltBeaconParser();
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, new byte[] {});
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("manufacturer should be right", 0x0118, sfd.manufacturer);
@@ -60,7 +52,7 @@ public class ScanFilterUtilsTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=1111,i:4-6,p:24-24");
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, new byte[] {});
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("manufacturer should be right", 0x004c, sfd.manufacturer);
@@ -75,7 +67,7 @@ public class ScanFilterUtilsTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout(BeaconParser.EDDYSTONE_UID_LAYOUT);
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, new byte[] {});
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("serviceUuid should be right", new Long(0xfeaa), sfd.serviceUuid);
@@ -87,7 +79,7 @@ public class ScanFilterUtilsTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:0-3=11223344,i:4-6,p:24-24");
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, new byte[] {});
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("manufacturer should be right", 0x004c, sfd.manufacturer);


### PR DESCRIPTION
This adds support for region-specific hardware filters to give you quick region exit events on pattern loss.  Exit events are often detected in about 20 seconds, but testing on the Galaxy S9 this is not 100% reliable.

For this to work, you must monitor at most one region with at least one identifier.  If these conditions are not met, hardware filters are not used to accelerate exit events.