### PR TITLE
Fix thread leak caused by scheduling ScanJob when no consumers bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Development
 
 Bug Fixes:
+- Fix thread leak caused by scheduling ScanJob when no consumers bound. (#885, David G. Young)
 - Protect against a NPE when changing ranged regions.  (#770, David G. Young)
 - Fix intermittent failed ranging/monitoring callbacks in race conditions. (#842, David G. Young) 
 - Prevent duplicate callbacks on Android 8+ with a foreground service by stopping ScanJob.  (#847, Stephen Ruda)

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -581,6 +581,7 @@ public class BeaconManager {
      *
      * @param enabled
      */
+
     public void setEnableScheduledScanJobs(boolean enabled) {
         if (isAnyConsumerBound()) {
             LogManager.e(TAG, "ScanJob may not be configured because a consumer is" +
@@ -998,14 +999,15 @@ public class BeaconManager {
 
     @TargetApi(18)
     private void applyChangesToServices(int type, Region region) throws RemoteException {
+        if (!isAnyConsumerBound()) {
+            LogManager.w(TAG, "The BeaconManager is not bound to the service.  Call beaconManager.bind(BeaconConsumer consumer) and wait for a callback to onBeaconServiceConnect()");
+            return;
+        }
         if (mScheduledScanJobsEnabled) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
             }
             return;
-        }
-        if (serviceMessenger == null) {
-            throw new RemoteException("The BeaconManager is not bound to the service.  Call beaconManager.bind(BeaconConsumer consumer) and wait for a callback to onBeaconServiceConnect()");
         }
         Message msg = Message.obtain(null, type, 0, 0);
         if (type == BeaconService.MSG_SET_SCAN_PERIODS) {


### PR DESCRIPTION
This fixes the thread leak described in #883