### PR TITLE
Fix region persistence usability problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Development
 
+- Fix region persistence usability problems (#1089, David G. Young)
 - Fix bugs with changing BeaconParsers for running scan service (#1091, David G. Young)
 
 ### 2.19.4 / 2022-03-10

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1379,7 +1379,7 @@ public class BeaconManager {
      */
     @NonNull
     public Collection<Region> getMonitoredRegions() {
-        return MonitoringStatus.getInstanceForApplication(mContext).regions();
+        return MonitoringStatus.getInstanceForApplication(mContext).getActiveRegions();
     }
 
     /**

--- a/lib/src/main/java/org/altbeacon/beacon/service/RegionMonitoringState.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RegionMonitoringState.java
@@ -35,6 +35,7 @@ public class RegionMonitoringState implements Serializable {
     private boolean inside = false;
     private long lastSeenTime = 0l;
     private final Callback callback;
+    private transient boolean activeSinceAppLaunch = false;
 
     public RegionMonitoringState(Callback c) {
         callback = c;
@@ -76,4 +77,7 @@ public class RegionMonitoringState implements Serializable {
     public boolean getInside() {
         return inside;
     }
+
+    public boolean getActiveSinceAppLaunch() { return activeSinceAppLaunch; }
+    public void setActiveSinceAppLaunch(boolean active) {  activeSinceAppLaunch = active; }
 }

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import static android.content.Context.MODE_PRIVATE;
 
 /**
- * Stores the full state of scanning for the libary, including all settings so it can be ressurrected easily
+ * Stores the full state of scanning for the library, including all settings so it can be ressurrected easily
  * for running from a scheduled job
  *
  * Created by dyoung on 3/26/17.
@@ -281,6 +281,14 @@ public class ScanState implements Serializable {
             if (!existingRangedRegions.contains(newRangedRegion)) {
                 LogManager.d(TAG, "Starting ranging region: "+newRangedRegion);
                 mRangedRegionState.put(newRangedRegion, new RangeState(new Callback(mContext.getPackageName())));
+            }
+            else {
+                // In case the user has changed the definition, update it.
+                Region existingRegion = existingRangedRegions.get(existingMonitoredRegions.indexOf(newRangedRegion));
+                if (newRangedRegion.hasSameIdentifiers(existingRegion)) {
+                    mRangedRegionState.remove(existingRegion);
+                    mRangedRegionState.put(newRangedRegion, new RangeState(new Callback(mContext.getPackageName())));
+                }
             }
         }
         for (Region existingRangedRegion: existingRangedRegions) {

--- a/lib/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/service/MonitoringStatusTest.java
@@ -86,8 +86,10 @@ public class MonitoringStatusTest {
         }
         monitoringStatus.saveMonitoringStatusIfOn();
         monitoringStatus.restoreMonitoringStatus();
+        Collection<Region> restoredRegions = monitoringStatus.regions();
+        assertEquals("tracked regions should be restored", 50, restoredRegions.size());
         Collection<Region> regions = beaconManager.getMonitoredRegions();
-        assertEquals("beaconManager should return restored regions", 50, regions.size());
+        assertEquals("beaconManager should not return regions it did not register", 0, regions.size());
     }
 
 


### PR DESCRIPTION
This solves problems with persisted regions discussed in #1075. 

Problems prior to this change:

1. If you start monitoring a region and then change your app code to use a new Region uniqueId without stopping monitoring that old Region, the old Region is orphaned in library persistence and continues to be monitored forever.

2.  If you range a region, then change your app code to update the Region's identifiers but don't change the uniqueId, the old identifiers continue to be used.

This change fixes both problems.  

A few notes on how Monitored region persistence changes with this update:

1. Immediately after starting the app, if you call `beaconManager.getMonitoredRegions()` before starting monitoring, you will get an empty list.  You will not get the persisted list of regions.  (Prior to this change you did get the persisted list of regions registered as of prior app executions, but this was really a bug not intended library behavior.)

3. Any previously persisted monitored regions are retained until the end of the first scan cycle, at which time they are purged unless you have called a `startMonitoring...` method variant for that region. If you make such a call, the region will not be purged.  If you fail to call `startMonitoring...` for a region before the end of the first scan cycle, it will be purged, and all previously tracked region state information will be lost.  

4. No `didExitRegion` or `didDetermineState` callbacks will be issued for "outside" Regions that are not re-registered by the end of the scan cycle.

5. You may still get a `didEnterRegion` or `didDetermineState` callback for a stale previously registered region that has not yet been purged.  This should be a very rare event and would only happen once if a matching beacon is detected on app launch with a stale persisted region before the end of the very first scan cycle on app launch.
