### PR TITLE
Android 12 Changes

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application>
-        <receiver android:name="org.altbeacon.beacon.startup.StartupBroadcastReceiver">
+        <receiver android:name="org.altbeacon.beacon.startup.StartupBroadcastReceiver" android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED"/>
                 <action android:name="android.intent.action.ACTION_POWER_CONNECTED"/>

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -672,7 +672,12 @@ public class BeaconParser implements Serializable {
             String name = null;
             if (device != null) {
                 macAddress = device.getAddress();
-                name = device.getName();
+                try {
+                  name = device.getName();
+                }
+                catch (SecurityException e) {
+                  Log.d(TAG,"Cannot read device name without Manifest.permission.BLUETOOTH_CONNECT");
+                }
             }
 
             beacon.mIdentifiers = identifiers;

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -64,6 +64,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import static android.app.PendingIntent.FLAG_ONE_SHOT;
+import static android.app.PendingIntent.FLAG_IMMUTABLE;
 import static android.app.PendingIntent.getBroadcast;
 
 /**
@@ -358,7 +359,7 @@ public class BeaconService extends Service {
 
     private PendingIntent getRestartIntent() {
         Intent restartIntent = new Intent(getApplicationContext(), StartupBroadcastReceiver.class);
-        return getBroadcast(getApplicationContext(), 1, restartIntent, FLAG_ONE_SHOT);
+        return getBroadcast(getApplicationContext(), 1, restartIntent, FLAG_ONE_SHOT | FLAG_IMMUTABLE);
     }
 
     /**

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -257,7 +257,7 @@ class ScanHelper {
     PendingIntent getScanCallbackIntent() {
         Intent intent = new Intent(mContext, StartupBroadcastReceiver.class);
         intent.putExtra("o-scan", true);
-        return PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
     }
 
     private final CycledLeScanCallback mCycledLeScanCallback = new CycledLeScanCallback() {

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -526,7 +526,7 @@ public abstract class CycledLeScanner {
         if (mWakeUpOperation == null) {
             Intent wakeupIntent = new Intent(mContext, StartupBroadcastReceiver.class);
             wakeupIntent.putExtra("wakeup", true);
-            mWakeUpOperation = PendingIntent.getBroadcast(mContext, 0, wakeupIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+            mWakeUpOperation = PendingIntent.getBroadcast(mContext, 0, wakeupIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
         }
         return mWakeUpOperation;
     }

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -260,7 +260,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     LogManager.e(npe, TAG, "Cannot start scan. Unexpected NPE.");
                 } catch (SecurityException e) {
                     // Thrown by Samsung Knox devices if bluetooth access denied for an app
-                    LogManager.e(TAG, "Cannot start scan.  Security Exception");
+                    LogManager.e(TAG, "Cannot start scan.  Security Exception: "+e.getMessage(), e);
                 }
 
             }
@@ -292,7 +292,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                     LogManager.e(npe, TAG, "Cannot stop scan. Unexpected NPE.");
                 } catch (SecurityException e) {
                     // Thrown by Samsung Knox devices if bluetooth access denied for an app
-                    LogManager.e(TAG, "Cannot stop scan.  Security Exception");
+                    LogManager.e(TAG, "Cannot stop scan.  Security Exception", e);
                 }
 
             }
@@ -308,7 +308,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             LogManager.w(TAG, "Cannot get bluetooth adapter");
         }
         catch (SecurityException e) {
-            LogManager.w(TAG, "SecurityException checking if bluetooth is on");
+            LogManager.w(TAG, "SecurityException checking if bluetooth is on", e);
         }
         return false;
     }
@@ -327,7 +327,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             }
         }
         catch (SecurityException e) {
-            LogManager.w(TAG, "SecurityException making new Android L scanner");
+            LogManager.w(TAG, "SecurityException making new Android L scanner", e);
         }
         return mScanner;
     }

--- a/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
+++ b/lib/src/main/java/org/altbeacon/bluetooth/BluetoothMedic.java
@@ -448,7 +448,7 @@ public class BluetoothMedic {
 
             PendingIntent resultPendingIntent = stackBuilder.getPendingIntent(
                     0,
-                    PendingIntent.FLAG_UPDATE_CURRENT
+                    PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
             );
             builder.setContentIntent(resultPendingIntent);
             NotificationManager notificationManager =


### PR DESCRIPTION
This builds on  #1040 by @nbadal to make a number of changes required to use the library with Android 12:

* All internal PendingIntents must specify FLAG_IMMUTABLE.
* All internal services and broadcast receivers in the library's Manifest must declare android:exported="false" 
* The library's automatic reading of the remote device's Bluetooth name must catch a SecurityException to prevent a crash in the case that the app does not have Manifest.permission.BLUETOOTH_CONNECT permission


## Notes on permissions:

This change does not add any permissions to the library's manifest, as it is unclear what is needed in the final version of Android 12.  Some of this may end up being documentation changes rather than library internal changes.

1. In my tests with Android 12 Build Number SPB3.210618.013, I was unable to get scans to start without throwing a SecurityException (caught internally by the library) unless `android.permission.BLUETOOTH_SCAN` was in the app manifest and granted at runtime by the user **in addition to** `android.permission.FINE_LOCATION`.  This seems contrary to the Android 12 documentation posted of August 12, 2021 [here](https://developer.android.com/about/versions/12/features/bluetooth-permissions) that suggests only one  of the two is necessary.  I am hoping this behavior will change in a subsequent beta release of Android 12.   But for now, apps targeting API 31 must declare both permissions in the manifest and request both from the user at runtime.

2. In order to for Beacon#bluetoothName to be populated in Android 12, the app must declare and  obtain `Manifest.permission.BLUETOOTH_CONNECT` from the user at runtime.

3. While I have not tested this, `android.permission.BLUETOOTH_ADVERTISE` is presumably needed for using `BeaconTransmitter`.   I am not sure if the app will crash or if the transmission will fail silently without this permission. 


