### PR TITLE
Deprecate use bind() and associated methods and classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ def getVersionName = {
 allprojects {
     repositories {
         google()
+        mavenCentral()
         jcenter()
     }
     version = getVersionName()

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconConsumer.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconConsumer.java
@@ -1,32 +1,4 @@
-/**
- * Radius Networks, Inc.
- * http://www.radiusnetworks.com
- *
- * @author David G. Young
- *
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
 package org.altbeacon.beacon;
-
-import android.content.Context;
-import android.content.Intent;
-import android.content.ServiceConnection;
-
 /**
  * An interface for an Android <code>Activity</code> or <code>Service</code>
  * that wants to interact with beacons.  The interface is used in conjunction
@@ -77,33 +49,7 @@ import android.content.ServiceConnection;
  * @see BeaconManager
  *
  * @author David G. Young
- *
+ * @deprecated Will be removed in 3.0.  See http://altbeacon.github.io/android-beacon-library/autobind.html
  */
-public interface BeaconConsumer {
-
-    /**
-     * Called when the beacon service is running and ready to accept your commands through the BeaconManager
-     */
-    public void onBeaconServiceConnect();
-
-    /**
-     * Called by the BeaconManager to get the context of your Service or Activity.  This method is implemented by Service or Activity.
-     * You generally should not override it.
-     * @return the application context of your service or activity
-     */
-    public Context getApplicationContext();
-
-    /**
-     * Called by the BeaconManager to unbind your BeaconConsumer to the  BeaconService.  This method is implemented by Service or Activity, and
-     * You generally should not override it.
-     * @return the application context of your service or activity
-     */
-    public void unbindService(ServiceConnection connection);
-
-    /**
-     * Called by the BeaconManager to bind your BeaconConsumer to the  BeaconService.  This method is implemented by Service or Activity, and
-     * You generally should not override it.
-     * @return the application context of your service or activity
-     */
-    public boolean bindService(Intent intent, ServiceConnection connection, int mode);
-}
+@Deprecated
+public interface BeaconConsumer extends InternalBeaconConsumer { }

--- a/lib/src/main/java/org/altbeacon/beacon/InternalBeaconConsumer.java
+++ b/lib/src/main/java/org/altbeacon/beacon/InternalBeaconConsumer.java
@@ -1,0 +1,57 @@
+/**
+ * Radius Networks, Inc.
+ * http://www.radiusnetworks.com
+ *
+ * @author David G. Young
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.altbeacon.beacon;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+
+public interface InternalBeaconConsumer {
+
+    /**
+     * Called when the beacon service is running and ready to accept your commands through the BeaconManager
+     */
+    public void onBeaconServiceConnect();
+
+    /**
+     * Called by the BeaconManager to get the context of your Service or Activity.  This method is implemented by Service or Activity.
+     * You generally should not override it.
+     * @return the application context of your service or activity
+     */
+    public Context getApplicationContext();
+
+    /**
+     * Called by the BeaconManager to unbind your BeaconConsumer to the  BeaconService.  This method is implemented by Service or Activity, and
+     * You generally should not override it.
+     * @return the application context of your service or activity
+     */
+    public void unbindService(ServiceConnection connection);
+
+    /**
+     * Called by the BeaconManager to bind your BeaconConsumer to the  BeaconService.  This method is implemented by Service or Activity, and
+     * You generally should not override it.
+     * @return the application context of your service or activity
+     */
+    public boolean bindService(Intent intent, ServiceConnection connection, int mode);
+}

--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaver.java
@@ -13,85 +13,22 @@ import org.altbeacon.beacon.logging.LogManager;
 /**
  * Simply creating an instance of this class and holding a reference to it in your Application can
  * improve battery life by 60% by slowing down scans when your app is in the background.
+ * @deprecated Will be removed in 3.0.  See http://altbeacon.github.io/android-beacon-library/autobind.html
  */
+@Deprecated
 @TargetApi(18)
-public class BackgroundPowerSaver implements Application.ActivityLifecycleCallbacks {
-    @NonNull
-    private static final String TAG = "BackgroundPowerSaver";
-
-    @NonNull
-    private final BeaconManager beaconManager;
-
-    private int activeActivityCount = 0;
-
-    /**
-     * Constructs a new BackgroundPowerSaver
-     *
-     * @deprecated the {@code countActiveActivityStrategy} flag is no longer used. Use
-     * {@link #BackgroundPowerSaver(Context)}
-     */
-    @Deprecated
-    public BackgroundPowerSaver(Context context, boolean countActiveActivityStrategy) {
-        this(context);
-    }
-
+public class BackgroundPowerSaver extends BackgroundPowerSaverInternal {
     /**
      * Constructs a new BackgroundPowerSaver using the default background determination strategy
      *
      * @param context
      */
     public BackgroundPowerSaver(Context context) {
-        if (android.os.Build.VERSION.SDK_INT < 18) {
-            LogManager.w(TAG, "BackgroundPowerSaver requires API 18 or higher.");
-        }
-        beaconManager = BeaconManager.getInstanceForApplication(context);
-        ((Application)context.getApplicationContext()).registerActivityLifecycleCallbacks(this);
+        super(context);
+    }
+    @Deprecated
+    public BackgroundPowerSaver(Context context, boolean countActiveActivityStrategy) {
+        this(context);
     }
 
-    @Override
-    public void onActivityCreated(Activity activity, Bundle bundle) {
-    }
-
-    @Override
-    public void onActivityStarted(Activity activity) {
-    }
-
-    @Override
-    public void onActivityResumed(Activity activity) {
-        activeActivityCount++;
-        if (activeActivityCount < 1) {
-            LogManager.d(TAG, "reset active activity count on resume.  It was %s", activeActivityCount);
-            activeActivityCount = 1;
-        }
-        beaconManager.setBackgroundMode(false);
-        LogManager.d(TAG, "activity resumed: %s active activities: %s", activity, activeActivityCount);
-    }
-
-    @Override
-    public void onActivityPaused(Activity activity) {
-        activeActivityCount--;
-        LogManager.d(
-                TAG,
-                "activity paused: %s active activities: %s",
-                activity,
-                activeActivityCount
-        );
-        if (activeActivityCount < 1) {
-            LogManager.d(TAG, "setting background mode");
-            beaconManager.setBackgroundMode(true);
-        }
-    }
-
-    @Override
-    public void onActivityStopped(Activity activity) {
-    }
-
-    @Override
-    public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
-
-    }
-
-    @Override
-    public void onActivityDestroyed(Activity activity) {
-    }
 }

--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
@@ -1,0 +1,85 @@
+package org.altbeacon.beacon.powersave;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.Application;
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+
+import org.altbeacon.beacon.BeaconManager;
+import org.altbeacon.beacon.logging.LogManager;
+
+/**
+ * @hide internal use only
+ */
+@TargetApi(18)
+public class BackgroundPowerSaverInternal implements Application.ActivityLifecycleCallbacks {
+    @NonNull
+    private static final String TAG = "BackgroundPowerSaver";
+
+    @NonNull
+    private final BeaconManager beaconManager;
+
+    private int activeActivityCount = 0;
+    /**
+     * Constructs a new BackgroundPowerSaver using the default background determination strategy
+     *
+     * @param context
+     */
+    public BackgroundPowerSaverInternal(Context context) {
+        if (android.os.Build.VERSION.SDK_INT < 18) {
+            LogManager.w(TAG, "BackgroundPowerSaver requires API 18 or higher.");
+        }
+        beaconManager = BeaconManager.getInstanceForApplication(context);
+        ((Application)context.getApplicationContext()).registerActivityLifecycleCallbacks(this);
+    }
+
+    @Override
+    public void onActivityCreated(Activity activity, Bundle bundle) {
+    }
+
+    @Override
+    public void onActivityStarted(Activity activity) {
+    }
+
+    @Override
+    public void onActivityResumed(Activity activity) {
+        activeActivityCount++;
+        if (activeActivityCount < 1) {
+            LogManager.d(TAG, "reset active activity count on resume.  It was %s", activeActivityCount);
+            activeActivityCount = 1;
+        }
+        beaconManager.setBackgroundMode(false);
+        LogManager.d(TAG, "activity resumed: %s active activities: %s", activity, activeActivityCount);
+    }
+
+    @Override
+    public void onActivityPaused(Activity activity) {
+        activeActivityCount--;
+        LogManager.d(
+                TAG,
+                "activity paused: %s active activities: %s",
+                activity,
+                activeActivityCount
+        );
+        if (activeActivityCount < 1) {
+            LogManager.d(TAG, "setting background mode");
+            beaconManager.setBackgroundMode(true);
+        }
+    }
+
+    @Override
+    public void onActivityStopped(Activity activity) {
+    }
+
+    @Override
+    public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
+
+    }
+
+    @Override
+    public void onActivityDestroyed(Activity activity) {
+    }
+}

