### PR TITLE
ThreadPoolExecutor troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.19.5-beta1 / 2022-04-14
+
+- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (TBD, David G. Young)
+
 ### 2.19.4 / 2022-03-10
 
 - Add ApiTrackingLogger (#1078, David G. Young)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.19.5-beta1 / 2022-04-14
 
-- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (TBD, David G. Young)
+- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (#1081, David G. Young)
 
 ### 2.19.4 / 2022-03-10
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1057,9 +1057,7 @@ public class BeaconManager {
     }
 
     /**
-     * Call this method if you are running the scanner service in a different process in order to
-     * synchronize any configuration settings, including BeaconParsers to the scanner
-     * @see #isScannerInDifferentProcess()
+     * Call this method in order to apply your settings changes to the already running scanning process
      */
     public void applySettings() {
         LogManager.d(TAG, "API applySettings");
@@ -1068,11 +1066,8 @@ public class BeaconManager {
         }
         if (!isAnyConsumerBound()) {
             LogManager.d(TAG, "Not synchronizing settings to service, as it has not started up yet");
-        } else if (isScannerInDifferentProcess()) {
-            LogManager.d(TAG, "Synchronizing settings to service");
-            syncSettingsToService();
         } else {
-            LogManager.d(TAG, "Not synchronizing settings to service, as it is in the same process");
+            syncSettingsToService();
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -133,6 +133,7 @@ public class BeaconManager {
     @Nullable
     private Notification mForegroundServiceNotification = null;
     private int mForegroundServiceNotificationId = -1;
+    public static boolean useAsyncTask = true;
 
     /**
      * Private lock object for singleton initialization protecting against denial-of-service attack.

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -33,7 +33,9 @@ import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
@@ -56,6 +58,8 @@ import org.altbeacon.beacon.service.SettingsData;
 import org.altbeacon.beacon.service.StartRMData;
 import org.altbeacon.beacon.service.scanner.NonBeaconLeScanCallback;
 import org.altbeacon.beacon.simulator.BeaconSimulator;
+import org.altbeacon.beacon.utils.ChangeAwareCopyOnWriteArrayList;
+import org.altbeacon.beacon.utils.ChangeAwareCopyOnWriteArrayListNotifier;
 import org.altbeacon.beacon.utils.ProcessUtils;
 
 import java.util.ArrayList;
@@ -69,7 +73,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
@@ -113,7 +116,7 @@ public class BeaconManager {
 
 
     @NonNull
-    private final List<BeaconParser> beaconParsers = new CopyOnWriteArrayList<>();
+    private final List<BeaconParser> beaconParsers;
 
     @Nullable
     private NonBeaconLeScanCallback mNonBeaconLeScanCallback;
@@ -133,7 +136,9 @@ public class BeaconManager {
     @Nullable
     private Notification mForegroundServiceNotification = null;
     private int mForegroundServiceNotificationId = -1;
-    public static boolean useAsyncTask = true;
+
+    private Handler mServiceSyncHandler = new Handler(Looper.getMainLooper());
+    private boolean mServiceSyncScheduled = false;
 
     /**
      * Private lock object for singleton initialization protecting against denial-of-service attack.
@@ -325,6 +330,16 @@ public class BeaconManager {
         if (!sManifestCheckingDisabled) {
            verifyServiceDeclaration();
          }
+        ChangeAwareCopyOnWriteArrayList<BeaconParser> beaconParsers =  new ChangeAwareCopyOnWriteArrayList<>();
+        beaconParsers.setNotifier(new ChangeAwareCopyOnWriteArrayListNotifier() {
+            @Override
+            public void onChange() {
+                LogManager.d(TAG, "API Beacon parsers changed");
+                BeaconManager.this.applySettings();
+            }
+        });
+
+        this.beaconParsers = beaconParsers;
         this.beaconParsers.add(new AltBeaconParser());
         setScheduledScanJobsEnabledDefault();
     }
@@ -378,7 +393,6 @@ public class BeaconManager {
      */
    @NonNull
     public List<BeaconParser> getBeaconParsers() {
-       LogManager.d(TAG, "API getBeaconParsers, current count "+beaconParsers.size());
        return beaconParsers;
     }
 
@@ -1071,7 +1085,7 @@ public class BeaconManager {
         }
     }
 
-    protected void syncSettingsToService() {
+    protected synchronized void syncSettingsToService() {
         if (mIntentScanStrategyCoordinator != null) {
             mIntentScanStrategyCoordinator.applySettings();
             return;
@@ -1082,10 +1096,32 @@ public class BeaconManager {
             }
             return;
         }
-        try {
-            applyChangesToServices(BeaconService.MSG_SYNC_SETTINGS, null);
-        } catch (RemoteException e) {
-            LogManager.e(TAG, "Failed to sync settings to service", e);
+        if (!isAnyConsumerBound()) {
+            // If no services are bound, there is no reason to sync settings
+            LogManager.d(TAG, "No settings sync to running service -- service not bound");
+            return;
+        }
+
+        // Because may API calls may be called in sequence, here we batch the sync to the service.
+        if (mServiceSyncScheduled == false) {
+            // call this at most every 100ms
+            mServiceSyncScheduled = true;
+            LogManager.d(TAG, "API Scheduling settings sync to running service.");
+            mServiceSyncHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mServiceSyncScheduled = false;
+                    try {
+                        LogManager.d(TAG, "API Performing settings sync to running service.");
+                        applyChangesToServices(BeaconService.MSG_SYNC_SETTINGS, null);
+                    } catch (RemoteException e) {
+                        LogManager.e(TAG, "Failed to sync settings to service", e);
+                    }
+                }
+            }, 100l);
+        }
+        else {
+            LogManager.d(TAG, "Already scheduled settings sync to running service.");
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -150,6 +150,10 @@ class ScanHelper {
     }
 
     void setBeaconParsers(Set<BeaconParser> beaconParsers) {
+        Log.d(TAG, "BeaconParsers set to  count: "+beaconParsers.size());
+        if (beaconParsers.size() > 0) {
+            Log.d(TAG, "First parser layout: "+beaconParsers.iterator().next().getLayout());
+        }
         mBeaconParsers = beaconParsers;
     }
 
@@ -206,6 +210,10 @@ class ScanHelper {
                 matchBeaconsByServiceUUID = false;
                 newBeaconParsers.addAll(beaconParser.getExtraDataParsers());
             }
+        }
+        Log.d(TAG, "Parser reload count: "+newBeaconParsers.size());
+        if (newBeaconParsers.size() > 0) {
+            Log.d(TAG, "First parser layout: "+newBeaconParsers.iterator().next().getLayout());
         }
         mBeaconParsers = newBeaconParsers;
         //initialize the extra data beacon tracker
@@ -449,6 +457,12 @@ class ScanHelper {
             if (LogManager.isVerboseLoggingEnabled()) {
                 LogManager.d(TAG, "Processing packet");
             }
+            if (ScanHelper.this.mBeaconParsers.size() > 0) {
+                Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
+            }
+            else {
+                Log.w(TAG, "No beacon parsers registered when decoding beacon");
+            }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {
                 beacon = parser.fromScanData(scanData.scanRecord, scanData.rssi, scanData.device, scanData.timestampMs);
@@ -495,6 +509,13 @@ class ScanHelper {
             scanResultProcessedTime = new Date();
             if (LogManager.isVerboseLoggingEnabled()) {
                 LogManager.d(TAG, "Processing packet");
+            }
+
+            if (ScanHelper.this.mBeaconParsers.size() > 0) {
+                Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
+            }
+            else {
+                Log.w(TAG, "No beacon parsers registered when decoding beacon");
             }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -461,7 +461,7 @@ class ScanHelper {
                 Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
             }
             else {
-                Log.w(TAG, "No beacon parsers registered when decoding beacon");
+                Log.w(TAG, "API No beacon parsers registered when decoding beacon");
             }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {

--- a/lib/src/main/java/org/altbeacon/beacon/utils/ChangeAwareCopyOnWriteArrayList.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/utils/ChangeAwareCopyOnWriteArrayList.kt
@@ -1,0 +1,61 @@
+package org.altbeacon.beacon.utils
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.util.ArrayList
+import java.util.function.Predicate
+
+class ChangeAwareCopyOnWriteArrayList<E>: ArrayList<E>() {
+    var notifier: ChangeAwareCopyOnWriteArrayListNotifier? = null
+
+    override fun add(element: E): Boolean {
+        val result = super.add(element)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun remove(element: E): Boolean {
+        val result = super.remove(element)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun clear() {
+        super.clear()
+        notifier?.onChange()
+    }
+
+    override fun addAll(elements: Collection<E>): Boolean {
+        val result = super.addAll(elements)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun removeAll(elements: Collection<E>): Boolean {
+        val result = super.removeAll(elements)
+        notifier?.onChange()
+        return result
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    override fun removeIf(filter: Predicate<in E>): Boolean {
+        val result = super.removeIf(filter)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun removeRange(fromIndex: Int, toIndex: Int) {
+        super.removeRange(fromIndex, toIndex)
+        notifier?.onChange()
+    }
+
+    override fun set(index: Int, element: E): E {
+        val result = super.set(index, element)
+        notifier?.onChange()
+        return result
+    }
+}
+
+interface ChangeAwareCopyOnWriteArrayListNotifier {
+    fun onChange()
+}


### PR DESCRIPTION
Includes several changes to help troubleshoot stalls in the `ThreadPoolExecutor` used to parse beacons.

1. Logs when we create a new ThreadPoolExecutor
2. Logs when we detect that a ThreadPoolExecutor is suspended unexpectedly
3. Recreates the ThreadPoolExecutor  in the above case
4. Logs when we detect that a ThreadPoolExecutor has not processed anything in over 30 minutes.  (This threshold is chosen because it is likely outside deep doze maintenance windows.)
5. Recreates the ThreadPoolExecutor in the above case
6. Logs how long processing has been queued on the ThreadPoolExecutor before we queue something new.  This will typically be very close to 0 milliseconds.
7. Sends all of the above (except 6) to the API logs, so even if you lose LogCat, you will be able to see ThreadPoolExecutor events in the API logs as long as the process keeps running.

When using this, watch for log lines like these:

```
API ThreadPoolExecutor created
API ThreadPoolExecutor unexpectedly shut down
API ThreadPoolExecutor has stalled for %d millis.  Killing it.
ThreadPoolExecutor has not run in %d mill-is
```

This change also includes an optional mechanism to disable using `AsyncTask` structures to schedule beacon parsing on the `ThreadPoolExecutor` and instead use a plain `Runnable`.  This may help if some complexities in the `AsyncTask` structure are causing a problem.  To enable this optional change, call `BeaconManager.useAsyncTask = false`.  I made this optional because I do not want to muddy the waters by making this change immediately.

The first and last lines are normal and expected.  The others indicate problems and will trigger recovery attempts.

This change is available in library version 2.19.5-beta2 on MavenCentral


