### PR TITLE
Fix NullPointerException in IntentScanStrategyCoordinator

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/service/IntentScanStrategyCoordinator.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/service/IntentScanStrategyCoordinator.kt
@@ -209,27 +209,28 @@ class IntentScanStrategyCoordinator(val context: Context) {
             val scanStartTime = System.currentTimeMillis()
 
             if (adapter != null) {
-                val scanner: BluetoothLeScanner = adapter.getBluetoothLeScanner()
-                val callback: ScanCallback = object : ScanCallback() {
-                    override fun onScanResult(callbackType: Int, result: ScanResult) {
-                        super.onScanResult(callbackType, result)
-                        scanHelper.processScanResult(result.device, result.rssi, result.scanRecord?.bytes, result.timestampNanos)
-                        try {
-                            scanner.stopScan(this)
-                        } catch (e: IllegalStateException) { /* do nothing */
-                        } // caught if bluetooth is off here
-                    }
-
-                    override fun onBatchScanResults(results: List<ScanResult>) {
-                        super.onBatchScanResults(results)
-                    }
-
-                    override fun onScanFailed(errorCode: Int) {
-                        super.onScanFailed(errorCode)
-                        LogManager.d(TAG, "Sending onScanFailed event")
-                    }
-                }
+                val scanner: BluetoothLeScanner? = adapter.getBluetoothLeScanner()
                 if (scanner != null) {
+                    val callback: ScanCallback = object : ScanCallback() {
+                        override fun onScanResult(callbackType: Int, result: ScanResult) {
+                            super.onScanResult(callbackType, result)
+                            scanHelper.processScanResult(result.device, result.rssi, result.scanRecord?.bytes, result.timestampNanos)
+                            try {
+                                scanner.stopScan(this)
+                            } catch (e: IllegalStateException) { /* do nothing */
+                            } // caught if bluetooth is off here
+                        }
+
+                        override fun onBatchScanResults(results: List<ScanResult>) {
+                            super.onBatchScanResults(results)
+                        }
+
+                        override fun onScanFailed(errorCode: Int) {
+                            super.onScanFailed(errorCode)
+                            LogManager.d(TAG, "Sending onScanFailed event")
+                        }
+                    }
+                
                     try {
                         scanner.startScan(callback)
                         while (beaconDetected == false) {


### PR DESCRIPTION
This fixes an Nullpointer Exception that can occur, if `adapter.getBluetoothLeScanner()` returns `null`. The code already checks if `scanner` is not null, but the Type Declaration does not allow that. For the change to work, callback had to be moved inside the if statement.