--- a/lib/src/main/java/org/altbeacon/beacon/service/IntentScanStrategyCoordinator.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/service/IntentScanStrategyCoordinator.kt
@@ -63,11 +63,12 @@ class IntentScanStrategyCoordinator(val context: Context) {
 
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     fun applySettings() {
         scanState.applyChanges(BeaconManager.getInstanceForApplication(context))
         reinitialize()
-        restartBackgroundScan()
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+            restartBackgroundScan()
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJobScheduler.java
@@ -242,6 +242,11 @@ public class ScanJobScheduler {
             LogManager.d(TAG, "We are not monitoring or ranging any regions.  We are going to cancel all scan jobs.");
             jobScheduler.cancel(ScanJob.getImmediateScanJobId(context));
             jobScheduler.cancel(ScanJob.getPeriodicScanJobId(context));
+            // We also need to cancel any passive scans left on if we are between scan jobs
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                ScanHelper scanHelper = new ScanHelper(context);
+                scanHelper.stopAndroidOBackgroundScan();
+            }
         }
     }
 }

--- a/lib/src/main/java/org/altbeacon/beacon/startup/BootstrapNotifier.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/BootstrapNotifier.java
@@ -4,6 +4,10 @@ import android.content.Context;
 
 import org.altbeacon.beacon.MonitorNotifier;
 
