### PR TITLE
Add support for covid beacon proposal from Apple and Google

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Development
+### 2.17 / 2020-04-19
 
 - Make BeaconParser more flexible so as to support covid beacon proposal (#965, David G. Young)
 - Add timestamps of precsely when first and last packet was detected for beacon (#956, Rémi Latapy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Development
 
+- Make BeaconParser more flexible so as to support covid beacon proposal (#965, David G. Young)
 - Add timestamps of precsely when first and last packet was detected for beacon (#956, Rémi Latapy)
 
 ### 2.16.4 / 2020-01-26

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Key Gradle build targets:
     ./gradlew test # run unit tests
     ./gradlew build # development build
     ./gradlew release -Prelease # release build
-    ./gradlew generateReleaseJavadoc
 
 ## License
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/ScanFilterUtils.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/ScanFilterUtils.java
@@ -44,19 +44,25 @@ public class ScanFilterUtils {
             // Note: the -2 here is because we want the filter and mask to start after the
             // two-byte manufacturer code, and the beacon parser expression is based on offsets
             // from the start of the two byte code
-            byte[] filter = new byte[endOffset + 1 - 2];
-            byte[] mask = new byte[endOffset + 1 - 2];
-            byte[] typeCodeBytes = BeaconParser.longToByteArray(typeCode, endOffset-startOffset+1);
-            for (int layoutIndex = 2; layoutIndex <= endOffset; layoutIndex++) {
-                int filterIndex = layoutIndex-2;
-                if (layoutIndex < startOffset) {
-                    filter[filterIndex] = 0;
-                    mask[filterIndex] = 0;
-                } else {
-                    filter[filterIndex] = typeCodeBytes[layoutIndex-startOffset];
-                    mask[filterIndex] = (byte) 0xff;
+            int length = endOffset + 1 - 2;
+            byte[] filter = new byte[0];
+            byte[] mask = new byte[0];
+            if (length > 0) {
+                filter = new byte[length];
+                mask = new byte[length];
+                byte[] typeCodeBytes = BeaconParser.longToByteArray(typeCode, endOffset-startOffset+1);
+                for (int layoutIndex = 2; layoutIndex <= endOffset; layoutIndex++) {
+                    int filterIndex = layoutIndex-2;
+                    if (layoutIndex < startOffset) {
+                        filter[filterIndex] = 0;
+                        mask[filterIndex] = 0;
+                    } else {
+                        filter[filterIndex] = typeCodeBytes[layoutIndex-startOffset];
+                        mask[filterIndex] = (byte) 0xff;
+                    }
                 }
             }
+
             ScanFilterData sfd = new ScanFilterData();
             sfd.manufacturer = manufacturer;
             sfd.filter = filter;

--- a/lib/src/test/java/org/altbeacon/beacon/CBeaconTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/CBeaconTest.java
@@ -1,0 +1,114 @@
+package org.altbeacon.beacon;
+
+import android.bluetooth.BluetoothDevice;
+import android.content.Context;
+import android.os.Parcel;
+import android.util.Log;
+
+import org.altbeacon.beacon.logging.LogManager;
+import org.altbeacon.beacon.logging.Loggers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+
+@Config(sdk = 28)
+
+/**
+ * Created by dyoung on 4/19/20.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CBeaconTest {
+
+    @Test
+    public void testDetectsCBeacon() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        byte[] bytes = hexStringToByteArray("02010603036ffd15166ffd0102030405060708090a0b0c0d0e0f100000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser();
+        parser.setBeaconLayout("s:0-1=fd6f,p:0-0:63,i:2-17");
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 0l);
+        assertNotNull("CBeacon should be not null if parsed successfully", beacon);
+        assertEquals("id should be parsed", "01020304-0506-0708-090a-0b0c0d0e0f10", beacon.getId1().toString());
+        assertEquals("txPower should be parsed", -82, beacon.getTxPower());
+    }
+
+    @Test
+    public void testDetectsCBeaconWithoutPower() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        byte[] bytes = hexStringToByteArray("02010603036ffd15166ffd0102030405060708090a0b0c0d0e0f100000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser();
+        parser.setBeaconLayout("s:0-1=fd6f,p:-:-59,i:2-17");
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 0l);
+        assertNotNull("CBeacon should be not null if parsed successfully", beacon);
+        assertEquals("id should be parsed", "01020304-0506-0708-090a-0b0c0d0e0f10", beacon.getId1().toString());
+        assertEquals("txPower should be set to value specified", -59, beacon.getTxPower());
+    }
+
+    @Test
+    public void doesNotDetectManufacturerAdvert() {
+        LogManager.setLogger(Loggers.verboseLogger());
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        byte[] bytes = hexStringToByteArray("02011a1bff1801beac2f234454cf6d4a0fadf2f4911ba9ffa600010002c50900");
+        BeaconParser parser = new BeaconParser();
+        parser.setBeaconLayout("s:0-1=fd6f,p:0-0:63,i:2-17");
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 0l);
+        assertNull("CBeacon should not be parsed", beacon);
+    }
+
+    //@Test
+    public void testBeaconAdvertisingBytes() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        Context context = RuntimeEnvironment.application;
+
+        Beacon beacon = new Beacon.Builder()
+                .setId1("01020304-0506-0708-090a-0b0c0d0e0f10")
+                .build();
+        BeaconParser beaconParser = new BeaconParser()
+                .setBeaconLayout("s:0-1=fd6f,p:-:-59,i:2-17");
+        byte[] data = beaconParser.getBeaconAdvertisementData(beacon);
+
+        String byteString = "";
+        for (int i = 0; i < data.length; i++) {
+            byteString += String.format("%02X", data[i]);
+            byteString += " ";
+        }
+        assertEquals("Advertisement bytes should be as expected", "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 ", byteString);
+    }
+
+    @Test
+    public void testBeaconAdvertisingBytesForLegacyFormat() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        Context context = RuntimeEnvironment.application;
+
+        Beacon beacon = new Beacon.Builder()
+                .setId1("01020304-0506-0708-090a-0b0c0d0e0f10")
+                .build();
+        BeaconParser beaconParser = new BeaconParser()
+                .setBeaconLayout("s:0-1=fd6f,p:0-0:63,i:2-17");
+        byte[] data = beaconParser.getBeaconAdvertisementData(beacon);
+
+        String byteString = "";
+        for (int i = 0; i < data.length; i++) {
+            byteString += String.format("%02X", data[i]);
+            byteString += " ";
+        }
+        assertEquals("Advertisement bytes should be as expected", "01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F 10 ", byteString);
+    }
+
+    public static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
+}


### PR DESCRIPTION
This updates the BeaconParser to be more flexible:

* Supports layouts based on GATT service advertisements without a matching beacon type code.   
* Makes the measured power field optional, and allows specifying a default measured power to use if it is absent.

The above changes are needed to more easily support  this format:

https://covid19-static.cdn-apple.com/applications/covid19/current/static/contact-tracing/pdf/ContactTracing-BluetoothSpecificationv1.1.pdf 