### PR TITLE
Auto bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+### 2.19-beta5 / 2021-08-01
+
+- Bug fixes to autobind (#1035, David G. Young)
+
+### 2.19-beta4 / 2021-07-10
+
+- Auto start background power saver when using autobind.   Expedite region exits when using intent scan strategy.  (#1035, David G. Young)
+
 ### 2.19-beta3 / 2021-07-04
 
-- Add experimental autobind methods for starting beacon ranging/monitoring without a manual call to bind(). (#10351, David G. Young)
+- Add experimental autobind methods for starting beacon ranging/monitoring without a manual call to bind(). (#1035, David G. Young)
 - Add support for beacon parsers based on 128-bit service UUIDs (#1035, David G. Young)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.19-beta3 / 2021-07-04
+
+- Add experimental autobind methods for starting beacon ranging/monitoring without a manual call to bind(). (#10351, David G. Young)
+- Add support for beacon parsers based on 128-bit service UUIDs (#1035, David G. Young)
+
+
 ### 2.19-beta2 / 2021-06-07
 
 - Add experimental IntentScanStrategy to eliminate a foreground service for some background scan use cases. (#1030, David G. Young)

--- a/lib/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -156,6 +156,16 @@ public class Beacon implements Parcelable, Serializable {
 
     protected int mServiceUuid = -1;
 
+
+    /**
+     * A 128 bit service uuid for the beacon
+     *
+     * This is valid only for GATT-based beacons.   If the beacon is a manufacturer data-based
+     * beacon, this field will be -1
+     */
+
+    protected byte[] mServiceUuid128Bit = {};
+
     /**
      * The Bluetooth device name.  This is a field transmitted by the remote beacon device separate
      * from the advertisement data
@@ -250,6 +260,13 @@ public class Beacon implements Parcelable, Serializable {
         mBluetoothAddress = in.readString();
         mBeaconTypeCode = in.readInt();
         mServiceUuid = in.readInt();
+        boolean hasServiceUuid128bit = in.readBoolean();
+        if (hasServiceUuid128bit) {
+            mServiceUuid128Bit = new byte[16];
+            for (int i = 0; i < 16; i++) {
+                mServiceUuid128Bit[i]= in.readByte();
+            }
+        }
         int dataSize = in.readInt();
         this.mDataFields = new ArrayList<Long>(dataSize);
         for (int i = 0; i < dataSize; i++) {
@@ -289,6 +306,7 @@ public class Beacon implements Parcelable, Serializable {
         this.mBluetoothAddress = otherBeacon.mBluetoothAddress;
         this.mBeaconTypeCode = otherBeacon.getBeaconTypeCode();
         this.mServiceUuid = otherBeacon.getServiceUuid();
+        this.mServiceUuid128Bit = otherBeacon.getServiceUuid128Bit();
         this.mBluetoothName = otherBeacon.mBluetoothName;
         this.mParserIdentifier = otherBeacon.mParserIdentifier;
         this.mMultiFrameBeacon = otherBeacon.mMultiFrameBeacon;
@@ -421,6 +439,10 @@ public class Beacon implements Parcelable, Serializable {
      */
     public int getServiceUuid() {
         return mServiceUuid;
+    }
+
+    public byte[] getServiceUuid128Bit() {
+        return mServiceUuid128Bit;
     }
 
     /**
@@ -667,6 +689,13 @@ public class Beacon implements Parcelable, Serializable {
         out.writeString(mBluetoothAddress);
         out.writeInt(mBeaconTypeCode);
         out.writeInt(mServiceUuid);
+        out.writeBoolean(mServiceUuid128Bit.length != 0);
+        if (mServiceUuid128Bit.length != 0) {
+            for (int i = 0; i < 16; i++) {
+                out.writeByte(mServiceUuid128Bit[i]);
+            }
+        }
+
         out.writeInt(mDataFields.size());
         for (Long dataField: mDataFields) {
             out.writeLong(dataField);
@@ -868,6 +897,11 @@ public class Beacon implements Parcelable, Serializable {
          */
         public Builder setServiceUuid(int serviceUuid) {
             mBeacon.mServiceUuid = serviceUuid;
+            return this;
+        }
+
+        public Builder setServiceUuid128Bit(byte[] serviceUuid128Bit) {
+            mBeacon.mServiceUuid128Bit = serviceUuid128Bit;
             return this;
         }
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1195,7 +1195,7 @@ public class BeaconManager {
         ensureBackgroundPowerSaver();
         if (isAnyConsumerBound()) {
             try {
-                stopRangingBeaconsInRegion(region);
+                stopMonitoringBeaconsInRegion(region);
             } catch (RemoteException e) {
                 LogManager.e(TAG, "Failed to stop monitoring", e);
             }

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
@@ -223,6 +223,7 @@ public class ScanState implements Serializable {
             }
 
             mMonitoringStatus.saveMonitoringStatusIfOn();
+
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/ScanFilterUtils.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/ScanFilterUtils.java
@@ -23,6 +23,7 @@ public class ScanFilterUtils {
     public static final String TAG = "ScanFilterUtils";
     class ScanFilterData {
         public Long serviceUuid = null;
+        public byte[] serviceUuid128Bit = {};
         public int manufacturer;
         public byte[] filter;
         public byte[] mask;
@@ -77,6 +78,7 @@ public class ScanFilterUtils {
                     sfd.mask[i] = (byte) 0xff;
                 }
                 sfd.serviceUuid = null;
+                sfd.serviceUuid128Bit = new byte[0];
                 scanFilters.add(sfd);
                 return scanFilters;
             }
@@ -109,6 +111,7 @@ public class ScanFilterUtils {
             sfd.filter = filter;
             sfd.mask = mask;
             sfd.serviceUuid = serviceUuid;
+            sfd.serviceUuid128Bit = beaconParser.getServiceUuid128Bit();
             scanFilters.add(sfd);
 
         }
@@ -144,9 +147,23 @@ public class ScanFilterUtils {
                         }
                         builder.setServiceUuid(parcelUuid, parcelUuidMask);
                     }
+                    else if (sfd.serviceUuid128Bit.length != 0) {
+                        String serviceUuidString = Identifier.fromBytes(sfd.serviceUuid128Bit, 0, 16, true).toString();
+                        String serviceUuidMaskString = "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF";
+                        ParcelUuid parcelUuid = ParcelUuid.fromString(serviceUuidString);
+                        ParcelUuid parcelUuidMask = ParcelUuid.fromString(serviceUuidMaskString);
+                        if (LogManager.isVerboseLoggingEnabled()) {
+                            LogManager.d(TAG, "making scan filter for service: "+serviceUuidString+" "+parcelUuid);
+                            LogManager.d(TAG, "making scan filter with service mask: "+serviceUuidMaskString+" "+parcelUuidMask);
+                        }
+                        builder.setServiceUuid(parcelUuid, parcelUuidMask);
+                    }
                     else {
                         builder.setServiceUuid(null);
                         builder.setManufacturerData((int) sfd.manufacturer, sfd.filter, sfd.mask);
+                        if (LogManager.isVerboseLoggingEnabled()) {
+                            LogManager.d(TAG, "making scan filter for manufacturer: "+sfd.manufacturer+" "+sfd.filter);
+                        }
                     }
                     ScanFilter scanFilter = builder.build();
                     if (LogManager.isVerboseLoggingEnabled()) {

--- a/lib/src/main/java/org/altbeacon/bluetooth/Pdu.java
+++ b/lib/src/main/java/org/altbeacon/bluetooth/Pdu.java
@@ -11,6 +11,7 @@ public class Pdu {
     private static final String  TAG = "Pdu";
     public static final byte MANUFACTURER_DATA_PDU_TYPE = (byte) 0xff;
     public static final byte GATT_SERVICE_UUID_PDU_TYPE = (byte) 0x16;
+    public static final byte GATT_SERVICE_UUID_128_BIT_PDU_TYPE = (byte) 0x21;
 
     private byte mType;
     private int mDeclaredLength;


### PR DESCRIPTION
Two new features:

1. Auto Bind

Adds new methods to start beacon ranging and monitoring that allows forgoing manual calls to `bind(...)` and `unbind(...)` and the use of `BeaconConsumer`.  This simplifies setup.

`beaconManager.startMonitoring(@NonNull Region region)`
`beaconManager.stopMonitoring(@NonNull Region region)`
`beaconManager.startRangingBeacons(@NonNull Region region)`
`beaconManager.stopRangingBeacons(@NonNull Region region)`

The old methods that do require a manual call to bind and a `BeaconConsumer` first still work:

`beaconManager.startMonitoringBeaconsInRegion(@NonNull Region region)`
`beaconManager.stopMonitoringBeaconsInRegion(@NonNull Region region)`
`beaconManager.startRangingBeaconsInRegion(@NonNull Region region)`
`beaconManager.stopRangingBeaconsInRegion(@NonNull Region region)`

2. Adds support for beacon parsers based on 128-bit service UUIDs. Example:

`beaconManager.getBeaconParsers().add(BeaconParser().setBeaconLayout("s:0-15=2F234454-CF6D-4A0F-ADF2-F4911BA9FFA6,m:16-17=A6FF,p:18-18,i:0-15l"))`

In the example above, a beacon with service UUID 2F234454-CF6D-4A0F-ADF2-F4911BA9FFA6 will be matched if the service data has the first two bytes 0xA6 0xFF.  A single identifier will be parsed out of the beacon which will always be the same as the service UUID.  This is useful for treating service advertisements as beacons for some use cases.


This change is available for testing in 2.19-beta5
