### PR TITLE
Bring detection timestamp up to beacon object

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
@@ -60,11 +60,12 @@ public class AltBeaconParser extends BeaconParser {
      * @param scanData The actual packet bytes
      * @param rssi The measured signal strength of the packet
      * @param device The Bluetooth device that was detected
+     * @param timestampMs The timestamp in milliseconds of the scan execution
      * @return An instance of an <code>Beacon</code>
      */
     @Override
-    public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
-        return fromScanData(scanData, rssi, device, new AltBeacon());
+    public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device, long timestampMs) {
+        return fromScanData(scanData, rssi, device, timestampMs, new AltBeacon());
     }
 
 }

--- a/lib/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -177,6 +177,11 @@ public class Beacon implements Parcelable, Serializable {
     protected boolean mMultiFrameBeacon = false;
 
     /**
+     * The timestamp of the beacon detection in milliseconds or -1 if getting the timestamp has failed.
+     */
+    protected long mTimestampMs = -1L;
+
+    /**
      * Required for making object Parcelable.  If you override this class, you must provide an
      * equivalent version of this method.
      */
@@ -257,6 +262,7 @@ public class Beacon implements Parcelable, Serializable {
         mRunningAverageRssi = (Double) in.readValue(null);
         mRssiMeasurementCount = in.readInt();
         mPacketCount = in.readInt();
+        mTimestampMs = in.readLong();
     }
 
     /**
@@ -281,6 +287,7 @@ public class Beacon implements Parcelable, Serializable {
         this.mParserIdentifier = otherBeacon.mParserIdentifier;
         this.mMultiFrameBeacon = otherBeacon.mMultiFrameBeacon;
         this.mManufacturer = otherBeacon.mManufacturer;
+        this.mTimestampMs = otherBeacon.mTimestampMs;
     }
 
     /**
@@ -530,6 +537,8 @@ public class Beacon implements Parcelable, Serializable {
      */
     public boolean isMultiFrameBeacon() { return mMultiFrameBeacon; }
 
+    public long getTimestampMs() { return mTimestampMs; }
+
     /**
      * Calculate a hashCode for this beacon
      * @return
@@ -636,6 +645,7 @@ public class Beacon implements Parcelable, Serializable {
         out.writeValue(mRunningAverageRssi);
         out.writeInt(mRssiMeasurementCount);
         out.writeInt(mPacketCount);
+        out.writeLong(mTimestampMs);
     }
 
     /**
@@ -724,6 +734,7 @@ public class Beacon implements Parcelable, Serializable {
             setRssi(beacon.getRssi());
             setServiceUuid(beacon.getServiceUuid());
             setMultiFrameBeacon(beacon.isMultiFrameBeacon());
+            setTimestampMs(beacon.getTimestampMs());
             return this;
         }
 
@@ -893,6 +904,14 @@ public class Beacon implements Parcelable, Serializable {
             return this;
         }
 
+        /**
+         * @see Beacon#mTimestampMs
+         * @return mTimestampMs
+         */
+        public Builder setTimestampMs(long timestampMs) {
+            mBeacon.mTimestampMs = timestampMs;
+            return this;
+        }
     }
 
 }

