### PR TITLE
Add ApiTrackingLogger for troubleshooting complex setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Development
 
+- Add ApiTrackingLogger (#1078, David G. Young)
 - Allow scanning with only BLUETOOTH_SCAN permission and not just location permissions. (#1065, Marcel Schnelle)
 
 ### 2.19.3 / 2021-10-5

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   java:
-    version: openjdk8
+    version: openjdk11
 dependencies:
   pre:
     - echo y | android update sdk --no-ui --all --filter "tools,android-30,build-tools-30.0.3,platform-tools,extra-android-m2repository,extra-google-m2repository"

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -218,6 +218,7 @@ public class BeaconManager {
      * @param p
      */
     public void setForegroundScanPeriod(long p) {
+        LogManager.d(TAG, "API setForegroundScanPeriod "+p);
         foregroundScanPeriod = p;
     }
 
@@ -230,6 +231,7 @@ public class BeaconManager {
      * @param p
      */
     public void setForegroundBetweenScanPeriod(long p) {
+        LogManager.d(TAG, "API setForegroundBetweenScanPeriod "+p);
         foregroundBetweenScanPeriod = p;
     }
 
@@ -242,6 +244,7 @@ public class BeaconManager {
      * @param p
      */
     public void setBackgroundScanPeriod(long p) {
+        LogManager.d(TAG, "API setBackgroundScanPeriod "+p);
         backgroundScanPeriod = p;
     }
 
@@ -251,6 +254,7 @@ public class BeaconManager {
      * @param p
      */
     public void setBackgroundBetweenScanPeriod(long p) {
+        LogManager.d(TAG, "API setBackgroundBetweenScanPeriod "+p);
         backgroundBetweenScanPeriod = p;
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                 backgroundBetweenScanPeriod < 15*60*1000 /* 15 min */) {
@@ -265,6 +269,7 @@ public class BeaconManager {
      * @param regionExitPeriod
      */
     public static void setRegionExitPeriod(long regionExitPeriod){
+        LogManager.d(TAG, "API setRegionExitPeriod "+regionExitPeriod);
         sExitRegionPeriod = regionExitPeriod;
         BeaconManager instance = sInstance;
         if (instance != null) {
@@ -306,6 +311,7 @@ public class BeaconManager {
                 instance = sInstance;
                 if (instance == null) {
                     sInstance = instance = new BeaconManager(context);
+                    LogManager.d(TAG, "API BeaconManager constructed ");
                 }
             }
         }
@@ -351,6 +357,7 @@ public class BeaconManager {
      * @hide
      */
     public void setScannerInSameProcess(boolean isScanner) {
+        LogManager.d(TAG, "API setScannerInSameProcess "+isScanner);
         mScannerInSameProcess = isScanner;
     }
 
@@ -370,7 +377,8 @@ public class BeaconManager {
      */
    @NonNull
     public List<BeaconParser> getBeaconParsers() {
-        return beaconParsers;
+       LogManager.d(TAG, "API getBeaconParsers, current count "+beaconParsers.size());
+       return beaconParsers;
     }
 
     /**
@@ -397,6 +405,7 @@ public class BeaconManager {
      */
     @Deprecated
     public void bind(@NonNull BeaconConsumer consumer) {
+        LogManager.d(TAG, "API bind");
         bindInternal(consumer);
     }
 
@@ -480,6 +489,7 @@ public class BeaconManager {
      */
     @Deprecated
     public void unbind(@NonNull BeaconConsumer consumer) {
+        LogManager.d(TAG, "API unbind");
         unbindInternal(consumer);
     }
 
@@ -583,6 +593,7 @@ public class BeaconManager {
      */
     @Deprecated
     public void setBackgroundMode(boolean backgroundMode) {
+        LogManager.d(TAG, "API setBackgroundMode "+backgroundMode);
         setBackgroundModeInternal(backgroundMode);
     }
 
@@ -591,6 +602,7 @@ public class BeaconManager {
      * @hide
      */
     public void setBackgroundModeInternal(boolean backgroundMode) {
+        LogManager.d(TAG, "API setBackgroundModeIternal "+backgroundMode);
         if (!isBleAvailableOrSimulated()) {
             LogManager.w(TAG, "Method invocation will be ignored.");
             return;
@@ -636,6 +648,7 @@ public class BeaconManager {
      */
 
     public void setEnableScheduledScanJobs(boolean enabled) {
+        LogManager.d(TAG, "API setEnableScheduledScanJobs "+enabled);
         if (isAnyConsumerBound()) {
             LogManager.e(TAG, "ScanJob may not be configured because a consumer is" +
                     " already bound.");
@@ -657,6 +670,7 @@ public class BeaconManager {
     }
 
     public void setIntentScanningStrategyEnabled(boolean enabled) {
+        LogManager.d(TAG, "API setIntentScanningStrategyEnabled "+enabled);
         if (isAnyConsumerBound()) {
             LogManager.e(TAG, "IntentScanningStrategy may not be configured because a consumer is" +
                     " already bound.");
@@ -724,6 +738,7 @@ public class BeaconManager {
      */
     @Deprecated
     public void setRangeNotifier(@Nullable RangeNotifier notifier) {
+        LogManager.d(TAG, "API setRangeNotifier "+notifier);
         rangeNotifiers.clear();
         if (null != notifier) {
             addRangeNotifier(notifier);
@@ -742,6 +757,7 @@ public class BeaconManager {
      * @see RangeNotifier
      */
     public void addRangeNotifier(@NonNull RangeNotifier notifier) {
+        LogManager.d(TAG, "API addRangeNotifier "+notifier);
         //noinspection ConstantConditions
         if (notifier != null) {
             rangeNotifiers.add(notifier);
@@ -755,6 +771,7 @@ public class BeaconManager {
      * @see RangeNotifier
      */
     public boolean removeRangeNotifier(@NonNull RangeNotifier notifier) {
+        LogManager.d(TAG, "API removeRangeNotifier "+notifier);
         return rangeNotifiers.remove(notifier);
     }
 
@@ -762,6 +779,7 @@ public class BeaconManager {
      * Remove all the Range Notifiers.
      */
     public void removeAllRangeNotifiers() {
+        LogManager.d(TAG, "API removeAllRangeNotifiers");
         rangeNotifiers.clear();
     }
 
@@ -781,6 +799,7 @@ public class BeaconManager {
      */
     @Deprecated
     public void setMonitorNotifier(@Nullable MonitorNotifier notifier) {
+        LogManager.d(TAG, "API setMonitorNotifier "+notifier);
         if (determineIfCalledFromSeparateScannerProcess()) {
             return;
         }
@@ -804,6 +823,7 @@ public class BeaconManager {
      * @see Region
      */
     public void addMonitorNotifier(@NonNull MonitorNotifier notifier) {
+        LogManager.d(TAG, "API addMonitorNotifier "+notifier);
         if (determineIfCalledFromSeparateScannerProcess()) {
             return;
         }
@@ -831,6 +851,7 @@ public class BeaconManager {
      * @see Region
      */
     public boolean removeMonitorNotifier(@NonNull MonitorNotifier notifier) {
+        LogManager.d(TAG, "API removeMonitorNotifier "+notifier);
         if (determineIfCalledFromSeparateScannerProcess()) {
             return false;
         }
@@ -841,6 +862,7 @@ public class BeaconManager {
      * Remove all the Monitor Notifiers.
      */
     public void removeAllMonitorNotifiers() {
+        LogManager.d(TAG, "API removeAllMonitorNotifiers");
         if (determineIfCalledFromSeparateScannerProcess()) {
             return;
         }
@@ -866,6 +888,7 @@ public class BeaconManager {
      * @param enabled true to enable the region state persistence, false to disable it.
      */
     public void setRegionStatePersistenceEnabled(boolean enabled) {
+        LogManager.d(TAG, "API setRegionStatePerisistenceEnabled "+enabled);
         mRegionStatePersistenceEnabled = enabled;
         if (!isScannerInDifferentProcess()) {
             if (enabled) {
@@ -923,6 +946,7 @@ public class BeaconManager {
     @Deprecated
     @TargetApi(18)
     public void startRangingBeaconsInRegion(@NonNull Region region) throws RemoteException {
+        LogManager.d(TAG, "API startRangingBeaconsInRegion "+region);
         LogManager.d(TAG, "startRangingBeaconsInRegion");
         if (!isBleAvailableOrSimulated()) {
             LogManager.w(TAG, "Method invocation will be ignored.");
@@ -954,6 +978,7 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void startRangingBeacons(@NonNull Region region) {
+        LogManager.d(TAG, "API startRangingBeacons "+region);
         LogManager.d(TAG, "startRanging");
         ensureBackgroundPowerSaver();
         if (isAnyConsumerBound()) {
@@ -987,6 +1012,7 @@ public class BeaconManager {
     @Deprecated
     @TargetApi(18)
     public void stopRangingBeaconsInRegion(@NonNull Region region) throws RemoteException {
+        LogManager.d(TAG, "API stopRangingBeacons "+region);
         LogManager.d(TAG, "stopRangingBeaconsInRegion");
         if (!isBleAvailableOrSimulated()) {
             LogManager.w(TAG, "Method invocation will be ignored.");
@@ -1011,6 +1037,7 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void stopRangingBeacons(@NonNull Region region) {
+        LogManager.d(TAG, "API stopRangingBeacons "+region);
         LogManager.d(TAG, "stopRangingBeacons");
         ensureBackgroundPowerSaver();
         if (isAnyConsumerBound()) {
@@ -1034,6 +1061,7 @@ public class BeaconManager {
      * @see #isScannerInDifferentProcess()
      */
     public void applySettings() {
+        LogManager.d(TAG, "API applySettings");
         if (determineIfCalledFromSeparateScannerProcess()) {
             return;
         }
@@ -1084,6 +1112,8 @@ public class BeaconManager {
     @Deprecated
     @TargetApi(18)
     public void startMonitoringBeaconsInRegion(@NonNull Region region) throws RemoteException {
+        LogManager.d(TAG, "API startMonitoringBeaconsInRegion "+region);
+
         if (!isBleAvailableOrSimulated()) {
             LogManager.w(TAG, "Method invocation will be ignored.");
             return;
@@ -1119,6 +1149,7 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void startMonitoring(@NonNull Region region) {
+        LogManager.d(TAG, "API startMonitoring "+region);
         ensureBackgroundPowerSaver();
         if (isAnyConsumerBound()) {
             try {
@@ -1154,6 +1185,7 @@ public class BeaconManager {
     @Deprecated
     @TargetApi(18)
     public void stopMonitoringBeaconsInRegion(@NonNull Region region) throws RemoteException {
+        LogManager.d(TAG, "API stopMonitoringBeaconsInRegion "+region);
         if (!isBleAvailableOrSimulated()) {
             LogManager.w(TAG, "Method invocation will be ignored.");
             return;
@@ -1198,6 +1230,7 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void stopMonitoring(@NonNull Region region) {
+        LogManager.d(TAG, "API stopMonitoring "+region);
         ensureBackgroundPowerSaver();
         if (isAnyConsumerBound()) {
             try {
@@ -1222,6 +1255,8 @@ public class BeaconManager {
      */
     @TargetApi(18)
     public void updateScanPeriods() throws RemoteException {
+        LogManager.d(TAG, "API updateScanPeriods");
+
         if (!isBleAvailableOrSimulated()) {
             LogManager.w(TAG, "Method invocation will be ignored.");
             return;
@@ -1230,7 +1265,7 @@ public class BeaconManager {
             return;
         }
         LogManager.d(TAG, "updating background flag to %s", mBackgroundMode);
-        LogManager.d(TAG, "updating scan period to %s, %s", this.getScanPeriod(), this.getBetweenScanPeriod());
+        LogManager.d(TAG, "updating scan periods to %s, %s", this.getScanPeriod(), this.getBetweenScanPeriod());
         if (isAnyConsumerBound()) {
             applyChangesToServices(BeaconService.MSG_SET_SCAN_PERIODS, null);
         }
@@ -1440,10 +1475,12 @@ public class BeaconManager {
      * @param maxTrackingAge in milliseconds
      */
     public void setMaxTrackingAge(int maxTrackingAge) {
+        LogManager.d(TAG, "API setMaxTrackingAge "+maxTrackingAge);
         RangedBeacon.setMaxTrackinAge(maxTrackingAge);
     }
 
     public static void setBeaconSimulator(BeaconSimulator beaconSimulator) {
+        LogManager.d(TAG, "API setBeaconSimulator "+beaconSimulator);
         warnIfScannerNotInSameProcess();
         BeaconManager.beaconSimulator = beaconSimulator;
     }
@@ -1455,6 +1492,7 @@ public class BeaconManager {
 
 
     protected void setDataRequestNotifier(@Nullable RangeNotifier notifier) {
+        LogManager.d(TAG, "API setDataRequestNotifier "+notifier);
         this.dataRequestNotifier = notifier;
     }
 
@@ -1469,6 +1507,7 @@ public class BeaconManager {
     }
 
     public void setNonBeaconLeScanCallback(@Nullable NonBeaconLeScanCallback callback) {
+        LogManager.d(TAG, "API setNonBeaconLeScanCallback "+callback);
         mNonBeaconLeScanCallback = callback;
     }
 
@@ -1587,6 +1626,7 @@ public class BeaconManager {
      * @deprecated This will be removed in the 3.0 release
      */
     public static void setAndroidLScanningDisabled(boolean disabled) {
+        LogManager.d(TAG, "API setAndroidLScanningDisabled "+disabled);
         sAndroidLScanningDisabled = disabled;
         BeaconManager instance = sInstance;
         if (instance != null) {
@@ -1611,6 +1651,7 @@ public class BeaconManager {
      * @param disabled
      */
     public static void setManifestCheckingDisabled(boolean disabled) {
+        LogManager.d(TAG, "API setManifestCheckingDisabled "+disabled);
         sManifestCheckingDisabled = disabled;
     }
 
@@ -1648,6 +1689,8 @@ public class BeaconManager {
      */
     public void enableForegroundServiceScanning(Notification notification, int notificationId)
             throws IllegalStateException {
+        LogManager.d(TAG, "API enableForegroundServiceScanning "+notification);
+
         if (isAnyConsumerBound()) {
             throw new IllegalStateException("May not be called after consumers are already bound.");
         }
@@ -1671,6 +1714,7 @@ public class BeaconManager {
      * service
      */
     public void disableForegroundServiceScanning() throws IllegalStateException {
+        LogManager.d(TAG, "API disableForegroundServiceScanning");
         if (isAnyConsumerBound()) {
             throw new IllegalStateException("May not be called after consumers are already bound");
         }

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -168,6 +168,8 @@ public class BeaconParser implements Serializable {
      * @return the BeaconParser instance
      */
     public BeaconParser setBeaconLayout(String beaconLayout) {
+        LogManager.d(TAG, "API setBeaconLayout "+beaconLayout);
+
         mBeaconLayout = beaconLayout;
         Log.d(TAG, "Parsing beacon layout: "+beaconLayout);
 

--- a/lib/src/main/java/org/altbeacon/beacon/logging/ApiTrackingLogger.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/logging/ApiTrackingLogger.kt
@@ -1,0 +1,86 @@
+package org.altbeacon.beacon.logging
+
+import android.util.Log
+import java.lang.StringBuilder
+import java.text.SimpleDateFormat
+import java.util.*
+import kotlin.collections.ArrayList
+
+class ApiTrackingLogger: Logger {
+    private var apiCalls = ArrayList<String>()
+    private val dateformat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+    protected fun formatString(message: String?, vararg args: Any?): String {
+        // If no varargs are supplied, treat it as a request to log the string without formatting.
+        try {
+            return if (args.size == 0 || message == null) message!! else String.format(message!!, *args)
+        }
+        catch (e: java.util.MissingFormatArgumentException) {
+            return message!!
+        }
+    }
+    override fun v(tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.v(tag, VerboseAndroidLogger().formatString(message, *args))
+    }
+
+    override fun v(t: Throwable?, tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.v(tag, formatString(message, *args), t)
+    }
+
+    override fun d(tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.d(tag, formatString(message, *args))
+    }
+
+    override fun d(t: Throwable?, tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.d(tag, formatString(message, *args), t)
+    }
+
+    override fun i(tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.i(tag, formatString(message, *args))
+    }
+
+    override fun i(t: Throwable?, tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.i(tag, formatString(message, *args), t)
+    }
+
+    override fun w(tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.w(tag, formatString(message, *args))
+    }
+
+    override fun w(t: Throwable?, tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.w(tag, formatString(message, *args), t)
+    }
+
+    override fun e(tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.e(tag, formatString(message, *args))
+    }
+
+    override fun e(t: Throwable?, tag: String?, message: String?, vararg args: Any?) {
+        trackApiLogs(message)
+        Log.e(tag, formatString(message, *args), t)
+    }
+    private fun trackApiLogs(message: String?) {
+        if (message != null && message.indexOf("API") == 0) {
+            val sb = StringBuilder()
+            sb.append(dateformat.format(Date()))
+            sb.append(" ")
+            sb.append(message)
+            apiCalls.add(sb.toString())
+        }
+    }
+    public fun getApiCalls(): Array<String> {
+        return apiCalls.toTypedArray()
+    }
+    public fun clearApiCalls() {
+        apiCalls.clear()
+    }
+
+}

--- a/lib/src/main/java/org/altbeacon/beacon/logging/Loggers.java
+++ b/lib/src/main/java/org/altbeacon/beacon/logging/Loggers.java
@@ -36,6 +36,9 @@ public final class Loggers {
     /** Warning Logger Singleton. */
     private static final Logger WARNING_ANDROID_LOGGER = new WarningAndroidLogger();
 
+    /** Api Tracking Logger Singleton. */
+    private static final ApiTrackingLogger API_TRACKING_ANDROID_LOGGER = new ApiTrackingLogger();
+
     /**
      * @return Get a logger that does nothing.
      */
@@ -65,6 +68,14 @@ public final class Loggers {
      */
     public static Logger warningLogger() {
         return WARNING_ANDROID_LOGGER;
+    }
+
+    /**
+     * @return Get a logger that logs all messages to default Android logs and tracks api calls
+     * @see android.util.Log
+     */
+    public static ApiTrackingLogger apiTrackingLogger() {
+        return API_TRACKING_ANDROID_LOGGER;
     }
 
     private Loggers() {


### PR DESCRIPTION
This adds a ApiTrackingLogger which will keep track of all API calls in an internal array, allowing you to retrieve them at a later time.  This is intended to aid in debugging complex library initializations and lifecycle changes by telling you what API calls were made to the library and when.

Example Usage:

```
LogManager.setLogger(Loggers.apiTrackingLogger())
LogManager.setVerboseLoggingEnabled(true)

...
// Do this later on when you want to see what API calls were logged since library startup:
val apiCalls = Loggers.apiTrackingLogger().getApiCalls()
for (apiCall in apiCalls) {
   Log.d(TAG, apiCall)
}
```

Sample results from starting the reference app.

```
2022-03-10 12:50:49.743 API getBeaconParsers, current count 1
2022-03-10 12:50:49.745 API getBeaconParsers, current count 0
2022-03-10 12:50:49.746 API setBeaconLayout m:2-3=0215,i:4-19,i:20-21,i:22-23,p:24-24
2022-03-10 12:50:49.749 API startMonitoring id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: null id3: null
2022-03-10 12:50:49.751 API setBackgroundModeIternal true
2022-03-10 12:50:49.752 API updateScanPeriods
2022-03-10 12:50:49.754 API startMonitoringBeaconsInRegion id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: null id3: null
2022-03-10 12:50:49.788 API getBeaconParsers, current count 1
2022-03-10 12:50:49.802 API startRangingBeacons id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: null id3: null
2022-03-10 12:50:49.803 API startRangingBeaconsInRegion id1: 2f234454-cf6d-4a0f-adf2-f4911ba9ffa6 id2: null id3: null
2022-03-10 12:50:49.811 API getBeaconParsers, current count 1
2022-03-10 12:50:49.904 API setBackgroundMode false
2022-03-10 12:50:49.905 API setBackgroundModeIternal false
2022-03-10 12:50:49.906 API updateScanPeriods
2022-03-10 12:50:49.915 API getBeaconParsers, current count 1
2022-03-10 12:50:50.047 API setScannerInSameProcess true
```