### PR TITLE
 Adding notification channel to support devices with Android 8.0 and above

### DIFF
--- a/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
+++ b/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
@@ -1,5 +1,6 @@
 package org.altbeacon.bluetooth;
 
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.TaskStackBuilder;
@@ -92,6 +93,7 @@ public class BluetoothMedic {
     @Nullable
     private Boolean mScanTestResult = null;
     private boolean mNotificationsEnabled = false;
+    private boolean mNotificationChannelCreated = false;
     private int mNotificationIcon = 0;
     private long mLastBluetoothPowerCycleTime = 0L;
     private static final long MIN_MILLIS_BETWEEN_BLUETOOTH_POWER_CYCLES = 60000L;
@@ -418,6 +420,9 @@ public class BluetoothMedic {
     private void sendNotification(Context context, String message, String detail) {
         initializeWithContext(context);
         if(this.mNotificationsEnabled) {
+            if (!this.mNotificationChannelCreated) {
+                createNotificationChannel(context, "err");
+            }
             NotificationCompat.Builder builder =
                     (new NotificationCompat.Builder(context, "err"))
                             .setContentTitle("BluetoothMedic: " + message)
@@ -436,6 +441,22 @@ public class BluetoothMedic {
             if (notificationManager != null) {
                 notificationManager.notify(1, builder.build());
             }
+        }
+    }
+
+    @RequiresApi(21)
+    private void createNotificationChannel(Context context, String channelId) {
+        // On Android 8.0 and above posting a notification without a
+        // channel is an error. So create a notification channel 'err'
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            String channelName = "Errors";
+            String description = "Scan errors";
+            int importance = NotificationManager.IMPORTANCE_DEFAULT;
+            NotificationChannel channel = new NotificationChannel(channelId, channelName, importance);
+            channel.setDescription(description);
+            NotificationManager notificationManager = context.getSystemService(NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+            mNotificationChannelCreated = true;
         }
     }
 


### PR DESCRIPTION
This PR adds a notification channel to be used in notifications posted by BluetoothMedic.
Posting notifications without a channel does not work on Android 8.0 and above

Expected Behavior:
When BluetoothMedic is used for power cycling bluetooth, on scan failures, and Medic notifications are enabled, when a scan failure occurs ,  bluetooth is power cycled and a notification is posted that says so.

Actual Behavior:
Bluetooth is power cycled, but no notification is posted.
If  Settings> developer options > Show Notification channel warnings is turned on, a warning toast message can be seen, .

Steps to reproduce:

1. Use the android beacon library reference app and enable BluetoothMedic power cycling and notifications in RangingActivity

    BluetoothMedic.getInstance().enablePowerCycleOnFailures(this);
    BluetoothMedic.getInstance().setNotificationsEnabled( true, R.drawable.ic_launcher);

2. Broadcast an 'onScanFailed' to simulate an LE scan failure

    Intent intent = new Intent("onScanFailed");
    intent.putExtra("errorCode",2);
    LocalBroadcastManager.getInstance(RangingActivity.this).sendBroadcast(intent);

3. Run RangingActivity

We should be able to see a bluetooth power cycling but no notification from BluetoothMedic

Device used : Galaxy Note 8 
Android version : 9.0

Attaching screenshots for 

before fix 
![screenshot_notif_warning](https://user-images.githubusercontent.com/22036927/72209487-3a77c580-3474-11ea-9405-c549bb3014c1.png)
 
after fix
![screenshot_after_fix](https://user-images.githubusercontent.com/22036927/72209496-6eeb8180-3474-11ea-9332-05423dade9d2.png)



