### PR TITLE
Don't force bluetooth on, don't reset bluetooth when devices are paired

### DIFF
--- a/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
+++ b/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
@@ -398,7 +398,13 @@ public class BluetoothMedic {
     private void cycleBluetooth() {
         LogManager.d(TAG, "Power cycling bluetooth");
         LogManager.d(TAG, "Turning Bluetooth off.");
-        if (mAdapter != null) {
+        // we do not force bt on
+        // we do not reset bluetooth while bonded with a device (you could deactivate bt headphones)
+        if (mAdapter != null 
+            && mAdapter.isEnabled()
+            && mAdapter.getBondedDevices().isEmpty() 
+            ) {
+
             this.mAdapter.disable();
             this.mHandler.postDelayed(new Runnable() {
                 public void run() {


### PR DESCRIPTION
Hello, 
While I was inspecting BluetoothMedic I was wondering if some specific cases where taken into account.
I was specifically thinking about these two cases :
* Bluetooth was off: using cycleBluetooth would enable bluetooth while it was previously off
* BT Headphones (or other devices ?) where bonded: using cycleBluetooth would break bt connection with your bonded devices.

I think that would lead to bad user experience: 
* my bt was off but using this apps turns my bt on automatically
* I was listening to music it stops while using this app

I'm not really sure these cases may happen: if bt is in bad state does it still plays music on you headphones ?

Maybe we should prevent these edge case with minor checks just in case.
What do you think about this ?