--- a/lib/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -177,9 +177,14 @@ public class Beacon implements Parcelable, Serializable {
     protected boolean mMultiFrameBeacon = false;
 
     /**
-     * The timestamp of the beacon detection in milliseconds or -1 if getting the timestamp has failed.
+     * The timestamp of the first packet detected in milliseconds.
      */
-    protected long mTimestampMs = -1L;
+    protected long mFirstCycleDetectionTimestamp = 0L;
+
+    /**
+     * The timestamp of the last packet detected in milliseconds.
+     */
+    protected long mLastCycleDetectionTimestamp = 0L;
 
     /**
      * Required for making object Parcelable.  If you override this class, you must provide an
@@ -262,7 +267,8 @@ public class Beacon implements Parcelable, Serializable {
         mRunningAverageRssi = (Double) in.readValue(null);
         mRssiMeasurementCount = in.readInt();
         mPacketCount = in.readInt();
-        mTimestampMs = in.readLong();
+        mFirstCycleDetectionTimestamp = in.readLong();
+        mLastCycleDetectionTimestamp = in.readLong();
     }
 
     /**
@@ -287,7 +293,8 @@ public class Beacon implements Parcelable, Serializable {
         this.mParserIdentifier = otherBeacon.mParserIdentifier;
         this.mMultiFrameBeacon = otherBeacon.mMultiFrameBeacon;
         this.mManufacturer = otherBeacon.mManufacturer;
-        this.mTimestampMs = otherBeacon.mTimestampMs;
+        this.mFirstCycleDetectionTimestamp = otherBeacon.mFirstCycleDetectionTimestamp;
+        this.mLastCycleDetectionTimestamp = otherBeacon.mLastCycleDetectionTimestamp;
     }
 
     /**
@@ -321,6 +328,38 @@ public class Beacon implements Parcelable, Serializable {
      */
     public void setPacketCount(int packetCount) {
         mPacketCount = packetCount;
+    }
+
+    /**
+     * Returns the timestamp of the first packet detected
+     */
+    public long getFirstCycleDetectionTimestamp() {
+        return mFirstCycleDetectionTimestamp;
+    }
+
+    /**
+     * Sets the timestamp of the first packet detected
+     *
+     * @param firstCycleDetectionTimestamp
+     */
+    public void setFirstCycleDetectionTimestamp(long firstCycleDetectionTimestamp) {
+        mFirstCycleDetectionTimestamp = firstCycleDetectionTimestamp;
+    }
+
+    /**
+     * Returns the timestamp of the last packet detected
+     */
+    public long getLastCycleDetectionTimestamp() {
+        return mLastCycleDetectionTimestamp;
+    }
+
+    /**
+     * Sets the timestamp of the last packet detected
+     *
+     * @param lastCycleDetectionTimestamp
+     */
+    public void setLastCycleDetectionTimestamp(long lastCycleDetectionTimestamp) {
+        mLastCycleDetectionTimestamp = lastCycleDetectionTimestamp;
     }
 
     /**
@@ -537,8 +576,6 @@ public class Beacon implements Parcelable, Serializable {
      */
     public boolean isMultiFrameBeacon() { return mMultiFrameBeacon; }
 
-    public long getTimestampMs() { return mTimestampMs; }
-
     /**
      * Calculate a hashCode for this beacon
      * @return
@@ -645,7 +682,8 @@ public class Beacon implements Parcelable, Serializable {
         out.writeValue(mRunningAverageRssi);
         out.writeInt(mRssiMeasurementCount);
         out.writeInt(mPacketCount);
-        out.writeLong(mTimestampMs);
+        out.writeLong(mFirstCycleDetectionTimestamp);
+        out.writeLong(mLastCycleDetectionTimestamp);
     }
 
     /**
@@ -734,7 +772,6 @@ public class Beacon implements Parcelable, Serializable {
             setRssi(beacon.getRssi());
             setServiceUuid(beacon.getServiceUuid());
             setMultiFrameBeacon(beacon.isMultiFrameBeacon());
-            setTimestampMs(beacon.getTimestampMs());
             return this;
         }
 
@@ -897,19 +934,11 @@ public class Beacon implements Parcelable, Serializable {
 
         /**
          * @see Beacon#mMultiFrameBeacon
-         * @return multiFrameBeacon
+         * @param multiFrameBeacon
+         * @return builder
          */
         public Builder setMultiFrameBeacon(boolean multiFrameBeacon) {
             mBeacon.mMultiFrameBeacon = multiFrameBeacon;
-            return this;
-        }
-
-        /**
-         * @see Beacon#mTimestampMs
-         * @return mTimestampMs
-         */
-        public Builder setTimestampMs(long timestampMs) {
-            mBeacon.mTimestampMs = timestampMs;
             return this;
         }
     }

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -617,7 +617,8 @@ public class BeaconParser implements Serializable {
             beacon.mManufacturer = manufacturer;
             beacon.mParserIdentifier = mIdentifier;
             beacon.mMultiFrameBeacon = extraParsers.size() > 0 || mExtraFrame;
-            beacon.mTimestampMs = timestampMs;
+            beacon.mFirstCycleDetectionTimestamp = timestampMs;
+            beacon.mLastCycleDetectionTimestamp = timestampMs;
         }
         return beacon;
     }

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -412,13 +412,14 @@ public class BeaconParser implements Serializable {
      * @param scanData The actual packet bytes
      * @param rssi The measured signal strength of the packet
      * @param device The Bluetooth device that was detected
+     * @param timestampMs The timestamp in milliseconds of the scan execution
      * @return An instance of a <code>Beacon</code>
      */
-    public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
-        return fromScanData(scanData, rssi, device, new Beacon());
+    public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device, long timestampMs) {
+        return fromScanData(scanData, rssi, device, timestampMs, new Beacon());
     }
 
