### PR TITLE
Background beacon scanning without a foreground service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.19-beta2 / 2021-06-07
 
-- Add experimental IntentScanStrategy to eliminate a foreground service for some background scan use cases. (#1034, David G. Young)
+- Add experimental IntentScanStrategy to eliminate a foreground service for some background scan use cases. (#1030, David G. Young)
 - Update service declarations as required for Android 12 (#1033, David G. Young)
 
 ### 2.19-beta / 2021-04-28

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -477,7 +477,7 @@ public class BeaconManager {
      */
     public void handleStategyFailover() {
         if (mIntentScanStrategyCoordinator != null) {
-            if (mIntentScanStrategyCoordinator.getDisableOnFailure() && mIntentScanStrategyCoordinator.getStrategyFailureDetected()) {
+            if (mIntentScanStrategyCoordinator.getDisableOnFailure() && mIntentScanStrategyCoordinator.getLastStrategyFailureDetectionCount() > 0) {
                 mIntentScanStrategyCoordinator = null;
                 LogManager.d(TAG, "unbinding all consumers for failover from intent strategy");
                 List<BeaconConsumer> oldConsumers = new ArrayList<BeaconConsumer>(consumers.keySet());

--- a/lib/src/main/java/org/altbeacon/beacon/IntentHandler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/IntentHandler.java
@@ -21,8 +21,7 @@ import java.util.Set;
  * Created by dyoung on 7/20/17.
  */
 
-/* package private*/
-class IntentHandler {
+public class IntentHandler {
     private static final String TAG = IntentHandler.class.getSimpleName();
     public void convertIntentsToCallbacks(Context context, Intent intent) {
         MonitoringData monitoringData = null;

--- a/lib/src/main/java/org/altbeacon/beacon/Region.java
+++ b/lib/src/main/java/org/altbeacon/beacon/Region.java
@@ -161,6 +161,10 @@ public class Region implements Parcelable, Serializable {
         return mIdentifiers.size() > i ? mIdentifiers.get(i) : null;
     }
 
+    public List<Identifier> getIdentifiers() {
+        return new ArrayList<>(mIdentifiers);
+    }
+
     /**
      * Returns the identifier used to start or stop ranging/monitoring this region when calling
      * the <code>BeaconManager</code> methods.

--- a/lib/src/main/java/org/altbeacon/beacon/service/IntentScanStrategyCoordinator.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/service/IntentScanStrategyCoordinator.kt
@@ -1,0 +1,126 @@
+package org.altbeacon.beacon.service
+
+import android.bluetooth.le.ScanResult
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageItemInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import org.altbeacon.beacon.BeaconManager
+import org.altbeacon.beacon.logging.LogManager
+import java.util.*
+
+class IntentScanStrategyCoordinator(val context: Context) {
+    private lateinit var scanHelper: ScanHelper
+    private lateinit var scanState: ScanState
+    private var initialized = false
+    private var started = false
+    private var longScanForcingEnabled = false
+    private var lastCycleEnd: Long = 0
+
+    fun ensureInitialized() {
+        if (!initialized) {
+            initialized = true
+            scanHelper = ScanHelper(context)
+            reinitialize()
+        }
+    }
+    fun reinitialize() {
+        if (!initialized) {
+            ensureInitialized() // this will call reinitialize
+            return
+        }
+        var newScanState = ScanState.restore(context)
+        if (newScanState == null) {
+            newScanState = ScanState(context)
+        }
+        scanState = newScanState
+        scanState.setLastScanStartTimeMillis(System.currentTimeMillis())
+        scanHelper.monitoringStatus = scanState.getMonitoringStatus()
+        scanHelper.rangedRegionState = scanState.getRangedRegionState()
+        scanHelper.setBeaconParsers(scanState.getBeaconParsers())
+        scanHelper.setExtraDataBeaconTracker(scanState.getExtraBeaconDataTracker())
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun applySettings() {
+        reinitialize()
+        scanState.applyChanges(BeaconManager.getInstanceForApplication(context))
+        restartBackgroundScan()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun start() {
+        started = true
+        ensureInitialized()
+        val beaconManager =
+            BeaconManager.getInstanceForApplication(context)
+        scanHelper.setExtraDataBeaconTracker(ExtraDataBeaconTracker())
+        beaconManager.setScannerInSameProcess(true)
+        val longScanForcingEnabledString =  getManifestMetadataValue("longScanForcingEnabled")
+        if (longScanForcingEnabledString != null && longScanForcingEnabledString == "true") {
+            LogManager.i(
+                BeaconService.TAG,
+                "longScanForcingEnabled to keep scans going on Android N for > 30 minutes"
+            )
+            longScanForcingEnabled = true
+        }
+        scanHelper.reloadParsers()
+        LogManager.d(TAG, "starting background scan")
+        scanHelper.startAndroidOBackgroundScan(scanState.getBeaconParsers())
+        lastCycleEnd = java.lang.System.currentTimeMillis()
+    }
+
+    private fun getManifestMetadataValue(key: String): String? {
+        val value: String? = null
+        try {
+            val info: PackageItemInfo = context.getPackageManager().getServiceInfo(
+                ComponentName(
+                    context,
+                    BeaconService::class.java
+                ), PackageManager.GET_META_DATA
+            )
+            if (info != null && info.metaData != null) {
+                return info.metaData[key].toString()
+            }
+        } catch (e: PackageManager.NameNotFoundException) {
+        }
+        return null
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun stop() {
+        ensureInitialized()
+        LogManager.d(TAG, "stopping background scan")
+        scanHelper.stopAndroidOBackgroundScan()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun restartBackgroundScan() {
+        ensureInitialized()
+        LogManager.d(TAG, "restarting background scan")
+        scanHelper.stopAndroidOBackgroundScan()
+        // We may need to pause between these two events?
+        scanHelper.startAndroidOBackgroundScan(scanState.getBeaconParsers())
+    }
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun processScanResults(scanResults: ArrayList<ScanResult?>) {
+        ensureInitialized()
+        for (scanResult in scanResults) {
+            if (scanResult != null) {
+                LogManager.d(TAG, "Got scan result: "+scanResult)
+                scanHelper.processScanResult(scanResult.device, scanResult.rssi, scanResult.scanRecord?.bytes, scanResult.timestampNanos/1000)
+            }
+        }
+        val now = java.lang.System.currentTimeMillis()
+        if (now - lastCycleEnd > BeaconManager.getInstanceForApplication(context).getForegroundScanPeriod()) {
+            LogManager.d(TAG, "End of scan cycle");
+            lastCycleEnd = now
+            scanHelper.getCycledLeScanCallback().onCycleEnd()
+        }
+    }
+    companion object {
+        val TAG = "IntentScanCoord"
+    }
+}

--- a/lib/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/MonitoringStatus.java
@@ -114,6 +114,18 @@ public class MonitoringStatus {
         }
     }
 
+    public synchronized boolean insideAnyRegion() {
+        Iterator<Region> monitoredRegionIterator = regions().iterator();
+        while (monitoredRegionIterator.hasNext()) {
+            Region region = monitoredRegionIterator.next();
+            RegionMonitoringState state = stateOf(region);
+            if (state != null && state.getInside() == true) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public synchronized void updateNewlyInsideInRegionsContaining(Beacon beacon) {
         List<Region> matchingRegions = regionsMatchingTo(beacon);
         boolean needsMonitoringStateSaving = false;

--- a/lib/src/main/java/org/altbeacon/beacon/service/RangeState.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RangeState.java
@@ -62,6 +62,12 @@ public class RangeState implements Serializable {
         }
     }
 
+    public int count() {
+        synchronized (mRangedBeacons) {
+            return mRangedBeacons.size();
+        }
+    }
+
     // returns a list of beacons that are tracked, and then removes any from the list that should not
     // be there for the next cycle
     public synchronized Collection<Beacon> finalizeBeacons() {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -298,7 +298,6 @@ class ScanHelper {
         }
     };
 
-    @RestrictTo(Scope.TESTS)
     CycledLeScanCallback getCycledLeScanCallback() {
         return mCycledLeScanCallback;
     }

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -25,6 +25,7 @@ import androidx.annotation.RestrictTo.Scope;
 import org.altbeacon.beacon.Beacon;
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.BeaconParser;
+import org.altbeacon.beacon.Identifier;
 import org.altbeacon.beacon.Region;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.service.scanner.CycledLeScanCallback;
@@ -186,9 +187,13 @@ class ScanHelper {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     void startAndroidOBackgroundScan(Set<BeaconParser> beaconParsers) {
+        startAndroidOBackgroundScan(beaconParsers, null);
+    }
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    void startAndroidOBackgroundScan(Set<BeaconParser> beaconParsers, List<Region> regions) {
         ScanSettings settings = (new ScanSettings.Builder().setScanMode(ScanSettings.SCAN_MODE_LOW_POWER)).build();
         List<ScanFilter> filters = new ScanFilterUtils().createScanFiltersForBeaconParsers(
-                new ArrayList<BeaconParser>(beaconParsers));
+                new ArrayList<BeaconParser>(beaconParsers), regions);
         try {
             final BluetoothManager bluetoothManager =
                     (BluetoothManager) mContext.getApplicationContext().getSystemService(Context.BLUETOOTH_SERVICE);
@@ -357,6 +362,17 @@ class ScanHelper {
                 }
             }
         }
+    }
+    
+    public boolean anyBeaconsDetectedThisCycle() {
+        synchronized (mRangedRegionState) {
+            for (RangeState rangeState: mRangedRegionState.values()) {
+                if (rangeState.count() > 0) {
+                    return true;
+                }
+            }
+        }
+        return mMonitoringStatus.insideAnyRegion();
     }
 
     /**

--- a/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -7,6 +7,7 @@ import android.bluetooth.le.ScanSettings;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -25,12 +26,12 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
     @Override
     public void onReceive(Context context, Intent intent) {
         LogManager.d(TAG, "onReceive called in startup broadcast receiver");
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "Not starting up beacon service because we do not have API version 18 (Android 4.3).  We have: %s", android.os.Build.VERSION.SDK_INT);
+        if (Build.VERSION.SDK_INT < 18) {
+            LogManager.w(TAG, "Not starting up beacon service because we do not have API version 18 (Android 4.3).  We have: %s", Build.VERSION.SDK_INT);
             return;
         }
         BeaconManager beaconManager = BeaconManager.getInstanceForApplication(context.getApplicationContext());
-        if (beaconManager.isAnyConsumerBound() || beaconManager.getScheduledScanJobsEnabled()) {
+        if (beaconManager.isAnyConsumerBound() || beaconManager.getScheduledScanJobsEnabled() || beaconManager.getIntentScanStrategyCoordinator() != null) {
             int bleCallbackType = intent.getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, -1); // e.g. ScanSettings.CALLBACK_TYPE_FIRST_MATCH
             if (bleCallbackType != -1) {
                 LogManager.d(TAG, "Passive background scan callback type: "+bleCallbackType);
@@ -40,7 +41,13 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
                     LogManager.w(TAG, "Passive background scan failed.  Code; "+errorCode);
                 }
                 ArrayList<ScanResult> scanResults = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
-                ScanJobScheduler.getInstance().scheduleAfterBackgroundWakeup(context, scanResults);
+
+                if (beaconManager.getIntentScanStrategyCoordinator() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    beaconManager.getIntentScanStrategyCoordinator().processScanResults(scanResults);
+                }
+                else if (beaconManager.getScheduledScanJobsEnabled() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    ScanJobScheduler.getInstance().scheduleAfterBackgroundWakeup(context, scanResults);
+                }
             }
             else if (intent.getBooleanExtra("wakeup", false)) {
                 LogManager.d(TAG, "got wake up intent");

--- a/lib/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import org.altbeacon.beacon.AltBeaconParser;
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.BeaconParser;
+import org.altbeacon.beacon.Identifier;
 import org.altbeacon.beacon.service.scanner.ScanFilterUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -45,7 +46,7 @@ public class ScanFilterUtilsTest {
     public void testGetAltBeaconScanFilter() throws Exception {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         BeaconParser parser = new AltBeaconParser();
-        BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
+        BeaconManager.setManifestCheckingDisabled(true); // no manifest available in robolectric
         List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
@@ -59,7 +60,7 @@ public class ScanFilterUtilsTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=1111,i:4-6,p:24-24");
-        BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
+        BeaconManager.setManifestCheckingDisabled(true); // no manifest available in robolectric
         List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
@@ -74,7 +75,7 @@ public class ScanFilterUtilsTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout(BeaconParser.EDDYSTONE_UID_LAYOUT);
-        BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
+        BeaconManager.setManifestCheckingDisabled(true); // no manifest available in robolectric
         List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
@@ -86,7 +87,7 @@ public class ScanFilterUtilsTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:0-3=11223344,i:4-6,p:24-24");
-        BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
+        BeaconManager.setManifestCheckingDisabled(true); // no manifest available in robolectric
         List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
@@ -94,6 +95,25 @@ public class ScanFilterUtilsTest {
         assertEquals("mask length should be right", 2, sfd.mask.length);
         assertArrayEquals("mask should be right", new byte[] {(byte)0xff, (byte)0xff}, sfd.mask);
         assertArrayEquals("filter should be right", new byte[] {(byte)0x33, (byte)0x44}, sfd.filter);
+    }
+
+    @Test
+    public void testScanFilterWithIdentifiers() throws Exception {
+        org.robolectric.shadows.ShadowLog.stream = System.err;
+        BeaconParser parser = new BeaconParser().setBeaconLayout("m:2-3=0215,i:4-19,i:20-21,i:22-23,p:24-24");
+        parser.setHardwareAssistManufacturerCodes(new int[] {0x004c});
+        BeaconManager.setManifestCheckingDisabled(true); // no manifest available in robolectric
+        ArrayList<Identifier> identifiers = new ArrayList<Identifier>();
+        identifiers.add(Identifier.parse("2F234454-CF6D-4A0F-ADF2-F4911BA9FFA6"));
+        identifiers.add(Identifier.parse("0x0102"));
+        identifiers.add(Identifier.parse("0x0304"));
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, identifiers);
+        assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
+        ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
+        assertEquals("manufacturer should be right", 0x004c, sfd.manufacturer);
+        assertEquals("mask length should be right", 22, sfd.mask.length);
+        assertArrayEquals("mask should be right", new byte[] {(byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff, (byte)0xff}, sfd.mask);
+        assertArrayEquals("filter should be right", new byte[] {(byte)0x02, (byte)0x15, (byte)0x2F, (byte)0x23, (byte)0x44, (byte)0x54, (byte)0xCF, (byte)0x6D, (byte)0x4A, (byte)0x0F, (byte)0xAD, (byte)0xF2, (byte)0xF4, (byte)0x91, (byte)0x1B, (byte)0xA9, (byte)0xFF, (byte)0xA6, (byte)0x01, (byte)0x02, (byte)0x03, (byte)0x04}, sfd.filter);
     }
 
 }

--- a/lib/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/service/scanner/ScanFilterUtilsTest.java
@@ -46,7 +46,7 @@ public class ScanFilterUtilsTest {
         org.robolectric.shadows.ShadowLog.stream = System.err;
         BeaconParser parser = new AltBeaconParser();
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("manufacturer should be right", 0x0118, sfd.manufacturer);
@@ -60,7 +60,7 @@ public class ScanFilterUtilsTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:2-3=1111,i:4-6,p:24-24");
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("manufacturer should be right", 0x004c, sfd.manufacturer);
@@ -75,7 +75,7 @@ public class ScanFilterUtilsTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout(BeaconParser.EDDYSTONE_UID_LAYOUT);
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("serviceUuid should be right", new Long(0xfeaa), sfd.serviceUuid);
@@ -87,7 +87,7 @@ public class ScanFilterUtilsTest {
         BeaconParser parser = new BeaconParser();
         parser.setBeaconLayout("m:0-3=11223344,i:4-6,p:24-24");
         BeaconManager.setsManifestCheckingDisabled(true); // no manifest available in robolectric
-        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser);
+        List<ScanFilterUtils.ScanFilterData> scanFilterDatas = new ScanFilterUtils().createScanFilterDataForBeaconParser(parser, null);
         assertEquals("scanFilters should be of correct size", 1, scanFilterDatas.size());
         ScanFilterUtils.ScanFilterData sfd = scanFilterDatas.get(0);
         assertEquals("manufacturer should be right", 0x004c, sfd.manufacturer);


### PR DESCRIPTION
This is an experimental implementation of background scanning without a foreground service.

Generally on Android it is not possible to do regular BLE scanning without a long running service to host the timers.   And on Android 8+ this must be a foreground service.

However, Android 8+ does offer an alternative appropriate for some use cases.  You can do a constant BLE scan with matching results delivered by an Android Intent.  This will wake up a suspended app as needed to deliver the results.  There are, however, some limitations:

1. Beacon Ranging results cannot be delivered at regular intervals if bluetooth devices are not detected.  If no devices are detected, ranging callbacks will simply stop.
2. Similarly to the above, Beacon monitoring exit region results cannot be delivered quickly.   It might take 25 minutes for a scheduled job to deliver a region exit.
3. For apps expected to run with large quantities of beacons in the vicinity or ones that transmit at a high rate (10 Hz or more), this can be draining of phone battery when beacons are around.

This technique effectively trades fast "loss of detection" times for not having a foreground service.  If an app can live with this tradeoff, this technique may be beneficial.

To use it, simply set this in config:

`beaconManager.setIntentScanningStrategyEnabled(true);`

Completed tasks:
[x ] Set up a Scheduled Job to deliver  region exit events and empty ranging events every ~15 minutes.
[x] Set up scan filters matching on the whole identifier to prevent excessive battery use when beacons of non-interest are around.
[x ] Build a way to detect if the scan filters used in this technique don't work on a specific device model and offer the option of automatically turning it off in these cases.  (Perhaps this can be done with a scheduled job that does a brief scan to look for beacons -- if the beacons are seen in the job but not in the intent-backed scans this would indicate that the technique fails.

Battery drain still remains to be tested