### PR TITLE
Repair Circle CI integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,40 @@
-version: 2
+# Execute unit tests on Circle CI.
+#
+# References:
+# https://circleci.com/developer/orbs/orb/circleci/android
+# https://circleci.com/blog/building-android-on-circleci
+
+version: 2.1
+
+orbs:
+  android: circleci/android@2.0.0
+
 jobs:
   build:
     working_directory: ~/code
-    docker:
-      - image: circleci/android:api-25-alpha
+    executor:
+      name: android/android-machine
+      tag: 2021.10.1
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx3200m -Dfile.encoding=utf-8
     steps:
-      - run: yes | sdkmanager --licenses || true
-      - run: yes | sdkmanager --update || exit 0
       - checkout
-      - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "./build.gradle" }}
-#      - run:
-#         name: Chmod permissions #if permission for Gradlew Dependencies fail, use this.
-#         command: sudo chmod +x ./gradlew
       - run:
-          name: Download Dependencies
-          command: ./gradlew androidDependencies
-      - save_cache:
-          paths:
-            - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum  "./build.gradle" }}
+          name: Display version
+          command: ./gradlew --version
+      - android/restore-gradle-cache
+      - android/restore-build-cache
+      - android/run-tests:
+          test-command: ./gradlew testRelease
+      - android/save-gradle-cache
+      - android/save-build-cache
       - run:
-          name: Run Tests
-          command: ./gradlew test
-      - store_artifacts:
-          path: ./build/reports
-          destination: reports
+          name: Save test results
+          command: |
+            mkdir -p ~/test-results/junit/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test-results/junit/ \;
+          when: always
       - store_test_results:
-          path: ./build/test-results
-      # See https://circleci.com/docs/2.0/deployment-integrations/ for deploy examples
+          path: ~/test-results
+      - store_artifacts:
+          path: ~/test-results/junit

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-machine:
-  java:
-    version: openjdk8
-dependencies:
-  pre:
-    - echo y | android update sdk --no-ui --all --filter "tools,android-30,build-tools-30.0.3,platform-tools,extra-android-m2repository,extra-google-m2repository"
-general:
-  branches:
-    ignore:


### PR DESCRIPTION
Sorry for breaking the CI with https://github.com/AltBeacon/android-beacon-library/pull/1065. 🙈 I noticed it on a whim after checking out the merged commit and felt really guilty, so this PR updates this integration to the current year's best practices. Most notably, the new CI images use JDK 11, which is required by the Android 12 SDK (the linked PR bumped up the `compileSdk` to 31, causing this shift). With the new integration, Circle CI provides some vastly improved tooling for running Android tasks, slimming down the build file and stabilizing its predictability.

An example run with this pipeline can be found in my fork:
https://app.circleci.com/pipelines/github/mannodermaus/android-beacon-library/7/workflows/44ae4cc8-e6e1-4562-ac0a-7fc4164da9c0/jobs/7