### PR TITLE
Remove background reset after unbind

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -469,10 +469,6 @@ public class BeaconManager {
                     // If this is the last consumer to disconnect, the service will exit
                     // release the serviceMessenger.
                     serviceMessenger = null;
-                    // Reset the mBackgroundMode to false, which is the default value
-                    // This way when we restart ranging or monitoring it will always be in
-                    // foreground mode
-                    mBackgroundMode = false;
                     // If we are using scan jobs, we cancel the active scan job
                     if (mScheduledScanJobsEnabled) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
### Issue
The background mode state is not preserved if the user wants to disable the monitoring explicitly in the background.

### Cause
The background mode resets when unbinding the consumer.

### Fix
Background flag should be maintained by the _BackgroundPowerSaver_ feature or explicitly by the user using _BeaconManager:setBackgroundMode_ method call.

### Roboelectric tests

The tests are passed (with fix #973).
![image](https://user-images.githubusercontent.com/64868084/82753485-aed15680-9dce-11ea-9b5b-10fc9e67ce35.png)


### Manual tests

Device: Huawei Mate 20 Pro
AndroidOS: 10
Debug without wire (over Wi-Fi)

Test case: enable monitoring in background:

1. **Before fix**
- This consumer is not bound.  Binding now: ...
- Activating background region monitoring
- Background region monitoring activated for region id1:
- Applying settings to ScanJob
- **Applying scan job settings with background mode false**
- Register calls: global=4 instance=4
- **Scheduling immediate ScanJob to run in 50 millis** _//the app thinks is in foreground, and it scanns contiosly ussing immediate scan job_
- Scheduling ScanJob (...) to run every 300000 millis
- consumer count is now: 1
- Waiting for BeaconService connection
- Register calls: global=5 instance=5
- **Beacon simulator not enabled**

2. **After fix**
- This consumer is not bound.  Binding now: ...
- Activating background region monitoring
- Background region monitoring activated for region id1:
- Applying settings to ScanJob
- **Applying scan job settings with background mode true** _//maintains the previous background state_
- Register calls: global=4 instance=4
- **Not scheduling an immediate scan because we are in background mode.   Cancelling existing immediate ScanJob.**
- Scheduling periodic ScanJob (...) to run every 310000 millis
- consumer count is now: 1
- Waiting for BeaconService connection
