### PR TITLE
Samsung devices stop scanning when screen is off

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -189,7 +189,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             // We only add these filters on 8.1+ devices, because adding scan filters has been reported
             // to cause scan failures on some Samsung devices with Android 5.x
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
-                if (Build.MANUFACTURER.equalsIgnoreCase("samsung") && !mPowerManager.isInteractive()) {
+                if (Build.MANUFACTURER.equalsIgnoreCase("samsung")) {
                     // On the Samsung Galaxy Note 8.1, scans are blocked with screen off when the
                     // scan filter is empty (wildcard).  We do a more detailed filter on Samsung only
                     // because it might block detections of AltBeacon packets with non-standard


### PR DESCRIPTION
We have been encountering an issue where Android 9 Samsung devices are scanning with the screen is on, with wildcard scanning, then once the screen is off it doesn't switch over to non-wildcard scanning immediately, causing gaps in scanning to take place. 

Because the current code checks if it is interactive, it doesn't fall into non-wildcard scanning until the screen is off. By immediately going into non-wildcard scanning, we prevent gaps during the transition period. 

We were also able to create a work around the stops ranging/starts ranging for regions when the screen turns off

Possibly related to #914 #933 