### PR TITLE
Add check for Android 12's BLUETOOTH_SCAN permission to CycledLeScanner

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScanner.java
@@ -564,6 +564,10 @@ public abstract class CycledLeScanner {
     }
 
     private boolean checkLocationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && checkPermission(Manifest.permission.BLUETOOTH_SCAN)) {
+            return true;
+        }
+
         return checkPermission(Manifest.permission.ACCESS_COARSE_LOCATION) || checkPermission(Manifest.permission.ACCESS_FINE_LOCATION);
     }
 


### PR DESCRIPTION
In addition to the existing permission checks for `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`, the `CycledLeScanner` is allowed to start its scan when running on an Android 12 device that has been granted the new permission, `BLUETOOTH_SCAN`.

Resolves https://github.com/AltBeacon/android-beacon-library/issues/1063. The impact of this change can be verified from my forked version:

```
repositories {
  jitpack()
}

dependencies {
  // implementation("org.altbeacon:android-beacon-library:2.19.2")
  implementation("com.github.mannodermaus:android-beacon-library:34b25a5e7a")
}
```