### PR TITLE
Reduce min-sdk to 14. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following instructions are for project administrators.
 
         git tag <version>
         git push --tags 
-        ./gradlew release 
+        ./gradlew release
         ./gradlew mavenPublish
         ./gradlew closeAndReleaseRepository
 

--- a/build.gradle
+++ b/build.gradle
@@ -54,5 +54,9 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-apply plugin: 'io.codearte.nexus-staging'
+if (getGradle().getStartParameter().getTaskRequests().toString().contains("release") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("mavenPublish") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("closeAndReleaseRepository")) {
+    apply plugin: 'io.codearte.nexus-staging'
+}
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 14
         targetSdkVersion 30
         versionCode 1
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -75,4 +75,8 @@ ext {
     PUBLISH_VERSION = version
     PUBLISH_ARTIFACT_ID = 'android-beacon-library'
 }
-apply from: "../gradle/publish-mavencentral.gradle"
+if (getGradle().getStartParameter().getTaskRequests().toString().contains("release") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("mavenPublish") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("closeAndReleaseRepository")) {
+    apply from: "../gradle/publish-mavencentral.gradle"
+}


### PR DESCRIPTION
This reduces them minimum Android SDK version for using this library to 14.  

This had been unnecessarily increased to 21 in the 2.18 release.  I could have sworn that I was forced to do this by using a modern Android dependency, but when I went back to find it I could not.



