### PR TITLE
Replace equals Regions on ranging beacons requests

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -369,7 +369,8 @@ public class BeaconService extends Service {
         synchronized (mScanHelper.getRangedRegionState()) {
             if (mScanHelper.getRangedRegionState().containsKey(region)) {
                 LogManager.i(TAG, "Already ranging that region -- will replace existing region.");
-                mScanHelper.getRangedRegionState().remove(region); // need to remove it, otherwise the old object will be retained because they are .equal //FIXME That is not true
+                // Need to explicitly remove because only value is updated for equals keys.
+                mScanHelper.getRangedRegionState().remove(region);
             }
             mScanHelper.getRangedRegionState().put(region, new RangeState(callback));
             LogManager.d(TAG, "Currently ranging %s regions.", mScanHelper.getRangedRegionState().size());

--- a/lib/src/test/java/org/altbeacon/beacon/BeaconManagerTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/BeaconManagerTest.java
@@ -57,4 +57,26 @@ public class BeaconManagerTest {
     assertEquals(beaconManager.getRangedRegions().size(), 2);
   }
 
+  @Test
+  public void stopRangingBeaconsInRegionTest() throws Exception {
+    BeaconManager beaconManager = BeaconManager
+        .getInstanceForApplication(RuntimeEnvironment.application);
+
+    String id = "id";
+    Region region1 = new Region(id, Collections.<Identifier>emptyList());
+    Region region2 = new Region(id, "00:11:22:33:FF:EE");
+    Region region3 = new Region(id + "-other", Collections.<Identifier>emptyList());
+
+    beaconManager.startRangingBeaconsInRegion(region1);
+    beaconManager.startRangingBeaconsInRegion(region2);
+    beaconManager.startRangingBeaconsInRegion(region3);
+    assertEquals(beaconManager.getRangedRegions().size(), 2);
+
+    beaconManager.stopRangingBeaconsInRegion(region1);
+    assertEquals(beaconManager.getRangedRegions().size(), 1);
+
+    beaconManager.stopRangingBeaconsInRegion(region3);
+    assertEquals(beaconManager.getRangedRegions().size(), 0);
+  }
+
 }

--- a/lib/src/test/java/org/altbeacon/beacon/BeaconManagerTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/BeaconManagerTest.java
@@ -1,0 +1,60 @@
+package org.altbeacon.beacon;
+
+import org.altbeacon.beacon.logging.LogManager;
+import org.altbeacon.beacon.logging.Loggers;
+import org.altbeacon.beacon.simulator.BeaconSimulator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class BeaconManagerTest {
+
+  @Before
+  public void before() {
+    org.robolectric.shadows.ShadowLog.stream = System.err;
+    LogManager.setLogger(Loggers.verboseLogger());
+    LogManager.setVerboseLoggingEnabled(true);
+    BeaconManager.setsManifestCheckingDisabled(true);
+    BeaconManager.setBeaconSimulator(new BeaconSimulator() {
+      @Override
+      public List<Beacon> getBeacons() {
+        return Collections.emptyList();
+      }
+    });
+  }
+
+  @Test
+  public void startRangingBeaconsInRegionMultipleInvocationsTest() throws Exception {
+    BeaconManager beaconManager = BeaconManager
+        .getInstanceForApplication(RuntimeEnvironment.application);
+
+    String id = "id";
+    Region region1 = new Region(id, Collections.<Identifier>emptyList());
+    Region region2 = new Region(id, "00:11:22:33:FF:EE");
+
+    beaconManager.startRangingBeaconsInRegion(region1);
+    assertEquals(beaconManager.getRangedRegions().size(), 1);
+    assertSame(beaconManager.getRangedRegions().iterator().next(), region1);
+    assertNotSame(beaconManager.getRangedRegions().iterator().next(), region2);
+
+    beaconManager.startRangingBeaconsInRegion(region2);
+    assertEquals(beaconManager.getRangedRegions().size(), 1);
+    assertNotSame(beaconManager.getRangedRegions().iterator().next(), region1);
+    assertSame(beaconManager.getRangedRegions().iterator().next(), region2);
+
+    Region region3 = new Region(id + "-other", Collections.<Identifier>emptyList());
+    beaconManager.startRangingBeaconsInRegion(region3);
+    assertEquals(beaconManager.getRangedRegions().size(), 2);
+  }
+
+}


### PR DESCRIPTION
Closes https://github.com/AltBeacon/android-beacon-library/issues/990

> Long-running app may call "startRangingBeaconsInRegion" a significant number of times.
There's no internal check if such range is already present resulting in unlimited array growth.