### PR TITLE
Add Experimental LiveData support for ranging and monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Remove dependency on androidx.localbroadcastmanager.content.LocalBroadcastManager (#1022, David G. Young)
 - Redo build scripts and publishing setup for Maven Central due to JCenter sunset (#1022, David G. Young)
+- Prevent internal growth of rangedRegions tracking set  (#922, Oleksandr Vandalko)
 
 ### 2.17.1 / 2020-06-11
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         mavenCentral()
@@ -8,6 +9,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.3"
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,7 +7,7 @@ android {
     buildToolsVersion "30.0.3"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 14
         targetSdkVersion 30
         versionCode 1
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -68,6 +68,8 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.1.0'
     androidTestImplementation 'org.apache.commons:commons-math3:3.6.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    implementation "androidx.core:core-ktx:+"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 ext {
@@ -76,3 +78,7 @@ ext {
     PUBLISH_ARTIFACT_ID = 'android-beacon-library'
 }
 apply from: "../gradle/publish-mavencentral.gradle"
+apply plugin: 'kotlin-android'
+repositories {
+    mavenCentral()
+}

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -58,6 +58,7 @@ import org.altbeacon.beacon.utils.ProcessUtils;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -215,6 +216,27 @@ public class BeaconManager {
     private long foregroundBetweenScanPeriod = DEFAULT_FOREGROUND_BETWEEN_SCAN_PERIOD;
     private long backgroundScanPeriod = DEFAULT_BACKGROUND_SCAN_PERIOD;
     private long backgroundBetweenScanPeriod = DEFAULT_BACKGROUND_BETWEEN_SCAN_PERIOD;
+    private HashMap<Region,RegionViewModel> mRegionViewModels = new HashMap<Region,RegionViewModel>();
+
+    /**
+     * LiveData object for getting beacon ranging and monitoring updates
+     * @return
+     */
+    public @NonNull RegionViewModel getRegionViewModel(Region region) {
+        RegionViewModel regionViewModel = mRegionViewModels.get(region);
+        if (regionViewModel != null) {
+            return regionViewModel;
+        }
+        else {
+            regionViewModel = new RegionViewModel();
+            mRegionViewModels.put(region,regionViewModel);
+            return regionViewModel;
+        }
+    }
+
+    public boolean isRegionViewModelInitialized(Region region) {
+        return mRegionViewModels.get(region) != null;
+    }
 
     /**
      * Sets the duration in milliseconds of each Bluetooth LE scan cycle to look for beacons.

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -221,7 +221,9 @@ public class BeaconManager {
     /**
      * LiveData object for getting beacon ranging and monitoring updates
      * @return
+     * @deprecated this method is experimental and subject to modification or removal at any time.
      */
+    @Deprecated
     public @NonNull RegionViewModel getRegionViewModel(Region region) {
         RegionViewModel regionViewModel = mRegionViewModels.get(region);
         if (regionViewModel != null) {

--- a/lib/src/main/java/org/altbeacon/beacon/IntentHandler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/IntentHandler.java
@@ -56,17 +56,21 @@ class IntentHandler {
             if (dataNotifier != null) {
                 dataNotifier.didRangeBeaconsInRegion(beacons, rangingData.getRegion());
             }
+            if (BeaconManager.getInstanceForApplication(context).isRegionViewModelInitialized(rangingData.getRegion())) {
+                RegionViewModel regionViewModel = BeaconManager.getInstanceForApplication(context).getRegionViewModel(rangingData.getRegion());
+                regionViewModel.getRangedBeacons().postValue(rangingData.getBeacons());
+            }
         }
 
         if (monitoringData != null) {
             LogManager.d(TAG, "got monitoring data");
             Set<MonitorNotifier> notifiers = BeaconManager.getInstanceForApplication(context).getMonitoringNotifiers();
+            Region region = monitoringData.getRegion();
+            Integer state = monitoringData.isInside() ? MonitorNotifier.INSIDE :
+                    MonitorNotifier.OUTSIDE;
             if (notifiers != null) {
                 for(MonitorNotifier notifier : notifiers) {
                     LogManager.d(TAG, "Calling monitoring notifier: %s", notifier);
-                    Region region = monitoringData.getRegion();
-                    Integer state = monitoringData.isInside() ? MonitorNotifier.INSIDE :
-                            MonitorNotifier.OUTSIDE;
                     notifier.didDetermineStateForRegion(state, region);
                     // In case the beacon scanner is running in a separate process, the monitoring
                     // status in this process  will not have been updated yet as a result of this
@@ -79,6 +83,11 @@ class IntentHandler {
                     }
                 }
             }
+            if (BeaconManager.getInstanceForApplication(context).isRegionViewModelInitialized(monitoringData.getRegion())) {
+                RegionViewModel regionViewModel = BeaconManager.getInstanceForApplication(context).getRegionViewModel(monitoringData.getRegion());
+                regionViewModel.getRegionState().postValue(state);
+            }
+
         }
 
     }

--- a/lib/src/main/java/org/altbeacon/beacon/RegionViewModel.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/RegionViewModel.kt
@@ -1,0 +1,13 @@
+package org.altbeacon.beacon
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class RegionViewModel: ViewModel() {
+    val regionState: MutableLiveData<Int> by lazy {
+        MutableLiveData<Int>()
+    }
+    val rangedBeacons: MutableLiveData<Collection<Beacon>> by lazy {
+        MutableLiveData<Collection<Beacon>>()
+    }
+}


### PR DESCRIPTION
This adds experimental LiveData support for beacon ranging and monitoring.  With this change, it is possible to do the following from a Kotlin Activity instead of using RangeNotifier and MonitorNotifier:

```
    val monitoringObserver = Observer<Int> { state ->
        var stateString = "inside"
        if (state == MonitorNotifier.OUTSIDE) {
            stateString == "outside"
        }
        Log.d(TAG, "monitoring state changed to : $stateString")
    }

    val rangingObserver = Observer<Collection<Beacon>> { beacons ->
        Log.d(TAG, "Ranged: ${beacons.count()} beacons")
    }

        // These two lines set up a Live Data observer so this Activity can get beacon data from the Application class
        val regionViewModel = BeaconManager.getInstanceForApplication(this).getRegionViewModel(region)
        // observer will be called each time the monitored regionState changes (inside vs. outside region)
        regionViewModel.regionState.observe(this, monitoringObserver)
        // observer will be called each time a new list of beacons is ranged (typically ~1 second in the foreground)
        regionViewModel.rangedBeacons.observe(this, rangingObserver)
```