### PR TITLE
Expedite foreground promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.19-beta / 2021-04028
+
+- Reduce crashes on starting foreground service (#1024, David G. Young)
+- Reduce minSdk to 14 (#1023 David G. Young)
+- Add experimental LiveData interface (#1025, David G. Young)
+
 ### 2.18 / 2021-04-14
 
 - Remove dependency on androidx.localbroadcastmanager.content.LocalBroadcastManager (#1022, David G. Young)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The following instructions are for project administrators.
 
         git tag <version>
         git push --tags 
-        ./gradlew release 
+        ./gradlew release
         ./gradlew mavenPublish
         ./gradlew closeAndReleaseRepository
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,5 +56,9 @@ task clean(type: Delete) {
     delete rootProject.buildDir
 }
 
-apply plugin: 'io.codearte.nexus-staging'
+if (getGradle().getStartParameter().getTaskRequests().toString().contains("release") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("mavenPublish") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("closeAndReleaseRepository")) {
+    apply plugin: 'io.codearte.nexus-staging'
+}
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -77,8 +77,12 @@ ext {
     PUBLISH_VERSION = version
     PUBLISH_ARTIFACT_ID = 'android-beacon-library'
 }
-apply from: "../gradle/publish-mavencentral.gradle"
 apply plugin: 'kotlin-android'
 repositories {
     mavenCentral()
+}
+if (getGradle().getStartParameter().getTaskRequests().toString().contains("release") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("mavenPublish") ||
+        getGradle().getStartParameter().getTaskRequests().toString().contains("closeAndReleaseRepository")) {
+    apply from: "../gradle/publish-mavencentral.gradle"
 }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'org.apache.commons:commons-math3:3.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.3.2"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -196,6 +196,7 @@ public class BeaconService extends Service {
     @MainThread
     @Override
     public void onCreate() {
+        this.startForegroundIfConfigured();
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             bluetoothCrashResolver = new BluetoothCrashResolver(this);
             bluetoothCrashResolver.start();
@@ -246,7 +247,6 @@ public class BeaconService extends Service {
         } catch (Exception e) {
             LogManager.e(e, TAG, "Cannot get simulated Scan data.  Make sure your org.altbeacon.beacon.SimulatedScanData class defines a field with the signature 'public static List<Beacon> beacons'");
         }
-        this.startForegroundIfConfigured();
     }
 
 

--- a/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
+++ b/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
@@ -11,6 +11,12 @@ import org.altbeacon.beacon.logging.LogManager;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+/**
+ * Utility class for detecting when an Android device enters and leaves various Doze modes
+ * April 02, 2019
+ * (c) 2019 David G. Young
+ * Apache 2 License
+ */
 public class DozeDetector {
     private static final String TAG = DozeDetector.class.getSimpleName();
 

--- a/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
+++ b/lib/src/main/java/org/altbeacon/beacon/utils/DozeDetector.java
@@ -1,0 +1,88 @@
+package org.altbeacon.beacon.utils;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.PowerManager;
+
+import org.altbeacon.beacon.logging.LogManager;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class DozeDetector {
+    private static final String TAG = DozeDetector.class.getSimpleName();
+
+    public boolean isInDozeMode(Context context) {
+        return isInFullDozeMode(context) == true || isInLightDozeMode(context) == true;
+    }
+    public boolean isInLightDozeMode(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+            try {
+                Method isLightDeviceIdleModeMethod = pm.getClass().getDeclaredMethod("isLightDeviceIdleMode");
+                boolean result =  (boolean)isLightDeviceIdleModeMethod.invoke(pm);
+                LogManager.d(TAG, "Light Doze mode? pm.isLightDeviceIdleMode: " + result);
+                return result;
+            } catch (IllegalAccessException | InvocationTargetException  | NoSuchMethodException e) {
+                LogManager.d(TAG, "Reflection failed for isLightDeviceIdleMode: " + e.toString(), e);
+            }
+        }
+        else {
+            LogManager.d(TAG, "We can't be in doze mode as we are pre-Android M");
+        }
+        return false;
+    }
+    public boolean isInFullDozeMode(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+
+            if (pm == null) {
+                LogManager.d(TAG, "Can't get PowerManager to check doze mode.");
+                return false;
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                LogManager.d(TAG, "Full Doze mode? pm.isDeviceIdleMode()="+pm.isDeviceIdleMode());
+                if (pm.isDeviceIdleMode()) {
+                    return true;
+                }
+            }
+
+            LogManager.d(TAG, "Doze mode? pm.isPowerSaveMode()="+pm.isPowerSaveMode());
+            return pm.isPowerSaveMode();
+        }
+        else {
+            LogManager.d(TAG, "We can't be in doze mode as we are pre-Android M");
+        }
+        return false;
+    }
+
+    public void registerDozeCallbacks(Context context, BroadcastReceiver receiver) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED);
+        context.registerReceiver(receiver, filter);
+
+        filter = new IntentFilter();
+        String action = getLightIdleModeChangeAction();
+        filter.addAction(action);
+        context.registerReceiver(receiver, filter);
+    }
+
+    public String getLightIdleModeChangeAction() {
+        String action = "android.os.action.LIGHT_DEVICE_IDLE_MODE_CHANGE";
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            try {
+                Object reflectionAction =PowerManager.class.getField("ACTION_LIGHT_DEVICE_IDLE_MODE_CHANGED").get(null);
+                if (reflectionAction != null && reflectionAction instanceof String) {
+                    action = (String) reflectionAction;
+                }
+            } catch (Exception e) {
+                LogManager.d(TAG, "Cannot get LIGHT_DEVICE_IDLE_MODE_CHANGE action: " + e.toString(), e);
+            }
+        }
+        return action;
+    }
+
+}


### PR DESCRIPTION
This moves the `BeaconService` call to promote itself to a foreground service to the first line in `onCreate`.  This is done in an attempt to avoid crashes initiated by Android caused by the failure to promote a service to a foreground service within 5 seconds.  Such an exception looks like this:

```
android.app.RemoteServiceException: Context.startForegroundService() did not then call Service.startForeground(): ServiceRecord{2ce3f6e u0 com.myapp/org.altbeacon.beacon.service.BeaconService}
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1801)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:210)
    at android.app.ActivityThread.main(ActivityThread.java:7124)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:898)
```

Because the service is started on the main thread, it is possible that if that thread is very busy or blocked (potentially by other apps!) then it may take a long time to even call this onCreate method.  In some cases where the main thread is busy or blocked, it may not be possible to do this in 5 seconds.  Forum posts are full of claims from crash logs that this happens sometimes.

This is no guaranteed fix.  But moving this to the top of the method gives the best thing that this library can do to prevent this crash.  The app developer needs to take care not to initialize this library to start scanning in a case where the main thread could be blocked or overly busy.  In other words, don't initialize beacon scanning then immediately do a large amount of work on the main thread.

This is in the 2.19-beta version of the library