### PR TITLE
Handle Foreground Service Start Failures in Android 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Development
 
+- Handle Foreground Service Start Failures in Android 12 (#1090, David G. Young)
 - Fix region persistence usability problems (#1089, David G. Young)
 - Fix bugs with changing BeaconParsers for running scan service (#1091, David G. Young)
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -25,6 +25,7 @@ package org.altbeacon.beacon;
 
 import android.annotation.TargetApi;
 import android.app.Notification;
+import android.app.ServiceStartNotAllowedException;
 import android.bluetooth.BluetoothManager;
 import android.content.ComponentName;
 import android.content.Context;
@@ -125,6 +126,7 @@ public class BeaconManager {
     @Nullable
     private Boolean mScannerInSameProcess = null;
     private boolean mScheduledScanJobsEnabled = false;
+    private boolean mScheduledScanJobsEnabledByFallback = false;
     @Nullable
     private IntentScanStrategyCoordinator mIntentScanStrategyCoordinator = null;
     private static boolean sAndroidLScanningDisabled = false;
@@ -420,11 +422,19 @@ public class BeaconManager {
         synchronized (consumers) {
             ConsumerInfo newConsumerInfo = new ConsumerInfo();
             ConsumerInfo alreadyBoundConsumerInfo = consumers.putIfAbsent(consumer, newConsumerInfo);
-            if (alreadyBoundConsumerInfo != null) {
+            boolean needToBind = mScheduledScanJobsEnabledByFallback || alreadyBoundConsumerInfo == null;
+            if (!needToBind) {
                 LogManager.d(TAG, "This consumer is already bound");
             }
             else {
-                LogManager.d(TAG, "This consumer is not bound.  Binding now: %s", consumer);
+                if (mScheduledScanJobsEnabledByFallback) {
+                    LogManager.d(TAG, "Need to rebind for switch to foreground service", consumer);
+                    // we are going to disable the fallbac so we can try a foreground service again
+                    mScheduledScanJobsEnabledByFallback = false;
+                }
+                else {
+                    LogManager.d(TAG, "This consumer is not bound.  Binding now: %s", consumer);
+                }
                 if (mIntentScanStrategyCoordinator != null) {
                     mIntentScanStrategyCoordinator.start();
                     consumer.onBeaconServiceConnect();
@@ -438,16 +448,33 @@ public class BeaconManager {
                     Intent intent = new Intent(consumer.getApplicationContext(), BeaconService.class);
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                             this.getForegroundServiceNotification() != null) {
-                        if (isAnyConsumerBound()) {
+                        if (isAnyConsumerBound() && !mScheduledScanJobsEnabledByFallback) {
                             LogManager.i(TAG, "Not starting foreground beacon scanning" +
                                     " service.  A consumer is already bound, so it should be started");
                         }
                         else {
-                            LogManager.i(TAG, "Starting foreground beacon scanning service.");
-                            mContext.startForegroundService(intent);
+                            LogManager.i(TAG, "Attempting to starting foreground beacon scanning service.");
+                            try {
+                                mContext.startForegroundService(intent);
+                                if (mScheduledScanJobsEnabledByFallback) {
+                                    LogManager.i(TAG, "Successfully switched to foreground service from fallback");
+                                    mScheduledScanJobsEnabledByFallback = false;
+                                    ScanJobScheduler.getInstance().cancelSchedule(mContext);
+                                }
+                                else {
+                                    LogManager.i(TAG, "successfully started foreground beacon scanning service.");
+                                }
+                            }
+                            catch (ServiceStartNotAllowedException e) {
+                                // This happens on Android 12+ if you try to start a service from the background without a
+                                // qualifying event
+                                LogManager.w(TAG, "Foreground service blocked by ServiceStartNotAllowedException.  Falling back to job scheduler");
+                                mScheduledScanJobsEnabledByFallback = true;
+                                syncSettingsToService();
+                                return;
+                            }
                         }
-                    }
-                    else {
+
                     }
                     consumer.bindService(intent, newConsumerInfo.beaconServiceConnection, Context.BIND_AUTO_CREATE);
                 }
@@ -458,25 +485,40 @@ public class BeaconManager {
 
     /**
      * Internal library use only.
-     * This will trigger a failover from the intent scan strategy to jobs or a foreground service
+     * This will trigger a failover from:
+     *   a) the intent scan strategy to jobs or a foreground service
+     *   b) the job scheduler (running on fallback) to the foreground service
      */
     public void handleStategyFailover() {
+        boolean shouldFailover = false;
+        if (mScheduledScanJobsEnabledByFallback) {
+            if (isAnyConsumerBound()) {
+                shouldFailover = true;
+            }
+            else {
+                mScheduledScanJobsEnabledByFallback = false;
+            }
+        }
         if (mIntentScanStrategyCoordinator != null) {
             if (mIntentScanStrategyCoordinator.getDisableOnFailure() && mIntentScanStrategyCoordinator.getLastStrategyFailureDetectionCount() > 0) {
+                shouldFailover = true;
                 mIntentScanStrategyCoordinator = null;
-                LogManager.d(TAG, "unbinding all consumers for failover from intent strategy");
-                List<InternalBeaconConsumer> oldConsumers = new ArrayList<InternalBeaconConsumer>(consumers.keySet());
-                for (InternalBeaconConsumer consumer: oldConsumers) {
-                    this.unbindInternal(consumer);
-                }
-                // No reason to delay between the two of these because there is no asynchonous behavior
-                // on unbinding with the intent scan strategy -- it is not a service
-                LogManager.d(TAG, "binding all consumers for failover from intent strategy");
-                for (InternalBeaconConsumer consumer: oldConsumers) {
-                    this.bindInternal(consumer);
-                }
-                LogManager.d(TAG, "Done with failover");
             }
+        }
+
+        if (shouldFailover) {
+            LogManager.i(TAG, "unbinding all consumers for failover from intent strategy");
+            List<InternalBeaconConsumer> oldConsumers = new ArrayList<InternalBeaconConsumer>(consumers.keySet());
+            for (InternalBeaconConsumer consumer: oldConsumers) {
+                this.unbindInternal(consumer);
+            }
+            // No reason to delay between the two of these because there is no asynchonous behavior
+            // on unbinding with the intent scan strategy or scheduled jobs -- they are not services
+            LogManager.i(TAG, "binding all consumers for failover from intent strategy");
+            for (InternalBeaconConsumer consumer: oldConsumers) {
+                this.bindInternal(consumer);
+            }
+            LogManager.i(TAG, "Done with failover");
         }
     }
 
@@ -508,7 +550,7 @@ public class BeaconManager {
                 if (mIntentScanStrategyCoordinator != null) {
                     LogManager.d(TAG, "Not unbinding as we are using intent scanning strategy");
                 }
-                else if (mScheduledScanJobsEnabled) {
+                else if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) {
                     LogManager.d(TAG, "Not unbinding from scanning service as we are using scan jobs.");
                 }
                 else {
@@ -522,7 +564,7 @@ public class BeaconManager {
                     // release the serviceMessenger.
                     serviceMessenger = null;
                     // If we are using scan jobs, we cancel the active scan job
-                    if (mScheduledScanJobsEnabled || mIntentScanStrategyCoordinator != null) {
+                    if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback || mIntentScanStrategyCoordinator != null) {
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                             LogManager.i(TAG, "Cancelling scheduled jobs after unbind of last consumer.");
                             ScanJobScheduler.getInstance().cancelSchedule(mContext);
@@ -554,7 +596,7 @@ public class BeaconManager {
             // Annotation doesn't guarantee we get a non-null, but raising an NPE here is excessive
             //noinspection ConstantConditions
             return consumer != null && consumers.get(consumer) != null &&
-                    (mScheduledScanJobsEnabled || serviceMessenger != null);
+                    (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback || serviceMessenger != null);
         }
     }
 
@@ -567,7 +609,7 @@ public class BeaconManager {
     public boolean isAnyConsumerBound() {
         synchronized(consumers) {
             return !consumers.isEmpty() &&
-                    (mIntentScanStrategyCoordinator != null || mScheduledScanJobsEnabled || serviceMessenger != null);
+                    (mIntentScanStrategyCoordinator != null || mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback || serviceMessenger != null);
         }
     }
 
@@ -663,10 +705,13 @@ public class BeaconManager {
             LogManager.w(TAG, "Disabling ScanJobs on Android 8+ may disable delivery of "+
                     "beacon callbacks in the background unless a foreground service is active.");
         }
-        if(!enabled && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            ScanJobScheduler.getInstance().cancelSchedule(mContext);
+        if (enabled) {
+            mScheduledScanJobsEnabledByFallback = false;
         }
         mScheduledScanJobsEnabled = enabled;
+        if(!(mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            ScanJobScheduler.getInstance().cancelSchedule(mContext);
+        }
     }
 
     public void setIntentScanningStrategyEnabled(boolean enabled) {
@@ -682,6 +727,8 @@ public class BeaconManager {
             return;
         }
         if(enabled && android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mScheduledScanJobsEnabled = false;
+            mScheduledScanJobsEnabledByFallback = false;
             ScanJobScheduler.getInstance().cancelSchedule(mContext);
             mIntentScanStrategyCoordinator = new IntentScanStrategyCoordinator(mContext);
         }
@@ -1080,7 +1127,7 @@ public class BeaconManager {
             mIntentScanStrategyCoordinator.applySettings();
             return;
         }
-        if (mScheduledScanJobsEnabled) {
+        if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
             }
@@ -1281,7 +1328,7 @@ public class BeaconManager {
             mIntentScanStrategyCoordinator.applySettings();
             return;
         }
-        if (mScheduledScanJobsEnabled) {
+        if (mScheduledScanJobsEnabled || mScheduledScanJobsEnabledByFallback) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 ScanJobScheduler.getInstance().applySettingsToScheduledJob(mContext, this);
             }

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -23,6 +23,7 @@
  */
 package org.altbeacon.beacon;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.ServiceStartNotAllowedException;
@@ -436,7 +437,9 @@ public class BeaconManager {
                     LogManager.d(TAG, "This consumer is not bound.  Binding now: %s", consumer);
                 }
                 if (mIntentScanStrategyCoordinator != null) {
-                    mIntentScanStrategyCoordinator.start();
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        mIntentScanStrategyCoordinator.start();
+                    }
                     consumer.onBeaconServiceConnect();
                 }
                 else if (mScheduledScanJobsEnabled) {
@@ -507,14 +510,14 @@ public class BeaconManager {
         }
 
         if (shouldFailover) {
-            LogManager.i(TAG, "unbinding all consumers for failover from intent strategy");
+            LogManager.i(TAG, "unbinding all consumers for stategy failover");
             List<InternalBeaconConsumer> oldConsumers = new ArrayList<InternalBeaconConsumer>(consumers.keySet());
             for (InternalBeaconConsumer consumer: oldConsumers) {
                 this.unbindInternal(consumer);
             }
             // No reason to delay between the two of these because there is no asynchonous behavior
             // on unbinding with the intent scan strategy or scheduled jobs -- they are not services
-            LogManager.i(TAG, "binding all consumers for failover from intent strategy");
+            LogManager.i(TAG, "binding all consumers for strategy failover");
             for (InternalBeaconConsumer consumer: oldConsumers) {
                 this.bindInternal(consumer);
             }
@@ -1747,6 +1750,41 @@ public class BeaconManager {
         setEnableScheduledScanJobs(false);
         mForegroundServiceNotification = notification;
         mForegroundServiceNotificationId = notificationId;
+    }
+
+    /**
+     *  Because Android 12 blocks starting foreground services under some conditions, the library
+     *  may fall back to using the Job Scheduler to schedule scans in these cases.  When this
+     *  happens, it may be possible to start a foreground service at a later time once a
+     *  qualifying event happens.  The library will automatically do this if the app comes to
+     *  the foreground (one example of a qualifying event.)  But the app itself may detect other
+     *  qualifying events defined here:
+     *
+     *  https://developer.android.com/guide/components/foreground-services#background-start-restrictions
+     *
+     *  If the app detects one of these events and wants to retry starting foreground service
+     *  scanning, call this method.
+     *
+     *  Calling this method does not guarantee that the retry will succeed, and if it does not,
+     *  the Job Scheduler will continue to be used.
+     *
+     * @see #foregroundServiceStartFailed() to determine if this method call may be helpful.
+     */
+    public void retryForegroundServiceScanning() {
+        if (foregroundServiceStartFailed()) {
+            handleStategyFailover();
+        }
+    }
+
+    /**
+     * Returns whether Android has blocked using a requsted foreground service to do scans.
+     *
+     *  @see #retryForegroundServiceScanning() for more info.
+     *
+     * @return
+     */
+    public boolean foregroundServiceStartFailed() {
+        return mScheduledScanJobsEnabledByFallback;
     }
 
     /**

--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
@@ -127,7 +127,7 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "Background mode not set.  We assume we are in the foreground.");
         }
-    }
+    }inferBackground
     private void inferBackground(String inferenceMechanism) {
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "We have inferred by "+inferenceMechanism+" that we are in the background.");

--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
@@ -59,6 +59,11 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
         }
         beaconManager.setBackgroundMode(false);
         LogManager.d(TAG, "activity resumed: %s active activities: %s", activity, activeActivityCount);
+        // If we are in a fallback from a foreground service to the scan jobs due to
+        // Android restrictions on starting foreground services, this is an opportunity
+        // to legally start the foreground service now.
+        BeaconManager.getInstanceForApplication(applicationContext).retryForegroundServiceScanning();
+
     }
 
     @Override
@@ -127,7 +132,7 @@ public class BackgroundPowerSaverInternal implements Application.ActivityLifecyc
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "Background mode not set.  We assume we are in the foreground.");
         }
-    }inferBackground
+    }
     private void inferBackground(String inferenceMechanism) {
         if (beaconManager.isBackgroundModeUninitialized()) {
             LogManager.i(TAG, "We have inferred by "+inferenceMechanism+" that we are in the background.");

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -172,7 +172,7 @@ public class BeaconService extends Service {
                     }
                 }
                 else if (msg.what == MSG_SYNC_SETTINGS) {
-                    LogManager.i(TAG, "Received settings update from other process");
+                    LogManager.i(TAG, "Received settings update");
                     SettingsData settingsData = SettingsData.fromBundle(msg.getData());
                     if (settingsData != null) {
                         settingsData.apply(service);

--- a/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -35,10 +35,16 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
             int bleCallbackType = intent.getIntExtra(BluetoothLeScanner.EXTRA_CALLBACK_TYPE, -1); // e.g. ScanSettings.CALLBACK_TYPE_FIRST_MATCH
             if (bleCallbackType != -1) {
                 LogManager.d(TAG, "Passive background scan callback type: "+bleCallbackType);
-                LogManager.d(TAG, "got Android O background scan via intent");
+                LogManager.d(TAG, "got Android background scan via intent");
                 int errorCode = intent.getIntExtra(BluetoothLeScanner.EXTRA_ERROR_CODE, -1); // e.g.  ScanCallback.SCAN_FAILED_INTERNAL_ERROR
                 if (errorCode != -1) {
                     LogManager.w(TAG, "Passive background scan failed.  Code; "+errorCode);
+                }
+                else {
+                    // If we are in a fallback from a foreground service to the scan jobs due to
+                    // Android restrictions on starting foreground services, this is an opportunity
+                    // to legally start the foreground service now.
+                    BeaconManager.getInstanceForApplication(context).handleStategyFailover();
                 }
                 ArrayList<ScanResult> scanResults = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
 

--- a/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
+++ b/lib/src/main/java/org/altbeacon/beacon/startup/StartupBroadcastReceiver.java
@@ -40,12 +40,6 @@ public class StartupBroadcastReceiver extends BroadcastReceiver
                 if (errorCode != -1) {
                     LogManager.w(TAG, "Passive background scan failed.  Code; "+errorCode);
                 }
-                else {
-                    // If we are in a fallback from a foreground service to the scan jobs due to
-                    // Android restrictions on starting foreground services, this is an opportunity
-                    // to legally start the foreground service now.
-                    BeaconManager.getInstanceForApplication(context).handleStategyFailover();
-                }
                 ArrayList<ScanResult> scanResults = intent.getParcelableArrayListExtra(BluetoothLeScanner.EXTRA_LIST_SCAN_RESULT);
 
                 if (beaconManager.getIntentScanStrategyCoordinator() != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {


### PR DESCRIPTION
Apps using this library on Android 12 can crash if they configure the library's foreground service for scanning as reported in https://github.com/AltBeacon/android-beacon-library/issues/1082. This happens because Android 12 restricts when foreground services can be started to when:

The app is in the foreground
The app has received BOOT_COMPLETED
A number of other qualifying events (motion, Firebase messages, Bluetooth connect, etc.) not tracked by the library.
While it is possible to code around the above, the restrictions make it difficult to use the library. These following changes are designed to make using the library with a foreground service on Android 12 easier.

The library will detect if starting its foreground service fails, catching the exception and preventing a crash.
If the foreground service can't be started, the library will fall back to using the default ScanJob scanning strategy. This will keep beacon detections working, albeit in a degraded fashion.
If the library detects the app has come to the foreground after the above failure has happened, it will start the foreground service at that time.
A new public API method on BeaconManager indicates if a failure to start the foreground service has happened: foregroundServiceStartFailed()
A new public API method on BeaconManager allows the app to retry starting the foreground service (useful for the case that a qualifying event other than the automatically handled foreground change is known to have happened): retryForegroundServiceScanning()
For this change I performed the following tests with the Kotlin reference app:

Modifying app to use a forreground service but long background between scan periods
Launching app with no beacons around
Killing foreground service from adb while app is in a between scan cycle.
Turning on a beacon to re-launch the app in the background. I see this:
2022-06-03 11:47:45.897 5802-5802/org.altbeacon.beaconreference I/BeaconManager: Attempting to starting foreground beacon scanning service.
2022-06-03 11:47:45.905 5802-5802/org.altbeacon.beaconreference W/BeaconManager: Foreground service blocked by ServiceStartNotAllowedException.  Falling back to job scheduler
The above confirms fallback to ScanJobs works.

Now test failover when the app. comes to the foreground:

Tapp app launcher to bring to foreground
06-03 11:52:38.440  5802  5802 I BeaconManager: unbinding all consumers for strategy failover
06-03 11:52:38.440  5802  5802 D BeaconManager: Unbinding
06-03 11:52:38.440  5802  5802 D BeaconManager: Not unbinding from scanning service as we are using scan jobs.
06-03 11:52:38.440  5802  5802 D BeaconManager: Before unbind, consumer count is 1
06-03 11:52:38.440  5802  5802 D BeaconManager: After unbind, consumer count is 0
06-03 11:52:38.440  5802  5802 I BeaconManager: Cancelling scheduled jobs after unbind of last consumer.
06-03 11:52:38.440  5802  5802 I ScanJob : Using immediateScanJobId from manifest: 208352939
06-03 11:52:38.442  5802  5802 I ScanJob : Using periodicScanJobId from manifest: 208352940
06-03 11:52:38.442  5802  5802 I BeaconManager: binding all consumers for strategy failover
06-03 11:52:38.443  5802  5802 D BeaconManager: Need to rebind for switch to foreground service
06-03 11:52:38.443  5802  5802 D BeaconManager: Binding to service
06-03 11:52:38.443  5802  5802 I BeaconManager: Attempting to starting foreground beacon scanning service.
06-03 11:52:38.444  5802  5802 I BeaconManager: successfully started foreground beacon scanning service.
06-03 11:52:38.446  5802  5802 D BeaconManager: consumer count is now: 1
06-03 11:52:38.446  5802  5802 I BeaconManager: Done with failover
Verify foreground service is started and beacons are being scanned.

Note: This PR replaces #1082 with a smaller set of changes.
