### PR TITLE
Expedite Samsung Screen Off Detections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Development
+
+- Expedite beacon detections on Samsung when transitionoing from screen on to screen onff (#941, David G. Young)
+
 ### 2.16.3 / 2019-09-18
 
 - Fix thread leak with 0 regions and settings applied, (#888, David G. Young)

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -419,5 +419,5 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                 }
             }
         }
-    }
+    };
 }


### PR DESCRIPTION
This change is designed to solve the problem reported in #936 where a Samsung Device will be slow do detect a beacon (it will take an extra full scan period) if the app is put to the background with the screen on, then subsequently the screen goes off.

This is caused by the fact that an empty scan filter is set up when the app is pushed to the background, then disallowed by Samsung once the screen goes off.  The required non-empty screen off scan filter is not set up until the next scan cycle ends.

The solution is to start a BroadcastReceiver on Samsung devices for this case to look for screen off events before the next scan cycle starts.  If a screen off is detected, switch immediately to a non-empty scan filter.

This is a work in progress as I have not yet tested it on a Samsung device.