### PR TITLE
Fix broken intent scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.19.3 / 2021-10-5
+
+- Fix failing intent-backed scans broken by Android 12 changes in the 2.19 release.
+
 ### 2.19.2 / 2021-08-18
 
 - Fix NullPointerException in IntentScanStrategyCoordinator (#1053, PhilipTocsen)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.19.3 / 2021-10-5
 
-- Fix failing intent-backed scans broken by Android 12 changes in the 2.19 release.
+- Fix failing intent-backed scans broken by Android 12 changes in the 2.19 release. (#1059, David G. Young)
 
 ### 2.19.2 / 2021-08-18
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following instructions are for project administrators.
         git tag <version>
         git push --tags 
         ./gradlew release
-        ./gradlew mavenPublish
+        ./gradlew mavenPublish # Wait 10 mins before using the next command
         ./gradlew closeAndReleaseRepository
 
 4. Keep checking for a half hour or so at https://repo1.maven.org/maven2/org/altbeacon/android-beacon-library/ to see that the new release shows up.

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -254,10 +254,17 @@ class ScanHelper {
     }
 
     // Low power scan results in the background will be delivered via Intent
+    @SuppressLint("WrongConstant")
     PendingIntent getScanCallbackIntent() {
         Intent intent = new Intent(mContext, StartupBroadcastReceiver.class);
         intent.putExtra("o-scan", true);
-        return PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        /* Android 12 (SDK 31) requires that all PendingIntents be created with either FLAG_MUTABLE or
+           FLAG_IMMUTABLE.  In this case we must use FLAG_MUTABLE because the scan will set additional flags
+           on the intent -- that is how Andorid's Intent-driven scan APIs work.  But because this library
+           is being compiled with SDK 30, the FLAG_MUTABLE is not available yet. We therefore use the hard-coded
+           value for this flag from SDK 31 release 1 and will fix that once the final SDK 31 is tested with this library.
+         */
+        return PendingIntent.getBroadcast(mContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | 0x02000000);
     }
 
     private final CycledLeScanCallback mCycledLeScanCallback = new CycledLeScanCallback() {


### PR DESCRIPTION
Fixes broken passive scans identified in #1058

The fix has been tested with the Kotlin reference app and `beaconManager.setIntentScanningStrategyEnabled(true)` and confirmed that beacons are detected on Android 10 and Android 12

This will be released imminently as 2.19.3