+/**
+ * @deprecated Will be removed in 3.0.  See http://altbeacon.github.io/android-beacon-library/autobind.html
+ */
+@Deprecated
 public interface BootstrapNotifier extends MonitorNotifier {
     public Context getApplicationContext();
 }

--- a/lib/src/main/java/org/altbeacon/beacon/startup/RegionBootstrap.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/RegionBootstrap.java
@@ -30,7 +30,10 @@ import java.util.List;
  * effectively disabling it.  When using the RegionBootstrap, any custom monitoring code must
  * therefore be placed in the callback methods in the BootstrapNotifier implementation passed to the
  * RegionBootstrap.
+ *
+ * @deprecated Will be removed in 3.0.  See http://altbeacon.github.io/android-beacon-library/autobind.html
  */
+@Deprecated
 public class RegionBootstrap {
 
     protected static final String TAG = "AppStarter";


### PR DESCRIPTION
This marks several methods, classes and interfaces as deprecated in order to phase out manual calls to `bind()` and `BackgroundPowerSaver` that have long been causes of confusion and app bugs.  Replacement mechanisms are simpler, more intuitive and less error-prone.  

Backward compatibility is designed into this change, meaning apps using the discouraged APIs will see no impact other than deprecation warnings.

The impact of this change is documented [here](https://altbeacon.github.io/android-beacon-library/autobind.html)