### PR TITLE
Parse beacons from entirety of scan result including scan response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 2.17.1 / 2020-05-25
+### Development
 
+- Parse multiple manufacturer sections in the advertisement and the scan response to look for beacons.  (#970, David G. Young)
 - Improve HW filter detection mechanism in order to detect beacons immediately after starting in background (#974, Vlad Vladau)
 
 ### 2.17 / 2020-04-19

--- a/lib/src/main/java/org/altbeacon/bluetooth/BleAdvertisement.java
+++ b/lib/src/main/java/org/altbeacon/bluetooth/BleAdvertisement.java
@@ -17,12 +17,19 @@ public class BleAdvertisement {
     private byte[] mBytes;
     public BleAdvertisement(byte[] bytes) {
         mBytes = bytes;
-        mPdus = parsePdus();
-    }
-    private List<Pdu> parsePdus() {
         ArrayList<Pdu> pdus = new ArrayList<Pdu>();
+        // Get PDUs from the main advert
+        parsePdus(0, bytes.length < 31 ? bytes.length : 31, pdus);
+        // Get PDUs from the scan response
+        // Android puts the scan response at offset 31
+        if (bytes.length > 31) {
+            parsePdus(31, bytes.length, pdus);
+        }
+        mPdus = pdus;
+    }
+    private void parsePdus(int startIndex, int endIndex, ArrayList<Pdu> pdus) {
+        int index = startIndex;
         Pdu pdu = null;
-        int index = 0;
         do {
             pdu = Pdu.parse(mBytes, index);
             if (pdu != null) {
@@ -30,10 +37,8 @@ public class BleAdvertisement {
                 pdus.add(pdu);
             }
         }
-        while (pdu != null && index < mBytes.length);
-        return pdus;
+        while (pdu != null && index < endIndex);
     }
-
 
     /**
      * The list of PDUs inside the advertisement

--- a/lib/src/test/java/org/altbeacon/beacon/OverflowAreaBeaconTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/OverflowAreaBeaconTest.java
@@ -1,0 +1,67 @@
+package org.altbeacon.beacon;
+
+import android.content.Context;
+
+import org.altbeacon.bluetooth.BleAdvertisement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+@Config(sdk = 28)
+
+/**
+ * Created by David G. Young 5/19/2020
+ */
+@RunWith(RobolectricTestRunner.class)
+public class OverflowAreaBeaconTest {
+
+    @Test
+    public void testDetectsOverfowAreadBeacon() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        Context context = RuntimeEnvironment.application;
+        BeaconManager.getInstanceForApplication(context).setDebug(true);
+        byte[] bytes = hexStringToByteArray("02011a020a0c0eff4c000f05a0336aa5f110025b0c14ff4c000156fe87490000000000000000000000000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser().setBeaconLayout("m:2-2=01,i:3-18,p:-:-59");
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
+        assertNotNull("beacon should be not null if parsed successfully", beacon);
+        assertEquals("id should be parsed", "56fe8749-0000-0000-0000-000000000000", beacon.getId1().toString());
+    }
+
+    public void testDetectsOverfowAreadBeaconInOverflowArea() {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        Context context = RuntimeEnvironment.application;
+        BeaconManager.getInstanceForApplication(context).setDebug(true);
+        byte[] bytes = hexStringToByteArray("02011a020a0c0eff4c000f05a0336aa5f110025b0c0000000000000000000014ff4c000156fe874900000000000000000000000000000000000000000000");
+        BeaconParser parser = new BeaconParser().setBeaconLayout("m:2-2=01,i:3-18,p:-:-59");
+        Beacon beacon = parser.fromScanData(bytes, -55, null, 123456L);
+        assertNotNull("beacon should be not null if parsed successfully", beacon);
+        assertEquals("id should be parsed", "56fe8749-0000-0000-0000-000000000000", beacon.getId1().toString());
+    }
+
+    public static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                    + Character.digit(s.charAt(i+1), 16));
+        }
+        return data;
+    }
+
+    @Test
+    public void testCanParsePdus() {
+        byte[] bytes = hexStringToByteArray("02011a020a0c0eff4c000f05a0336aa5f110025b0c14ff4c000156fe87490000000000000000000000000000000000000000000000000000000000000000");
+        BleAdvertisement bleAdvert = new BleAdvertisement(bytes);
+        Assert.assertEquals("should find four PDUs", 4, bleAdvert.getPdus().size());
+        Assert.assertEquals("First PDU should be flags type 1", 1, bleAdvert.getPdus().get(0).getType());
+        Assert.assertEquals("Second PDU should be type 10", 10, bleAdvert.getPdus().get(1).getType());
+        Assert.assertEquals("Third PDU should be man type 0xff", -1, bleAdvert.getPdus().get(2).getType());
+        Assert.assertEquals("fourth PDU should be man type 0xff", -1, bleAdvert.getPdus().get(3).getType());
+
+    }
+}

--- a/lib/src/test/java/org/altbeacon/bluetooth/BleAdvertisementTest.java
+++ b/lib/src/test/java/org/altbeacon/bluetooth/BleAdvertisementTest.java
@@ -33,13 +33,13 @@ public class BleAdvertisementTest {
 
     @Test
     public void testCanParsePdusFromOtherBeacon() {
-        byte[] bytes = hexStringToByteArray("0201060303aafe1516aafe00e72f234454f4911ba9ffa60000000000010c09526164426561636f6e20470000000000000000000000000000000000000000");
+        byte[] bytes = hexStringToByteArray("0201060303aafe1516aafe00e72f234454f4911ba9ffa600000000000100000c09526164426561636f6e2047000000000000000000000000000000000000");
         BleAdvertisement bleAdvert = new BleAdvertisement(bytes);
-        assertEquals("An otherBeacon advert should four three PDUs", 4, bleAdvert.getPdus().size());
+        assertEquals("An otherBeacon advert should find four PDUs", 4, bleAdvert.getPdus().size());
         assertEquals("First PDU should be flags type 1", 1, bleAdvert.getPdus().get(0).getType());
         assertEquals("Second PDU should be services type 3", 3, bleAdvert.getPdus().get(1).getType());
         assertEquals("Third PDU should be serivce type 0x16", 0x16, bleAdvert.getPdus().get(2).getType());
-        assertEquals("Fourth PDU should be scan response type 9", 9, bleAdvert.getPdus().get(3).getType());
+        assertEquals("fourth PDU should be scan response type 9", 9, bleAdvert.getPdus().get(3).getType());
 
     }
 }


### PR DESCRIPTION
Makes scan result parsing more robust to detect beacon patterns in two cases that were not detected before:

* If multiple data types exist in the PDUs  (e.g. more than one FF manufacturer data type), try parsing every one of them to look for a match.

* If a scan response exists, parse the PDUs there as well.

The above changes allow detecting [overflow area advertisements](http://www.davidgyoungtech.com/2020/05/07/hacking-the-overflow-area) from iOS more reliably.  Unit tests cover two such cases.
