### PR TITLE
Fix delete and rename scan state file on Windows

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
@@ -193,17 +193,6 @@ public class ScanState implements Serializable {
                 outputStream = mContext.openFileOutput(TEMP_STATUS_PRESERVATION_FILE_NAME, MODE_PRIVATE);
                 objectOutputStream = new ObjectOutputStream(outputStream);
                 objectOutputStream.writeObject(this);
-                File file = new File(mContext.getFilesDir(), STATUS_PRESERVATION_FILE_NAME);
-                File tempFile = new File(mContext.getFilesDir(), TEMP_STATUS_PRESERVATION_FILE_NAME);
-                LogManager.d(TAG, "Temp file is "+tempFile.getAbsolutePath());
-                LogManager.d(TAG, "Perm file is "+file.getAbsolutePath());
-
-                if (!file.delete()) {
-                    LogManager.e(TAG, "Error while saving scan status to file: Cannot delete existing file.");
-                }
-                if (!tempFile.renameTo(file)) {
-                    LogManager.e(TAG, "Error while saving scan status to file: Cannot rename temp file.");
-                }
             } catch (IOException e) {
                 LogManager.e(TAG, "Error while saving scan status to file: ", e.getMessage());
             } finally {
@@ -220,6 +209,19 @@ public class ScanState implements Serializable {
                     }
                 }
             }
+
+            File file = new File(mContext.getFilesDir(), STATUS_PRESERVATION_FILE_NAME);
+            File tempFile = new File(mContext.getFilesDir(), TEMP_STATUS_PRESERVATION_FILE_NAME);
+            LogManager.d(TAG, "Temp file is "+tempFile.getAbsolutePath());
+            LogManager.d(TAG, "Perm file is "+file.getAbsolutePath());
+
+            if (!file.delete()) {
+                LogManager.e(TAG, "Error while saving scan status to file: Cannot delete existing file.");
+            }
+            if (!tempFile.renameTo(file)) {
+                LogManager.e(TAG, "Error while saving scan status to file: Cannot rename temp file.");
+            }
+
             mMonitoringStatus.saveMonitoringStatusIfOn();
         }
     }


### PR DESCRIPTION
## Error
ScanStateTest.serializationTest is failing on Windows with this error message: "E/ScanState: Error while saving scan status to file: Cannot rename temp file"
It is logged from the save method in ScanState when the temporary file (android-beacon-library-scan-state-temp) is renamed to the normal file (android-beacon-library-scan-state). 
## Cause
The root cause seems to be this error message: "The process cannot access the file because it is being used by another process java.exe" which can be seen when you try to manually rename the file from Windows File System Explorer.
In order to reproduce, place a breakpoint before renameTo is called and then try to apply manual steps.
## Fix
What I think is happening is that the java.exe process is locking the file because the stream resources are not closed so I moved the call to delete and rename the normal file after the resources are closed.
## Gradle Test Report
![TestReport230520](https://user-images.githubusercontent.com/5949812/82740025-8bb29280-9d4d-11ea-847e-3496d4dc79e6.png)
## Manual tests
No manual tests.