### PR TITLE
Handle Foreground Service Start Failures in Android 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.19.5-beta1 / 2022-04-14
+
+- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (TBD, David G. Young)
+
 ### 2.19.4 / 2022-03-10
 
 - Add ApiTrackingLogger (#1078, David G. Young)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.19.5-beta1 / 2022-04-14
 
-- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (TBD, David G. Young)
+- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (#1081, David G. Young)
 
 ### 2.19.4 / 2022-03-10
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1057,9 +1057,7 @@ public class BeaconManager {
     }
 
     /**
-     * Call this method if you are running the scanner service in a different process in order to
-     * synchronize any configuration settings, including BeaconParsers to the scanner
-     * @see #isScannerInDifferentProcess()
+     * Call this method in order to apply your settings changes to the already running scanning process
      */
     public void applySettings() {
         LogManager.d(TAG, "API applySettings");
@@ -1068,11 +1066,8 @@ public class BeaconManager {
         }
         if (!isAnyConsumerBound()) {
             LogManager.d(TAG, "Not synchronizing settings to service, as it has not started up yet");
-        } else if (isScannerInDifferentProcess()) {
-            LogManager.d(TAG, "Synchronizing settings to service");
-            syncSettingsToService();
         } else {
-            LogManager.d(TAG, "Not synchronizing settings to service, as it is in the same process");
+            syncSettingsToService();
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -133,6 +133,7 @@ public class BeaconManager {
     @Nullable
     private Notification mForegroundServiceNotification = null;
     private int mForegroundServiceNotificationId = -1;
+    public static boolean useAsyncTask = true;
 
     /**
      * Private lock object for singleton initialization protecting against denial-of-service attack.

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -25,6 +25,7 @@ package org.altbeacon.beacon;
 
 import android.annotation.TargetApi;
 import android.app.Notification;
+import android.app.ServiceStartNotAllowedException;
 import android.bluetooth.BluetoothManager;
 import android.content.ComponentName;
 import android.content.Context;
@@ -128,6 +129,7 @@ public class BeaconManager {
     @Nullable
     private Boolean mScannerInSameProcess = null;
     private boolean mScheduledScanJobsEnabled = false;
+    private boolean mScheduledScanJobsEnabledByFallback = false;
     @Nullable
     private IntentScanStrategyCoordinator mIntentScanStrategyCoordinator = null;
     private static boolean sAndroidLScanningDisabled = false;
@@ -435,11 +437,19 @@ public class BeaconManager {
         synchronized (consumers) {
             ConsumerInfo newConsumerInfo = new ConsumerInfo();
             ConsumerInfo alreadyBoundConsumerInfo = consumers.putIfAbsent(consumer, newConsumerInfo);
-            if (alreadyBoundConsumerInfo != null) {
+            boolean needToBind = mScheduledScanJobsEnabledByFallback || alreadyBoundConsumerInfo == null;
+            if (!needToBind) {
                 LogManager.d(TAG, "This consumer is already bound");
             }
             else {
-                LogManager.d(TAG, "This consumer is not bound.  Binding now: %s", consumer);
+                if (mScheduledScanJobsEnabledByFallback) {
+                    LogManager.d(TAG, "Need to rebind for switch to foreground service", consumer);
+                    // we are going to disable the fallbac so we can try a foreground service again
+                    mScheduledScanJobsEnabledByFallback = false;
+                }
+                else {
+                    LogManager.d(TAG, "This consumer is not bound.  Binding now: %s", consumer);
+                }
                 if (mIntentScanStrategyCoordinator != null) {
                     mIntentScanStrategyCoordinator.start();
                     consumer.onBeaconServiceConnect();
@@ -453,16 +463,33 @@ public class BeaconManager {
                     Intent intent = new Intent(consumer.getApplicationContext(), BeaconService.class);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                             this.getForegroundServiceNotification() != null) {
-                        if (isAnyConsumerBound()) {
+                        if (isAnyConsumerBound() && !mScheduledScanJobsEnabledByFallback) {
                             LogManager.i(TAG, "Not starting foreground beacon scanning" +
                                     " service.  A consumer is already bound, so it should be started");
                         }
                         else {
-                            LogManager.i(TAG, "Starting foreground beacon scanning service.");
-                            mContext.startForegroundService(intent);
+                            LogManager.i(TAG, "Attempting to starting foreground beacon scanning service.");
+                            try {
+                                mContext.startForegroundService(intent);
+                                if (mScheduledScanJobsEnabledByFallback) {
+                                    LogManager.i(TAG, "Successfully switched to foreground service from fallback");
+                                    mScheduledScanJobsEnabledByFallback = false;
+                                    ScanJobScheduler.getInstance().cancelSchedule(mContext);
+                                }
+                                else {
+                                    LogManager.i(TAG, "successfully started foreground beacon scanning service.");
+                                }
+                            }
+                            catch (ServiceStartNotAllowedException e) {
+                                // This happens on Android 12+ if you try to start a service from the background without a
+                                // qualifying event
+                                LogManager.w(TAG, "Foreground service blocked by ServiceStartNotAllowedException.  Falling back to job scheduler");
+                                mScheduledScanJobsEnabledByFallback = true;
+                                syncSettingsToService();
+                                return;
+                            }
                         }
-                    }
-                    else {
+
                     }
                     consumer.bindService(intent, newConsumerInfo.beaconServiceConnection, Context.BIND_AUTO_CREATE);
                 }
@@ -473,25 +500,40 @@ public class BeaconManager {
 
     /**
      * Internal library use only.
-     * This will trigger a failover from the intent scan strategy to jobs or a foreground service
+     * This will trigger a failover from:
+     *   a) the intent scan strategy to jobs or a foreground service
+     *   b) the job scheduler (running on fallback) to the foreground service
      */
     public void handleStategyFailover() {
+        boolean shouldFailover = false;
+        if (mScheduledScanJobsEnabledByFallback) {
+            if (isAnyConsumerBound()) {
+                shouldFailover = true;
+            }
+            else {
+                mScheduledScanJobsEnabledByFallback = false;
+            }
+        }
         if (mIntentScanStrategyCoordinator != null) {
             if (mIntentScanStrategyCoordinator.getDisableOnFailure() && mIntentScanStrategyCoordinator.getLastStrategyFailureDetectionCount() > 0) {
+                shouldFailover = true;
                 mIntentScanStrategyCoordinator = null;
-                LogManager.d(TAG, "unbinding all consumers for failover from intent strategy");
-                List<InternalBeaconConsumer> oldConsumers = new ArrayList<InternalBeaconConsumer>(consumers.keySet());
-                for (InternalBeaconConsumer consumer: oldConsumers) {
-                    this.unbindInternal(consumer);
-                }
-                // No reason to delay between the two of these because there is no asynchonous behavior
-                // on unbinding with the intent scan strategy -- it is not a service
-                LogManager.d(TAG, "binding all consumers for failover from intent strategy");
-                for (InternalBeaconConsumer consumer: oldConsumers) {
-                    this.bindInternal(consumer);
-                }
-                LogManager.d(TAG, "Done with failover");
             }
+        }
+
+        if (shouldFailover) {
+            LogManager.i(TAG, "unbinding all consumers for failover from intent strategy");
+            List<InternalBeaconConsumer> oldConsumers = new ArrayList<InternalBeaconConsumer>(consumers.keySet());
+            for (InternalBeaconConsumer consumer: oldConsumers) {
+                this.unbindInternal(consumer);
+            }
+            // No reason to delay between the two of these because there is no asynchonous behavior
+            // on unbinding with the intent scan strategy or scheduled jobs -- they are not services
+            LogManager.i(TAG, "binding all consumers for failover from intent strategy");
+            for (InternalBeaconConsumer consumer: oldConsumers) {
+                this.bindInternal(consumer);
+            }
+            LogManager.i(TAG, "Done with failover");
         }
     }
 
@@ -523,7 +565,7 @@ public class BeaconManager {
                 if (mIntentScanStrategyCoordinator != null) {
                     LogManager.d(TAG, "Not unbinding as we are using intent scanning strategy");
                 }
-                else if (mScheduledScanJobsEnabled) {
+                else if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) {
                     LogManager.d(TAG, "Not unbinding from scanning service as we are using scan jobs.");
                 }
                 else {
@@ -537,7 +579,7 @@ public class BeaconManager {
                     // release the serviceMessenger.
                     serviceMessenger = null;
                     // If we are using scan jobs, we cancel the active scan job
-                    if (mScheduledScanJobsEnabled || mIntentScanStrategyCoordinator != null) {
+                    if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback || mIntentScanStrategyCoordinator != null) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             LogManager.i(TAG, "Cancelling scheduled jobs after unbind of last consumer.");
                             ScanJobScheduler.getInstance().cancelSchedule(mContext);
@@ -569,7 +611,7 @@ public class BeaconManager {
             // Annotation doesn't guarantee we get a non-null, but raising an NPE here is excessive
             //noinspection ConstantConditions
             return consumer != null && consumers.get(consumer) != null &&
-                    (mScheduledScanJobsEnabled || serviceMessenger != null);
+                    (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback || serviceMessenger != null);
         }
     }
 
@@ -582,7 +624,7 @@ public class BeaconManager {
     public boolean isAnyConsumerBound() {
         synchronized(consumers) {
             return !consumers.isEmpty() &&
-                    (mIntentScanStrategyCoordinator != null || mScheduledScanJobsEnabled || serviceMessenger != null);
+                    (mIntentScanStrategyCoordinator != null || mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback || serviceMessenger != null);
         }
     }
 
@@ -678,10 +720,13 @@ public class BeaconManager {
             LogManager.w(TAG, "Disabling ScanJobs on Android 8+ may disable delivery of "+
                     "beacon callbacks in the background unless a foreground service is active.");
         }
-        if(!enabled && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            ScanJobScheduler.getInstance().cancelSchedule(mContext);
+        if (enabled) {
+            mScheduledScanJobsEnabledByFallback = false;
         }
         mScheduledScanJobsEnabled = enabled;
+        if(!(mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            ScanJobScheduler.getInstance().cancelSchedule(mContext);
+        }
     }
 
     public void setIntentScanningStrategyEnabled(boolean enabled) {
@@ -697,6 +742,8 @@ public class BeaconManager {
             return;
         }
         if(enabled && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mScheduledScanJobsEnabled = false;
+            mScheduledScanJobsEnabledByFallback = false;
             ScanJobScheduler.getInstance().cancelSchedule(mContext);
             mIntentScanStrategyCoordinator = new IntentScanStrategyCoordinator(mContext);
         }
@@ -1090,7 +1137,7 @@ public class BeaconManager {
             mIntentScanStrategyCoordinator.applySettings();
             return;
         }
-        if (mScheduledScanJobsEnabled) {
+        if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
             }
@@ -1313,7 +1360,7 @@ public class BeaconManager {
             mIntentScanStrategyCoordinator.applySettings();
             return;
         }
-        if (mScheduledScanJobsEnabled) {
+        if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
             }

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -23,6 +23,7 @@
  */
 package org.altbeacon.beacon;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.ServiceStartNotAllowedException;
@@ -451,7 +452,9 @@ public class BeaconManager {
                     LogManager.d(TAG, "This consumer is not bound.  Binding now: %s", consumer);
                 }
                 if (mIntentScanStrategyCoordinator != null) {
-                    mIntentScanStrategyCoordinator.start();
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        mIntentScanStrategyCoordinator.start();
+                    }
                     consumer.onBeaconServiceConnect();
                 }
                 else if (mScheduledScanJobsEnabled) {
@@ -522,14 +525,14 @@ public class BeaconManager {
         }
 
         if (shouldFailover) {
-            LogManager.i(TAG, "unbinding all consumers for failover from intent strategy");
+            LogManager.i(TAG, "unbinding all consumers for stategy failover");
             List<InternalBeaconConsumer> oldConsumers = new ArrayList<InternalBeaconConsumer>(consumers.keySet());
             for (InternalBeaconConsumer consumer: oldConsumers) {
                 this.unbindInternal(consumer);
             }
             // No reason to delay between the two of these because there is no asynchonous behavior
             // on unbinding with the intent scan strategy or scheduled jobs -- they are not services
-            LogManager.i(TAG, "binding all consumers for failover from intent strategy");
+            LogManager.i(TAG, "binding all consumers for strategy failover");
             for (InternalBeaconConsumer consumer: oldConsumers) {
                 this.bindInternal(consumer);
             }
@@ -1779,6 +1782,41 @@ public class BeaconManager {
         setEnableScheduledScanJobs(false);
         mForegroundServiceNotification = notification;
         mForegroundServiceNotificationId = notificationId;
+    }
+
+    /**
+     *  Because Android 12 blocks starting foreground services under some conditions, the library
+     *  may fall back to using the Job Scheduler to schedule scans in these cases.  When this
+     *  happens, it may be possible to start a foreground service at a later time once a
+     *  qualifying event happens.  The library will automatically do this if the app comes to
+     *  the foreground (one example of a qualifying event.)  But the app itself may detect other
+     *  qualifying events defined here:
+     *
+     *  https://developer.android.com/guide/components/foreground-services#background-start-restrictions
+     *
+     *  If the app detects one of these events and wants to retry starting foreground service
+     *  scanning, call this method.
+     *
+     *  Calling this method does not guarantee that the retry will succeed, and if it does not,
+     *  the Job Scheduler will continue to be used.
+     *
+     * @see #foregroundServiceStartFailed() to determine if this method call may be helpful.
+     */
+    public void retryForegroundServiceScanning() {
+        if (foregroundServiceStartFailed()) {
+            handleStategyFailover();
+        }
+    }
+
+    /**
+     * Returns whether Android has blocked using a requsted foreground service to do scans.
+     *
+     *  @see #retryForegroundServiceScanning() for more info.
+     *
+     * @return
+     */
+    public boolean foregroundServiceStartFailed() {
+        return mScheduledScanJobsEnabledByFallback;
     }
 
     /**

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -33,7 +33,9 @@ import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
@@ -56,6 +58,8 @@ import org.altbeacon.beacon.service.SettingsData;
 import org.altbeacon.beacon.service.StartRMData;
 import org.altbeacon.beacon.service.scanner.NonBeaconLeScanCallback;
 import org.altbeacon.beacon.simulator.BeaconSimulator;
+import org.altbeacon.beacon.utils.ChangeAwareCopyOnWriteArrayList;
+import org.altbeacon.beacon.utils.ChangeAwareCopyOnWriteArrayListNotifier;
 import org.altbeacon.beacon.utils.ProcessUtils;
 
 import java.util.ArrayList;
@@ -69,7 +73,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
@@ -113,7 +116,7 @@ public class BeaconManager {
 
 
     @NonNull
-    private final List<BeaconParser> beaconParsers = new CopyOnWriteArrayList<>();
+    private final List<BeaconParser> beaconParsers;
 
     @Nullable
     private NonBeaconLeScanCallback mNonBeaconLeScanCallback;
@@ -133,7 +136,9 @@ public class BeaconManager {
     @Nullable
     private Notification mForegroundServiceNotification = null;
     private int mForegroundServiceNotificationId = -1;
-    public static boolean useAsyncTask = true;
+
+    private Handler mServiceSyncHandler = new Handler(Looper.getMainLooper());
+    private boolean mServiceSyncScheduled = false;
 
     /**
      * Private lock object for singleton initialization protecting against denial-of-service attack.
@@ -325,6 +330,16 @@ public class BeaconManager {
         if (!sManifestCheckingDisabled) {
            verifyServiceDeclaration();
          }
+        ChangeAwareCopyOnWriteArrayList<BeaconParser> beaconParsers =  new ChangeAwareCopyOnWriteArrayList<>();
+        beaconParsers.setNotifier(new ChangeAwareCopyOnWriteArrayListNotifier() {
+            @Override
+            public void onChange() {
+                LogManager.d(TAG, "API Beacon parsers changed");
+                BeaconManager.this.applySettings();
+            }
+        });
+
+        this.beaconParsers = beaconParsers;
         this.beaconParsers.add(new AltBeaconParser());
         setScheduledScanJobsEnabledDefault();
     }
@@ -378,7 +393,6 @@ public class BeaconManager {
      */
    @NonNull
     public List<BeaconParser> getBeaconParsers() {
-       LogManager.d(TAG, "API getBeaconParsers, current count "+beaconParsers.size());
        return beaconParsers;
     }
 
@@ -1071,7 +1085,7 @@ public class BeaconManager {
         }
     }
 
-    protected void syncSettingsToService() {
+    protected synchronized void syncSettingsToService() {
         if (mIntentScanStrategyCoordinator != null) {
             mIntentScanStrategyCoordinator.applySettings();
             return;
@@ -1082,10 +1096,32 @@ public class BeaconManager {
             }
             return;
         }
-        try {
-            applyChangesToServices(BeaconService.MSG_SYNC_SETTINGS, null);
-        } catch (RemoteException e) {
-            LogManager.e(TAG, "Failed to sync settings to service", e);
+        if (!isAnyConsumerBound()) {
+            // If no services are bound, there is no reason to sync settings
+            LogManager.d(TAG, "No settings sync to running service -- service not bound");
+            return;
+        }
+
+        // Because may API calls may be called in sequence, here we batch the sync to the service.
+        if (mServiceSyncScheduled == false) {
+            // call this at most every 100ms
+            mServiceSyncScheduled = true;
+            LogManager.d(TAG, "API Scheduling settings sync to running service.");
+            mServiceSyncHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mServiceSyncScheduled = false;
+                    try {
+                        LogManager.d(TAG, "API Performing settings sync to running service.");
+                        applyChangesToServices(BeaconService.MSG_SYNC_SETTINGS, null);
+                    } catch (RemoteException e) {
+                        LogManager.e(TAG, "Failed to sync settings to service", e);
+                    }
+                }
+            }, 100l);
+        }
+        else {
+            LogManager.d(TAG, "Already scheduled settings sync to running service.");
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
@@ -127,7 +127,7 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "Background mode not set.  We assume we are in the foreground.");
         }
-    }
+    }inferBackground
     private void inferBackground(String inferenceMechanism) {
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "We have inferred by "+inferenceMechanism+" that we are in the background.");

--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
@@ -59,6 +59,11 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
         }
         beaconManager.setBackgroundMode(false);
         LogManager.d(TAG, "activity resumed: %s active activities: %s", activity, activeActivityCount);
+        // If we are in a fallback from a foreground service to the scan jobs due to
+        // Android restrictions on starting foreground services, this is an opportunity
+        // to legally start the foreground service now.
+        BeaconManager.getInstanceForApplication(applicationContext).retryForegroundServiceScanning();
+
     }
 
     @Override
@@ -127,7 +132,7 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "Background mode not set.  We assume we are in the foreground.");
         }
-    }inferBackground
+    }
     private void inferBackground(String inferenceMechanism) {
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "We have inferred by "+inferenceMechanism+" that we are in the background.");

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -172,7 +172,7 @@ public class BeaconService extends Service {
                     }
                 }
                 else if (msg.what == MSG_SYNC_SETTINGS) {
-                    LogManager.i(TAG, "Received settings update from other process");
+                    LogManager.i(TAG, "Received settings update");
                     SettingsData settingsData = SettingsData.fromBundle(msg.getData());
                     if (settingsData != null) {
                         settingsData.apply(service);

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -150,6 +150,10 @@ class ScanHelper {
     }
 
     void setBeaconParsers(Set<BeaconParser> beaconParsers) {
+        Log.d(TAG, "BeaconParsers set to  count: "+beaconParsers.size());
+        if (beaconParsers.size() > 0) {
+            Log.d(TAG, "First parser layout: "+beaconParsers.iterator().next().getLayout());
+        }
         mBeaconParsers = beaconParsers;
     }
 
@@ -206,6 +210,10 @@ class ScanHelper {
                 matchBeaconsByServiceUUID = false;
                 newBeaconParsers.addAll(beaconParser.getExtraDataParsers());
             }
+        }
+        Log.d(TAG, "Parser reload count: "+newBeaconParsers.size());
+        if (newBeaconParsers.size() > 0) {
+            Log.d(TAG, "First parser layout: "+newBeaconParsers.iterator().next().getLayout());
         }
         mBeaconParsers = newBeaconParsers;
         //initialize the extra data beacon tracker
@@ -449,6 +457,12 @@ class ScanHelper {
             if (LogManager.isVerboseLoggingEnabled()) {
                 LogManager.d(TAG, "Processing packet");
             }
+            if (ScanHelper.this.mBeaconParsers.size() > 0) {
+                Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
+            }
+            else {
+                Log.w(TAG, "No beacon parsers registered when decoding beacon");
+            }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {
                 beacon = parser.fromScanData(scanData.scanRecord, scanData.rssi, scanData.device, scanData.timestampMs);
@@ -495,6 +509,13 @@ class ScanHelper {
             scanResultProcessedTime = new Date();
             if (LogManager.isVerboseLoggingEnabled()) {
                 LogManager.d(TAG, "Processing packet");
+            }
+
+            if (ScanHelper.this.mBeaconParsers.size() > 0) {
+                Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
+            }
+            else {
+                Log.w(TAG, "No beacon parsers registered when decoding beacon");
             }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -461,7 +461,7 @@ class ScanHelper {
                 Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
             }
             else {
-                Log.w(TAG, "No beacon parsers registered when decoding beacon");
+                Log.w(TAG, "API No beacon parsers registered when decoding beacon");
             }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {

--- a/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -35,10 +35,16 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
             int bleCallbackType = intent.getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, -1); // e.g. ScanSettings.CALLBACK_TYPE_FIRST_MATCH
             if (bleCallbackType != -1) {
                 LogManager.d(TAG, "Passive background scan callback type: "+bleCallbackType);
-                LogManager.d(TAG, "got Android O background scan via intent");
+                LogManager.d(TAG, "got Android background scan via intent");
                 int errorCode = intent.getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, -1); // e.g.  ScanCallback.SCAN_FAILED_INTERNAL_ERROR
                 if (errorCode != -1) {
                     LogManager.w(TAG, "Passive background scan failed.  Code; "+errorCode);
+                }
+                else {
+                    // If we are in a fallback from a foreground service to the scan jobs due to
+                    // Android restrictions on starting foreground services, this is an opportunity
+                    // to legally start the foreground service now.
+                    BeaconManager.getInstanceForApplication(context).handleStategyFailover();
                 }
                 ArrayList<ScanResult> scanResults = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
 

--- a/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -40,12 +40,6 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
                 if (errorCode != -1) {
                     LogManager.w(TAG, "Passive background scan failed.  Code; "+errorCode);
                 }
-                else {
-                    // If we are in a fallback from a foreground service to the scan jobs due to
-                    // Android restrictions on starting foreground services, this is an opportunity
-                    // to legally start the foreground service now.
-                    BeaconManager.getInstanceForApplication(context).handleStategyFailover();
-                }
                 ArrayList<ScanResult> scanResults = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
 
                 if (beaconManager.getIntentScanStrategyCoordinator() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/lib/src/main/java/org/altbeacon/beacon/utils/ChangeAwareCopyOnWriteArrayList.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/utils/ChangeAwareCopyOnWriteArrayList.kt
@@ -1,0 +1,61 @@
+package org.altbeacon.beacon.utils
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.util.ArrayList
+import java.util.function.Predicate
+
+class ChangeAwareCopyOnWriteArrayList<E>: ArrayList<E>() {
+    var notifier: ChangeAwareCopyOnWriteArrayListNotifier? = null
+
+    override fun add(element: E): Boolean {
+        val result = super.add(element)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun remove(element: E): Boolean {
+        val result = super.remove(element)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun clear() {
+        super.clear()
+        notifier?.onChange()
+    }
+
+    override fun addAll(elements: Collection<E>): Boolean {
+        val result = super.addAll(elements)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun removeAll(elements: Collection<E>): Boolean {
+        val result = super.removeAll(elements)
+        notifier?.onChange()
+        return result
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    override fun removeIf(filter: Predicate<in E>): Boolean {
+        val result = super.removeIf(filter)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun removeRange(fromIndex: Int, toIndex: Int) {
+        super.removeRange(fromIndex, toIndex)
+        notifier?.onChange()
+    }
+
+    override fun set(index: Int, element: E): E {
+        val result = super.set(index, element)
+        notifier?.onChange()
+        return result
+    }
+}
+
+interface ChangeAwareCopyOnWriteArrayListNotifier {
+    fun onChange()
+}


### PR DESCRIPTION
Apps using this library on Android 12 can crash if they configure the library's foreground service for scanning as reported in #1082.  This happens because Android 12 restricts when foreground services can be started to when:

* The app is in the foreground
* The app has received BOOT_COMPLETED
* A number of other qualifying events (motion, Firebase messages, Bluetooth connect, etc.) not tracked by the library.

While it is possible to code around the above, the restrictions make it difficult to use the library.  These following changes are designed to make using the library with a foreground service on Android 12 easier.

1. The library will detect if starting its foreground service fails, catching the exception and preventing a crash.
2. If the foreground service can't be started, the library will fall back to using the default ScanJob scanning strategy. This will keep beacon detections working, albeit in a degraded fashion.
3. If the library detects the app has come to the foreground after the above failure has happened, it will start the foreground service at that time.
4. A new public API method on BeaconManager indicates if a failure to start the foreground service has happened:  foregroundServiceStartFailed()
5. A new public API method on BeaconManager allows the app to retry starting the foreground service (useful for the case that a qualifying event other than the automatically handled foreground change is  known to have happened): retryForegroundServiceScanning()

For this change I performed the following tests with the Kotlin reference app:

1. Modifying app to use a forreground service but long background between scan periods
2. Launching app with no beacons around
3. Killing foreground service from adb while app is in a between scan cycle.
4. Turning on a beacon to re-launch the app in the background. I see this:

```
2022-06-03 11:47:45.897 5802-5802/org.altbeacon.beaconreference I/BeaconManager: Attempting to starting foreground beacon scanning service.
2022-06-03 11:47:45.905 5802-5802/org.altbeacon.beaconreference W/BeaconManager: Foreground service blocked by ServiceStartNotAllowedException.  Falling back to job scheduler
```

The above confirms fallback to ScanJobs works.

Now test failover when the app. comes to the foreground:

5. Tapp app launcher to bring to foreground

```
06-03 11:52:38.440  5802  5802 I BeaconManager: unbinding all consumers for strategy failover
06-03 11:52:38.440  5802  5802 D BeaconManager: Unbinding
06-03 11:52:38.440  5802  5802 D BeaconManager: Not unbinding from scanning service as we are using scan jobs.
06-03 11:52:38.440  5802  5802 D BeaconManager: Before unbind, consumer count is 1
06-03 11:52:38.440  5802  5802 D BeaconManager: After unbind, consumer count is 0
06-03 11:52:38.440  5802  5802 I BeaconManager: Cancelling scheduled jobs after unbind of last consumer.
06-03 11:52:38.440  5802  5802 I ScanJob : Using immediateScanJobId from manifest: 208352939
06-03 11:52:38.442  5802  5802 I ScanJob : Using periodicScanJobId from manifest: 208352940
06-03 11:52:38.442  5802  5802 I BeaconManager: binding all consumers for strategy failover
06-03 11:52:38.443  5802  5802 D BeaconManager: Need to rebind for switch to foreground service
06-03 11:52:38.443  5802  5802 D BeaconManager: Binding to service
06-03 11:52:38.443  5802  5802 I BeaconManager: Attempting to starting foreground beacon scanning service.
06-03 11:52:38.444  5802  5802 I BeaconManager: successfully started foreground beacon scanning service.
06-03 11:52:38.446  5802  5802 D BeaconManager: consumer count is now: 1
06-03 11:52:38.446  5802  5802 I BeaconManager: Done with failover
```

Verify foreground service is started and beacons are being scanned.

