### PR TITLE
Remove unneeded android material dependency, accidentally added in 2.18

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -54,7 +54,6 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
-    implementation 'com.google.android.material:material:1.3.0'
     testImplementation 'junit:junit:4.+'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'


### PR DESCRIPTION
This removes an unneeded declared dependency accidentally added in the 2.18 release when build scripts were reworked to  publish to Maven Central rather than JCenter.

The binary aar artifact does not include the incorrectly declared dependency `com.google.android.material:material:1.3.0`, so there is no practical impact on apps using library versions 2.18.x and 2.19 with this declaration.  

The only impact is that maven inaccurately reports this declared dependency in android-beacon-library-2.19.pom as reported in #1048.   Please ignore that declared dependency until this is corrected in the next release.