### PR TITLE
Fix thread leak with 0 regions and settings applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Development
+
+- Fix thread leak with 0 regions and settings applied, (#888, David G. Young)
+
 ### 2.16.2 / 2019-05-29
 
 - Prevent crash on alarms going off with a different user active (#886, David G. Young)

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -102,8 +102,6 @@ public class ScanJobScheduler {
         }
     }
 
-    // This method appears to be never used, because it is only used by Android O APIs, which
-    // must exist on another branch until the SDKs are released.
     public void scheduleAfterBackgroundWakeup(Context context, List<ScanResult> scanResults) {
         if (scanResults != null) {
             mBackgroundScanResultQueue.addAll(scanResults);
@@ -156,99 +154,57 @@ public class ScanJobScheduler {
 
         JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
 
-        if (backgroundWakeup || !scanState.getBackgroundMode()) {
-            // If we are in the foreground, and we want to start a scan soon, we will schedule an
-            // immediate job
-            if (millisToNextJobStart < scanState.getScanJobIntervalMillis() - 50) {
-                // If the next time we want to scan is less than 50ms from the periodic scan cycle, then]
-                // we schedule it for that specific time.
-                LogManager.d(TAG, "Scheduling immediate ScanJob to run in "+millisToNextJobStart+" millis");
-                JobInfo immediateJob = new JobInfo.Builder(ScanJob.getImmediateScanJobId(context), new ComponentName(context, ScanJob.class))
-                        .setPersisted(true) // This makes it restart after reboot
-                        .setExtras(new PersistableBundle())
-                        .setMinimumLatency(millisToNextJobStart)
-                        .setOverrideDeadline(millisToNextJobStart).build();
-                int error = jobScheduler.schedule(immediateJob);
-                if (error < 0) {
-                    LogManager.e(TAG, "Failed to schedule scan job.  Beacons will not be detected. Error: "+error);
+        int monitoredAndRangedRegionCount = scanState.getMonitoringStatus().regions().size() + scanState.getRangedRegionState().size();
+        if (monitoredAndRangedRegionCount > 0) {
+            if (backgroundWakeup || !scanState.getBackgroundMode()) {
+                // If we are in the foreground, and we want to start a scan soon, we will schedule an
+                // immediate job
+                if (millisToNextJobStart < scanState.getScanJobIntervalMillis() - 50) {
+                    // If the next time we want to scan is less than 50ms from the periodic scan cycle, then]
+                    // we schedule it for that specific time.
+                    LogManager.d(TAG, "Scheduling immediate ScanJob to run in "+millisToNextJobStart+" millis");
+                    JobInfo immediateJob = new JobInfo.Builder(ScanJob.getImmediateScanJobId(context), new ComponentName(context, ScanJob.class))
+                            .setPersisted(true) // This makes it restart after reboot
+                            .setExtras(new PersistableBundle())
+                            .setMinimumLatency(millisToNextJobStart)
+                            .setOverrideDeadline(millisToNextJobStart).build();
+                    int error = jobScheduler.schedule(immediateJob);
+                    if (error < 0) {
+                        LogManager.e(TAG, "Failed to schedule scan job.  Beacons will not be detected. Error: "+error);
+                    }
+                } else {
+                    LogManager.d(TAG, "Not scheduling immediate scan, assuming periodic is about to run");
                 }
-            } else {
-                LogManager.d(TAG, "Not scheduling immediate scan, assuming periodic is about to run");
             }
+            else {
+                LogManager.d(TAG, "Not scheduling an immediate scan because we are in background mode.   Cancelling existing immediate ScanJob.");
+                jobScheduler.cancel(ScanJob.getImmediateScanJobId(context));
+            }
+
+            JobInfo.Builder periodicJobBuilder = new JobInfo.Builder(ScanJob.getPeriodicScanJobId(context), new ComponentName(context, ScanJob.class))
+                    .setPersisted(true) // This makes it restart after reboot
+                    .setExtras(new PersistableBundle());
+
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                // ON Android N+ we specify a tolerance of 0ms (capped at 5% by the OS) to ensure
+                // our scans happen within 5% of the schduled time.
+                periodicJobBuilder.setPeriodic(scanState.getScanJobIntervalMillis(), 0L).build();
+            }
+            else {
+                periodicJobBuilder.setPeriodic(scanState.getScanJobIntervalMillis()).build();
+            }
+            final JobInfo jobInfo = periodicJobBuilder.build();
+            LogManager.d(TAG, "Scheduling ScanJob " + jobInfo + " to run every "+scanState.getScanJobIntervalMillis()+" millis");
+            int error = jobScheduler.schedule(jobInfo);
+            if (error < 0) {
+                LogManager.e(TAG, "Failed to schedule scan job.  Beacons will not be detected. Error: "+error);
+            }
+
         }
         else {
-            LogManager.d(TAG, "Not scheduling an immediate scan because we are in background mode.   Cancelling existing immediate scan.");
+            LogManager.d(TAG, "We are not monitoring or ranging any regions.  We are going to cancel all scan jobs.");
             jobScheduler.cancel(ScanJob.getImmediateScanJobId(context));
-        }
-
-        JobInfo.Builder periodicJobBuilder = new JobInfo.Builder(ScanJob.getPeriodicScanJobId(context), new ComponentName(context, ScanJob.class))
-                .setPersisted(true) // This makes it restart after reboot
-                .setExtras(new PersistableBundle());
-
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            // ON Android N+ we specify a tolerance of 0ms (capped at 5% by the OS) to ensure
-            // our scans happen within 5% of the schduled time.
-            periodicJobBuilder.setPeriodic(scanState.getScanJobIntervalMillis(), 0L).build();
-        }
-        else {
-            periodicJobBuilder.setPeriodic(scanState.getScanJobIntervalMillis()).build();
-        }
-        // On Android O I see this:
-        //
-        // 06-07 22:15:51.361 6455-6455/org.altbeacon.beaconreference W/JobInfo: Specified interval for 1 is +5m10s0ms. Clamped to +15m0s0ms
-        // 06-07 22:15:51.361 6455-6455/org.altbeacon.beaconreference W/JobInfo: Specified flex for 1 is 0. Clamped to +5m0s0ms
-        //
-        // This suggests logs are being clamped at a max of every 15 minutes +/- 5 minutes in the background
-        // This is the same way it worked on Android N per this post: https://stackoverflow.com/questions/38344220/job-scheduler-not-running-on-android-n
-        //
-        // In practice, I see the following runtimes on the Nexus Player with Android O
-        // This shows that the 15 minutes has some slop.
-        //
-        /*
-06-07 22:25:51.380 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@7188bc6
-06-07 22:41:01.227 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@382ed7b
-06-07 22:55:51.373 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@203c928
-06-07 23:10:59.083 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@dc96415
-06-07 23:25:51.371 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@68bed2e
-06-07 23:40:59.142 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@c295843
-06-07 23:55:51.369 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@cd047e4
-06-08 00:10:59.082 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@8009a61
-06-08 00:25:51.368 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@f1fa2ca
-06-08 00:40:59.085 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@88dddef
-06-08 00:55:51.374 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@eb2b360
-06-08 01:10:51.670 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@9bca225
-06-08 01:25:51.383 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@871c8fe
-06-08 01:45:51.404 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@3bf42d3
-06-08 01:56:12.354 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@c3d4e34
-06-08 02:21:51.771 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@1557571
-06-08 02:37:01.861 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@e2c879a
-06-08 02:52:11.943 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@c9f0d7f
-06-08 03:07:22.041 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@4e0cab0
-06-08 03:23:12.696 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@1139a7d
-06-08 03:38:22.776 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@e06b8f6
-06-08 03:52:12.792 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@74147eb
-06-08 04:08:32.872 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@90d9fec
-06-08 04:21:12.856 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@a4abd49
-06-08 04:38:42.959 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@741d912
-06-08 04:50:12.923 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@15bfe17
-06-08 05:08:53.047 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@fa229e8
-06-08 05:19:13.050 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@b0e49d5
-06-08 05:39:03.142 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@18823ee
-06-08 05:54:13.212 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@a72fc03
-06-08 06:10:51.850 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@3fb84a4
-06-08 06:26:01.917 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@53d6c21
-06-08 06:41:11.994 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@848958a
-06-08 06:56:22.053 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@43cdaf
-06-08 07:06:32.119 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@5318c20
-06-08 07:29:12.356 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@34f102d
-06-08 07:44:22.431 6455-6455/org.altbeacon.beaconreference I/ScanJob: Running periodic scan job: instance is org.altbeacon.beacon.service.ScanJob@4d2e9e6
-         */
-
-        final JobInfo jobInfo = periodicJobBuilder.build();
-        LogManager.d(TAG, "Scheduling ScanJob " + jobInfo + " to run every "+scanState.getScanJobIntervalMillis()+" millis");
-        int error = jobScheduler.schedule(jobInfo);
-        if (error < 0) {
-            LogManager.e(TAG, "Failed to schedule scan job.  Beacons will not be detected. Error: "+error);
+            jobScheduler.cancel(ScanJob.getPeriodicScanJobId(context));
         }
     }
 }


### PR DESCRIPTION
This fixes an thread leak in an usual case where:

* ScanJobs are being used (default on Android 8+) AND
* 0 regions are being monitored and ranged, AND one of the following happens:
  -  BeaconManager is used to apply a scanning settings change to the scanning service/job
  -  BackgroundPowerSaver is active and the app switches foreground/background mode

The most likely way this could affect users of this library is by leaving BackgroundPowerSaver enabled on Android 8+ when the app is not ranging and monitoring any regions.

This happened because the ScanJob code failed to stop all the threads on CycledLeScanner by calling destroy() in the case where a ScanJob was abandoned because the BLE scan did not start.  And the BLE scan did not start (by design) if the number of regions monitored and ranged were 0.

This change also adds code to the ScanJobScheduler that cancels all scheduled ScanJobs if there are 0 regions monitored and ranged.  It is pointless and wasteful to keep the jobs going in this case.