### PR TITLE
Improve default background mode with autobind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### 2.19 /2021 / 2021-08-09
+### 2.19.1 / 2021-08-13
+
+- Improve default background mode with autobind (#1051, David G. Young)
+
+### 2.19 / 2021-08-09
 
 - Manual binding/unbinding deprecated.  (#1046, David G. Young)
 - Android 12 changes. (#1043, Nick Badal, David G. Young)

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1584,6 +1584,7 @@ public class BeaconManager {
      * scan for beacons
      *
      * @param disabled
+     * @deprecated This will be removed in the 3.0 release
      */
     public static void setAndroidLScanningDisabled(boolean disabled) {
         sAndroidLScanningDisabled = disabled;
@@ -1753,6 +1754,7 @@ public class BeaconManager {
     private void ensureBackgroundPowerSaver() {
         if (mInternalBackgroundPowerSaver == null) {
             mInternalBackgroundPowerSaver = new BackgroundPowerSaverInternal(mContext);
+            mInternalBackgroundPowerSaver.enableDefaultBackgroundStateInference();
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
@@ -3,8 +3,12 @@ package org.altbeacon.beacon.powersave;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Bundle;
+import android.os.PowerManager;
 
 import androidx.annotation.NonNull;
 
@@ -18,9 +22,10 @@ import org.altbeacon.beacon.logging.LogManager;
 public class BackgroundPowerSaverInternal implements Application.ActivityLifecycleCallbacks {
     @NonNull
     private static final String TAG = "BackgroundPowerSaver";
-
     @NonNull
     private final BeaconManager beaconManager;
+    @NonNull
+    private final Context applicationContext;
 
     private int activeActivityCount = 0;
     /**
@@ -32,8 +37,9 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
         if (android.os.Build.VERSION.SDK_INT < 18) {
             LogManager.w(TAG, "BackgroundPowerSaver requires API 18 or higher.");
         }
-        beaconManager = BeaconManager.getInstanceForApplication(context);
-        ((Application)context.getApplicationContext()).registerActivityLifecycleCallbacks(this);
+        applicationContext = context.getApplicationContext();
+        beaconManager = BeaconManager.getInstanceForApplication(applicationContext);
+        ((Application)applicationContext).registerActivityLifecycleCallbacks(this);
     }
 
     @Override
@@ -82,4 +88,92 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
     @Override
     public void onActivityDestroyed(Activity activity) {
     }
+
+    /**
+     * @hide
+     * Internal library use only
+     * This method will try to infer the initial background state, since it is impossible to know
+     * if this application has an activity in the foreground from a library unless a lifecycle
+     * tracker started on Application.onCreate().  Becasue we cannot guarantee that is when we were
+     * called
+     */
+    public void enableDefaultBackgroundStateInference() {
+        if (beaconManager.isBackgroundModeUninitialized()) {
+            // the library will assume we are in foreground mode unless there is evidence to the contrary
+            // this logic sequence looks for that evidence
+            if (methodCalledByApplicationOnCreate()) {
+                // if we were called by application.onCreate we know we are not yet in the foreground
+                inferBackground("application.onCreate in the call stack");
+            }
+            else {
+                PowerManager powerManager = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
+                boolean screenOffNow = false;
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT_WATCH) {
+                    screenOffNow = !powerManager.isInteractive();
+                }
+                if (screenOffNow) {
+                    // if the screen is off, we know we are in the background
+                    inferBackground("the screen being off");
+                }
+                else {
+                    // Register for the screen going off in the future when we still don't know the
+                    // background state.  If we see it happen, we know we are in the
+                    // background.
+                    IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_OFF);
+                    applicationContext.getApplicationContext().registerReceiver(screenOffReceiver, filter);
+                }
+            }
+        }
+        if (beaconManager.isBackgroundModeUninitialized()) {
+            LogManager.i(TAG, "Background mode not set.  We assume we are in the foreground.");
+        }
+    }
+    private void inferBackground(String inferenceMechanism) {
+        if (beaconManager.isBackgroundModeUninitialized()) {
+            LogManager.i(TAG, "We have inferred by "+inferenceMechanism+" that we are in the background.");
+            beaconManager.setBackgroundModeInternal(true);
+        }
+    }
+    // Sadly, Android APIs  give us no way of knowing if Application.onCreate has completed or if
+    // we are otherwise in a launching state prior to when any UI components have been displayed
+    // So we do a trick here that approximates this -- we check if the stack trace has this method
+    // inside of it.  This will work if the call stack that initiates this direcdtly comes from
+    // Application.onCreate, but it will fail to detect any asynchronous executions that start there,
+    // but managed to compelete executing before UI elements were launched.
+    private boolean methodCalledByApplicationOnCreate() {
+        StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+        String targetMethodname = "onCreate";
+        String targetClassname = Application.class.getCanonicalName();
+        android.app.Instrumentation a;
+        for (StackTraceElement element: stackTraceElements) {
+            if (targetMethodname.equals(element.getMethodName())) {
+                if (targetClassname.equals(element.getClassName())) {
+                    return true;
+                }
+                else {
+                    // See if the target method is a superclass of the actual calling method
+                    if (element.getClassName() != null) {
+                        try {
+                            Class<?> c = Class.forName(element.getClassName());
+                            while ((c = c.getSuperclass()) != null) {
+                                String superclassname = c.getCanonicalName();
+                                if (targetClassname.equals(superclassname)) {
+                                    return true;
+                                }
+                            }
+
+                        } catch (ClassNotFoundException e) { }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+    private BroadcastReceiver screenOffReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            inferBackground("the screen going off");
+            applicationContext.getApplicationContext().unregisterReceiver(screenOffReceiver);
+        }
+    };
 }


### PR DESCRIPTION
## The Problem

The library uses a `BackgroundPowerSaver` class to track the activity lifecycle to determine if the app is in the foreground or background and apply configured scan periods depending on the background mode.  As of version 2.19, direct use of this class is deprecated and instead one is automatically created whenever `startMonitoring` or `startRangingBeacons` is first called.  

The problem with the above is that **we don't know the actual foreground/background state of the app when the user makes these calls.**  Android provides no APIs to determine the current foreground/background status of the app.  The preferred approach to doing this is to start tracking activities with the `Application.onCreate()` method.  But this library cannot guarantee that the first call to start monitoring or ranging (which start the internal `BackgroundPowerSaver`) are made from `Application.onCreate()`.  They often will not be.  So **the initial background/foreground mode of the library is often wrong.**

Here is how it works as of 2.19:

* After the first call to startMonitoring/startRangingBeacons, the library will be in the default foreground mode regardless of the actual app foregrounds state
* The above will incorrectly use foreground scan periods when the app is launched in the background

## The Solution

While we cannot exactly determine the foreground/background state on the first call to startMonitoring/startRangingBeacons, we can infer if it is in the background from a few things:

* If the first call to  startRangingBecons/startMonitoring has a call stack that includes `Application#onCreate`, then the library will start out in background mode.  This guarantees proper initial mode if you start monitoring there, and this was the documented place to use `RegionBootstrap` and `BackgroundPowerSaver` which are the ancestors to the autobind methods.
* If the screen is off when during the first call to startRangingBecons/startMonitoring, the library will start out in background mode.
* If the screen goes off between the first call to startRangingBecons/startMonitoring and the first time an app activity appears/disappears, the library will switch to background mode.

## Impact

Based on the above, the library will always start out in the proper mode if ranging/montioring is first started from:

* `Application#onCreate` (background) which is recommended for background scanning
*  A visible Activity or Fragment (foreground)

The only times that it may be set wrong will be when it is started from a backgrounded component outside the `Application#onCreate` call stack.  This will often happen I the library starts looking for beacons based on some background event (e.g. a timer, or a signal from a server.). Further, this will only be wrong is if the screen is on at the same time as this happens (e.g. the user is using a different app, has the lock screen or springboard up.)

In the case where the library starts out (incorrectly) in foreground mode, the library will automatically switch to background mode as soon as the screen goes off.  As a result, the amount of time in the wrong mode will usually be limited and not have significant battery impact.