-    protected Beacon fromScanData(byte[] bytesToProcess, int rssi, BluetoothDevice device, Beacon beacon) {
+    protected Beacon fromScanData(byte[] bytesToProcess, int rssi, BluetoothDevice device, long timestampMs, Beacon beacon) {
         BleAdvertisement advert = new BleAdvertisement(bytesToProcess);
         boolean parseFailed = false;
         Pdu pduToParse = null;
@@ -616,6 +617,7 @@ public class BeaconParser implements Serializable {
             beacon.mManufacturer = manufacturer;
             beacon.mParserIdentifier = mIdentifier;
             beacon.mMultiFrameBeacon = extraParsers.size() > 0 || mExtraFrame;
+            beacon.mTimestampMs = timestampMs;
         }
         return beacon;
     }

--- a/lib/src/main/java/org/altbeacon/beacon/service/Callback.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/Callback.java
@@ -39,7 +39,7 @@ import java.io.Serializable;
 public class Callback implements Serializable {
     private static final String TAG = "Callback";
 
-    //TODO: Remove this constructor in favor of an empty one, as the packae name is no longer needed
+    //TODO: Remove this constructor in favor of an empty one, as the package name is no longer needed
     public Callback(String intentPackageName) {
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -22,6 +22,8 @@ public class RangedBeacon implements Serializable {
     Beacon mBeacon;
     protected transient RssiFilter mFilter = null;
     private int packetCount = 0;
+    private long firstCycleDetectionTimestamp = 0;
+    private long lastCycleDetectionTimestamp = 0;
 
     public RangedBeacon(Beacon beacon) {
         updateBeacon(beacon);
@@ -30,6 +32,10 @@ public class RangedBeacon implements Serializable {
     public void updateBeacon(Beacon beacon) {
         packetCount += 1;
         mBeacon = beacon;
+        if(firstCycleDetectionTimestamp == 0) {
+            firstCycleDetectionTimestamp = beacon.getFirstCycleDetectionTimestamp();
+        }
+        lastCycleDetectionTimestamp = beacon.getLastCycleDetectionTimestamp();
         addMeasurement(mBeacon.getRssi());
     }
 
@@ -57,7 +63,11 @@ public class RangedBeacon implements Serializable {
             LogManager.d(TAG, "No measurements available to calculate running average");
         }
         mBeacon.setPacketCount(packetCount);
+        mBeacon.setFirstCycleDetectionTimestamp(firstCycleDetectionTimestamp);
+        mBeacon.setLastCycleDetectionTimestamp(lastCycleDetectionTimestamp);
         packetCount = 0;
+        firstCycleDetectionTimestamp = 0L;
+        lastCycleDetectionTimestamp = 0L;
     }
 
     public void addMeasurement(Integer rssi) {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -397,8 +397,7 @@ class ScanHelper {
             Beacon beacon = null;
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {
-                beacon = parser.fromScanData(scanData.scanRecord,
-                        scanData.rssi, scanData.device, scanData.timestampMs);
+                beacon = parser.fromScanData(scanData.scanRecord, scanData.rssi, scanData.device, scanData.timestampMs);
 
                 if (beacon != null) {
                     break;

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -250,7 +250,7 @@ class ScanHelper {
     PendingIntent getScanCallbackIntent() {
         Intent intent = new Intent(mContext, StartupBroadcastReceiver.class);
         intent.putExtra("o-scan", true);
-        return PendingIntent.getBroadcast(mContext,0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     private final CycledLeScanCallback mCycledLeScanCallback = new CycledLeScanCallback() {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageItemInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Handler;
+import android.os.SystemClock;
 
 import androidx.annotation.Nullable;
 
@@ -83,7 +84,8 @@ public class ScanJob extends JobService {
                     ScanRecord scanRecord = result.getScanRecord();
                     if (scanRecord != null) {
                         if (mScanHelper != null) {
-                            mScanHelper.processScanResult(result.getDevice(), result.getRssi(), scanRecord.getBytes());
+                            mScanHelper.processScanResult(result.getDevice(), result.getRssi(), scanRecord.getBytes(),
+                                    System.currentTimeMillis() - SystemClock.elapsedRealtime() + result.getTimestampNanos() / 1000000);
                         }
                     }
                 }

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -79,7 +79,7 @@ public class ScanJob extends JobService {
                 }
 
                 List<ScanResult> queuedScanResults =  new ArrayList<>(ScanJobScheduler.getInstance().dumpBackgroundScanResultQueue());
-                LogManager.d(TAG, "Processing %d queued scan resuilts", queuedScanResults.size());
+                LogManager.d(TAG, "Processing %d queued scan results", queuedScanResults.size());
                 for (ScanResult result : queuedScanResults) {
                     ScanRecord scanRecord = result.getScanRecord();
                     if (scanRecord != null) {
@@ -89,7 +89,7 @@ public class ScanJob extends JobService {
                         }
                     }
                 }
-                LogManager.d(TAG, "Done processing queued scan resuilts");
+                LogManager.d(TAG, "Done processing queued scan results");
 
                 // This syncronized block is around the scan start.
                 // Without it, it is possilbe that onStopJob is called in another thread and

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -109,7 +109,7 @@ public class ScanJobScheduler {
         synchronized (this) {
             // We typically get a bunch of calls in a row here, separated by a few millis.  Only do this once.
             if (System.currentTimeMillis() - mScanJobScheduleTime > MIN_MILLIS_BETWEEN_SCAN_JOB_SCHEDULING) {
-                LogManager.d(TAG, "scheduling an immediate scan job because last did "+(System.currentTimeMillis() - mScanJobScheduleTime)+"seconds ago.");
+                LogManager.d(TAG, "scheduling an immediate scan job because last did "+(System.currentTimeMillis() - mScanJobScheduleTime)+"millis ago.");
                 mScanJobScheduleTime = System.currentTimeMillis();
             }
             else {

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanCallback.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanCallback.java
@@ -13,6 +13,6 @@ import androidx.annotation.MainThread;
  */
 @MainThread
 public interface CycledLeScanCallback {
-    void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord);
+    void onLeScan(BluetoothDevice device, int rssi, byte[] scanRecord, long timestampMs);
     void onCycleEnd();
 }

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
@@ -111,7 +111,7 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
                         public void onLeScan(final BluetoothDevice device, final int rssi,
                                              final byte[] scanRecord) {
                             LogManager.d(TAG, "got record");
-                            mCycledLeScanCallback.onLeScan(device, rssi, scanRecord);
+                            mCycledLeScanCallback.onLeScan(device, rssi, scanRecord, -1L);
                             if (mBluetoothCrashResolver != null) {
                                 mBluetoothCrashResolver.notifyScannedDevice(device, getLeScanCallback());
                             }

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForJellyBeanMr2.java
@@ -111,7 +111,7 @@ public class CycledLeScannerForJellyBeanMr2 extends CycledLeScanner {
                         public void onLeScan(final BluetoothDevice device, final int rssi,
                                              final byte[] scanRecord) {
                             LogManager.d(TAG, "got record");
-                            mCycledLeScanCallback.onLeScan(device, rssi, scanRecord, -1L);
+                            mCycledLeScanCallback.onLeScan(device, rssi, scanRecord, System.currentTimeMillis());
                             if (mBluetoothCrashResolver != null) {
                                 mBluetoothCrashResolver.notifyScannedDevice(device, getLeScanCallback());
                             }

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -349,7 +349,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     }
                     mCycledLeScanCallback.onLeScan(scanResult.getDevice(),
                             scanResult.getRssi(), scanResult.getScanRecord().getBytes(),
-                            System.currentTimeMillis() - android.os.SystemClock.elapsedRealtime() + scanResult.getTimestampNanos() / 1000000);
+                            System.currentTimeMillis() - SystemClock.elapsedRealtime() + scanResult.getTimestampNanos() / 1000000);
                     if (mBackgroundLScanStartTime > 0) {
                         LogManager.d(TAG, "got a filtered scan result in the background.");
                     }
@@ -362,7 +362,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     for (ScanResult scanResult : results) {
                         mCycledLeScanCallback.onLeScan(scanResult.getDevice(),
                                 scanResult.getRssi(), scanResult.getScanRecord().getBytes(),
-                                System.currentTimeMillis() - android.os.SystemClock.elapsedRealtime() + scanResult.getTimestampNanos() / 1000000);
+                                System.currentTimeMillis() - SystemClock.elapsedRealtime() + scanResult.getTimestampNanos() / 1000000);
                     }
                     if (mBackgroundLScanStartTime > 0) {
                         LogManager.d(TAG, "got a filtered batch scan result in the background.");

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -348,7 +348,8 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                         }
                     }
                     mCycledLeScanCallback.onLeScan(scanResult.getDevice(),
-                            scanResult.getRssi(), scanResult.getScanRecord().getBytes());
+                            scanResult.getRssi(), scanResult.getScanRecord().getBytes(),
+                            System.currentTimeMillis() - android.os.SystemClock.elapsedRealtime() + scanResult.getTimestampNanos() / 1000000);
                     if (mBackgroundLScanStartTime > 0) {
                         LogManager.d(TAG, "got a filtered scan result in the background.");
                     }
@@ -360,7 +361,8 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     LogManager.d(TAG, "got batch records");
                     for (ScanResult scanResult : results) {
                         mCycledLeScanCallback.onLeScan(scanResult.getDevice(),
-                                scanResult.getRssi(), scanResult.getScanRecord().getBytes());
+                                scanResult.getRssi(), scanResult.getScanRecord().getBytes(),
+                                System.currentTimeMillis() - android.os.SystemClock.elapsedRealtime() + scanResult.getTimestampNanos() / 1000000);
                     }
                     if (mBackgroundLScanStartTime > 0) {
                         LogManager.d(TAG, "got a filtered batch scan result in the background.");

--- a/lib/src/test/java/org/altbeacon/beacon/AltBeaconParserTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/AltBeaconParserTest.java
@@ -39,7 +39,7 @@ public class AltBeaconParserTest {
         BeaconManager.setDebug(true);
         byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c50900");
         AltBeaconParser parser = new AltBeaconParser();
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals ("Beacon should have one data field", 1, beacon.getDataFields().size());
         assertEquals("manData should be parsed", 9, ((AltBeacon) beacon).getMfgReserved());
     }
@@ -49,7 +49,7 @@ public class AltBeaconParserTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600050003be020e09526164426561636f6e20555342020a0300000000000000000000000000");
         AltBeaconParser parser = new AltBeaconParser();
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("Beacon should be not null if parsed successfully", beacon);
     }
     @Test
@@ -58,7 +58,7 @@ public class AltBeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1bff1801aabb2f234454cf6d4a0fadf2f4911ba9ffa600010002c50900");
         AltBeaconParser parser = new AltBeaconParser();
         parser.setMatchingBeaconTypeCode(0xaabbl);
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("Beacon should be not null if parsed successfully", beacon);
     }
     @Test
@@ -68,7 +68,7 @@ public class AltBeaconParserTest {
         LogManager.d("XXX", "testParseWrongFormatReturnsNothing start");
         byte[] bytes = hexStringToByteArray("02011a1aff1801ffff2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
         AltBeaconParser parser = new AltBeaconParser();
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         LogManager.d("XXX", "testParseWrongFormatReturnsNothing end");
         assertNull("Beacon should be null if not parsed successfully", beacon);
     }
@@ -79,7 +79,7 @@ public class AltBeaconParserTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         byte[] bytes = hexStringToByteArray("02011a1aff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c5000000");
         AltBeaconParser parser = new AltBeaconParser();
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("mRssi should be as passed in", -55, beacon.getRssi());
         assertEquals("uuid should be parsed", "2f234454-cf6d-4a0f-adf2-f4911ba9ffa6", beacon.getIdentifier(0).toString());
         assertEquals("id2 should be parsed", "1", beacon.getIdentifier(1).toString());

--- a/lib/src/test/java/org/altbeacon/beacon/AltBeaconTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/AltBeaconTest.java
@@ -55,7 +55,7 @@ public class AltBeaconTest {
     public void testRecognizeBeacon() {
         byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
         AltBeaconParser parser = new AltBeaconParser();
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("manData should be parsed", 9, ((AltBeacon) beacon).getMfgReserved() );
     }
 

--- a/lib/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/BeaconParserTest.java
@@ -82,7 +82,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1aff180112342f234454cf6d4a0fadf2f4911ba9ffa600010002c5");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=1234,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("mRssi should be as passed in", -55, beacon.getRssi());
         assertEquals("uuid should be parsed", "2f234454-cf6d-4a0f-adf2-f4911ba9ffa6", beacon.getIdentifier(0).toString());
         assertEquals("id2 should be parsed", "1", beacon.getIdentifier(1).toString());
@@ -98,7 +98,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1aff180112342f234454cf6d4a0fadf2f4911ba9ffa600010002c5");
         BeaconParser parser = new BeaconParser("my_beacon_type");
         parser.setBeaconLayout("m:2-3=1234,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("parser identifier should be accessible", "my_beacon_type", beacon.getParserIdentifier());
     }
 
@@ -109,7 +109,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1aff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c5000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("mRssi should be as passed in", -55, beacon.getRssi());
         assertEquals("uuid should be parsed", "2f234454-cf6d-4a0f-adf2-f4911ba9ffa6", beacon.getIdentifier(0).toString());
         assertEquals("id2 should be parsed", "1", beacon.getIdentifier(1).toString());
@@ -128,7 +128,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:0-3=1801beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("mRssi should be as passed in", -55, beacon.getRssi());
         assertEquals("uuid should be parsed", "2f234454-cf6d-4a0f-adf2-f4911ba9ffa6", beacon.getIdentifier(0).toString());
         assertEquals("id2 should be parsed", "1", beacon.getIdentifier(1).toString());
@@ -143,7 +143,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         byte[] regeneratedBytes = parser.getBeaconAdvertisementData(beacon);
         byte[] expectedMatch = Arrays.copyOfRange(bytes, 7, bytes.length);
         assertArrayEquals("beacon advertisement bytes should be the same after re-encoding", expectedMatch, regeneratedBytes);
@@ -155,7 +155,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("0201060303aafe1516aafe2001021203130414243405152535");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout(BeaconParser.EDDYSTONE_TLM_LAYOUT);
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         byte[] regeneratedBytes = parser.getBeaconAdvertisementData(beacon);
         byte[] expectedMatch = Arrays.copyOfRange(bytes, 11, bytes.length);
         assertEquals("beacon advertisement bytes should be the same after re-encoding", byteArrayToHexString(expectedMatch), byteArrayToHexString(regeneratedBytes));
@@ -167,7 +167,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1bff1801beac0102030405060708090a0b0c0d0e0f1011121314c50900000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-9,i:10-15l,i:16-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("mRssi should be as passed in", -55, beacon.getRssi());
         assertEquals("id1 should be big endian", "0x010203040506", beacon.getIdentifier(0).toString());
         assertEquals("id2 should be little endian", "0x0c0b0a090807", beacon.getIdentifier(1).toString());
@@ -182,7 +182,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("02011a1bff1801beac0102030405060708090a0b0c0d0e0f1011121314c509");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-9,i:10-15l,i:16-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         byte[] regeneratedBytes = parser.getBeaconAdvertisementData(beacon);
         byte[] expectedMatch = Arrays.copyOfRange(bytes, 7, bytes.length);
         System.err.println(byteArrayToHexString(expectedMatch));
@@ -197,7 +197,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("0201061bffaabbbeace2c56db5dffb48d2b060d0f5a71096e000010004c50000000000000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("manufacturer should be parsed", "bbaa", String.format("%04x", beacon.getManufacturer()));
     }
 
@@ -209,7 +209,7 @@ public class BeaconParserTest {
         BeaconParser parser = new BeaconParser();
         parser.setAllowPduOverflow(false);
         parser.setBeaconLayout("s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-20");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNull("beacon should not be parsed", beacon);
     }
 
@@ -219,7 +219,7 @@ public class BeaconParserTest {
         byte[] bytes = hexStringToByteArray("0201060303aafe0d16aafe10e70102030405060708090a0b0c0d0e0f0102030405060708090a0b0c0d0e0f00000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-20v");
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertEquals("URL Identifier should be truncated at 8 bytes", 8, beacon.getId1().toByteArray().length);
     }
 
@@ -234,7 +234,7 @@ public class BeaconParserTest {
         parser.setAllowPduOverflow(false);
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
 
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNull("beacon should not be parsed", beacon);
     }
 
@@ -249,7 +249,7 @@ public class BeaconParserTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
 
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("beacon should be parsed", beacon);
     }
 
@@ -277,7 +277,7 @@ public class BeaconParserTest {
         System.arraycopy(headerBytes, 0, advBytes, 0, headerBytes.length);
         System.arraycopy(bytes, 0, advBytes, headerBytes.length, bytes.length);
 
-        Beacon parsedBeacon = p.fromScanData(advBytes, -59, null);
+        Beacon parsedBeacon = p.fromScanData(advBytes, -59, null, 123456L);
         assertNotNull(String.format("Parsed beacon from %s should not be null", byteArrayToHexString(advBytes)), parsedBeacon);
         double parsedLatitude = Long.parseLong(parsedBeacon.getId2().toString().substring(2), 16) / 10000.0 - 90.0;
         double parsedLongitude = Long.parseLong(parsedBeacon.getId3().toString().substring(2), 16) / 10000.0 - 180.0;
@@ -315,7 +315,7 @@ public class BeaconParserTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=beac,i:4-19,i:20-21,i:22-23,p:24-24,d:25-25");
 
-        Beacon beacon = parser.fromScanData(bytes, -55, null);
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNull("beacon not be parsed without an exception being thrown", beacon);
     }
 
@@ -348,7 +348,7 @@ public class BeaconParserTest {
         System.arraycopy(bodyBytes, 0, bytes, headerBytes.length, bodyBytes.length);
 
         // Try parsing the byte array
-        Beacon parsedBeacon = parser.fromScanData(bytes, -59, null);
+        Beacon parsedBeacon = parser.fromScanData(bytes, -59, null, 123456L);
 
         assertEquals("parsed beacon should contain a valid data on index 0", now, parsedBeacon.getDataFields().get(0));
         assertEquals("parsed beacon should contain a valid data on index 1", Long.valueOf(1234L), parsedBeacon.getDataFields().get(1));

--- a/lib/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/GattBeaconTest.java
@@ -34,7 +34,7 @@ public class GattBeaconTest {
         byte[] bytes = hexStringToByteArray("020106030334121516341200e72f234454f4911ba9ffa6000000000001000000000000000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=00,p:3-3:-41,i:4-13,i:14-19");
         assertNotNull("Service uuid parsed should not be null", parser.getServiceUuid());
-        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
         assertEquals("id1 should be parsed", "0x2f234454f4911ba9ffa6", gattBeacon.getId1().toString());
         assertEquals("id2 should be parsed", "0x000000000001", gattBeacon.getId2().toString());
@@ -49,7 +49,7 @@ public class GattBeaconTest {
         LogManager.setVerboseLoggingEnabled(true);
         byte[] bytes = hexStringToByteArray("020106030334121616341210ec007261646975736e6574776f726b7373070000000000000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=10,p:3-3:-41,i:4-20v");
-        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
         assertEquals("GattBeacon identifier length should be proper length",
                 17,
@@ -65,7 +65,7 @@ public class GattBeaconTest {
         LogManager.d("GattBeaconTest", "Parsing short packet");
         byte[] bytes = hexStringToByteArray("020106030334121516341210ec007261646975736e6574776f726b7307000000000000000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=10,p:3-3:-41,i:4-20v");
-        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
         assertEquals("GattBeacon identifier length should be adjusted smaller if packet is short",
                      16,
@@ -90,7 +90,7 @@ public class GattBeaconTest {
         LogManager.setVerboseLoggingEnabled(true);
         byte[] bytes = hexStringToByteArray("0201060303aafe1516aafe00e700010203040506070809010203040506000000000000000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser().setBeaconLayout(BeaconParser.EDDYSTONE_UID_LAYOUT);
-        Beacon eddystoneUidBeacon = parser.fromScanData(bytes, -55, null);
+        Beacon eddystoneUidBeacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("Eddystone-UID should be not null if parsed successfully", eddystoneUidBeacon);
     }
 
@@ -104,7 +104,7 @@ public class GattBeaconTest {
         byte[] bytes = hexStringToByteArray("020106030334120a16341210ed00636e6e070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=1234,m:2-2=10,p:3-3:-41,i:4-20v");
         LogManager.d("xxx", "------");
-        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("GattBeacon should be not null if parsed successfully", gattBeacon);
         assertEquals("GattBeacon identifier length should be adjusted smaller if packet is short",
                 5,
@@ -148,7 +148,7 @@ public class GattBeaconTest {
         byte[] bytes = {2, 1, 4, 3, 3, (byte) 216, (byte) 254, 19, 22, (byte) 216, (byte) 254, 0, (byte) 242, 3, 103, 111, 111, 46, 103, 108, 47, 104, 113, 66, 88, 69, 49, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=fed8,m:2-2=00,p:3-3:-41,i:4-21v");
         LogManager.d("xxx", "------");
-        Beacon uriBeacon = parser.fromScanData(bytes, -55, null);
+        Beacon uriBeacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("UriBeacon should be not null if parsed successfully", uriBeacon);
         assertEquals("UriBeacon identifier length should be correct",
                 14,
@@ -167,7 +167,7 @@ public class GattBeaconTest {
         byte[] bytes = hexStringToByteArray("0201060303aafe0416aafe100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         BeaconParser parser = new BeaconParser().setBeaconLayout("s:0-1=feaa,m:2-2=10,p:3-3:-41,i:4-20v");
         LogManager.d("xxx", "------");
-        Beacon gattBeacon = parser.fromScanData(bytes, -55, null);
+        Beacon gattBeacon = parser.fromScanData(bytes, -55, null, 123456L);
         assertNull("GattBeacon should be null when not parsed successfully", gattBeacon);
     }
 

--- a/lib/src/test/java/org/altbeacon/beacon/SBeaconTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/SBeaconTest.java
@@ -23,7 +23,7 @@ public class SBeaconTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         byte[] bytes = hexStringToByteArray("02011a1bff1801031501000100c502000000000000000003");
         SBeaconParser parser = new SBeaconParser();
-        SBeacon sBeacon = (SBeacon) parser.fromScanData(bytes, -55, null);
+        SBeacon sBeacon = (SBeacon) parser.fromScanData(bytes, -55, null, 123456L);
         assertNotNull("SBeacon should be not null if parsed successfully", sBeacon);
         assertEquals("id should be parsed", "0x000000000003", sBeacon.getId());
         assertEquals("group should be parsed", 1, sBeacon.getGroup());
@@ -87,7 +87,7 @@ public class SBeaconTest {
         private static final String TAG = "SBeaconParser";
 
         @Override
-        public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
+        public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device, long timestamp) {
             int startByte = 2;
             while (startByte <= 5) {
                 // "m:2-3=0203,i:2-2,i:7-8,i:14-19,d:10-13,p:9-9"

--- a/lib/src/test/java/org/altbeacon/beacon/org/altbeacon/beacon/simulator/BeaconSimulatorTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/org/altbeacon/beacon/simulator/BeaconSimulatorTest.java
@@ -50,7 +50,7 @@ public class BeaconSimulatorTest {
     public void testSetBeacons(){
         StaticBeaconSimulator staticBeaconSimulator = new StaticBeaconSimulator();
         byte[] beaconBytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c509");
-        Beacon beacon = new AltBeaconParser().fromScanData(beaconBytes, -55, null);
+        Beacon beacon = new AltBeaconParser().fromScanData(beaconBytes, -55, null,123456L);
         ArrayList<Beacon> beacons = new ArrayList<Beacon>();
         beacons.add(beacon);
         staticBeaconSimulator.setBeacons(beacons);

--- a/lib/src/test/java/org/altbeacon/beacon/service/BeaconServiceTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/service/BeaconServiceTest.java
@@ -51,7 +51,7 @@ public class BeaconServiceTest {
         int activeThreadCountBeforeScan = executor.getActiveCount();
 
         byte[] scanRecord = new byte[1];
-        callback.onLeScan(null, -59, scanRecord);
+        callback.onLeScan(null, -59, scanRecord, 123456L);
 
         int activeThreadCountAfterScan = executor.getActiveCount();
 


### PR DESCRIPTION
Allow to retrieve detection time, useful for background detections.

- Use `ScanResult::getTimestampNanos` and system clock/elapsedRealTime to compute epoch timestamp.
- Bring it from scan callbacks up to `Beacon` object in `mFirstCycleDetectionTimestamp` field and `mLastCycleDetectionTimestamp` which correspond respectively to the timestamp of the first and last detected packets.

Linked issue https://github.com/AltBeacon/android-beacon-library/issues/918