### PR TITLE
Fix BluetoothMedic crash when started on non-looper thread.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Parse multiple manufacturer sections in the advertisement and the scan response to look for beacons.  (#970, David G. Young)
 - Improve HW filter detection mechanism in order to detect beacons immediately after starting in background (#974, Vlad Vladau)
+- Fix crash on BluetoothMedic when started on thread without a looper (#980, David G. Young)
 
 ### 2.17 / 2020-04-19
 

--- a/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
+++ b/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Handler;
+import android.os.Looper;
 import android.os.PersistableBundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -86,7 +87,7 @@ public class BluetoothMedic {
     @Nullable
     private LocalBroadcastManager mLocalBroadcastManager;
     @NonNull
-    private Handler mHandler = new Handler();
+    private Handler mHandler = new Handler(Looper.getMainLooper());
     private int mTestType = 0;
     @Nullable
     private Boolean mTransmitterTestResult = null;


### PR DESCRIPTION
Fixes #980

Reproduced the problem by adding these lines to onCreate() of BeaconReferenceApplication:

```
        Thread t = new Thread() {
          public void run() {
              try {
                  BluetoothMedic.getInstance();
              }
              catch (Exception e) {
                  Log.e(TAG, "Crash!", e);
                  System.exit(1);
              }
          }
        };
        t.start();
```

Before this fix, that crashed.  After this fix, it did not.