### PR TITLE
Fix bugs with changing BeaconParsers for running scan service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.19.5-beta1 / 2022-04-14
+
+- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (TBD, David G. Young)
+
 ### 2.19.4 / 2022-03-10
 
 - Add ApiTrackingLogger (#1078, David G. Young)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 2.19.5-beta1 / 2022-04-14
 
-- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (TBD, David G. Young)
+- Add checking to see if ThreadPoolExecutor is stalled and try to recover. (#1081, David G. Young)
 
 ### 2.19.4 / 2022-03-10
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1057,9 +1057,7 @@ public class BeaconManager {
     }
 
     /**
-     * Call this method if you are running the scanner service in a different process in order to
-     * synchronize any configuration settings, including BeaconParsers to the scanner
-     * @see #isScannerInDifferentProcess()
+     * Call this method in order to apply your settings changes to the already running scanning process
      */
     public void applySettings() {
         LogManager.d(TAG, "API applySettings");
@@ -1068,11 +1066,8 @@ public class BeaconManager {
         }
         if (!isAnyConsumerBound()) {
             LogManager.d(TAG, "Not synchronizing settings to service, as it has not started up yet");
-        } else if (isScannerInDifferentProcess()) {
-            LogManager.d(TAG, "Synchronizing settings to service");
-            syncSettingsToService();
         } else {
-            LogManager.d(TAG, "Not synchronizing settings to service, as it is in the same process");
+            syncSettingsToService();
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -133,6 +133,7 @@ public class BeaconManager {
     @Nullable
     private Notification mForegroundServiceNotification = null;
     private int mForegroundServiceNotificationId = -1;
+    public static boolean useAsyncTask = true;
 
     /**
      * Private lock object for singleton initialization protecting against denial-of-service attack.

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -33,7 +33,9 @@ import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
 import android.os.Message;
 import android.os.Messenger;
 import android.os.RemoteException;
@@ -56,6 +58,8 @@ import org.altbeacon.beacon.service.SettingsData;
 import org.altbeacon.beacon.service.StartRMData;
 import org.altbeacon.beacon.service.scanner.NonBeaconLeScanCallback;
 import org.altbeacon.beacon.simulator.BeaconSimulator;
+import org.altbeacon.beacon.utils.ChangeAwareCopyOnWriteArrayList;
+import org.altbeacon.beacon.utils.ChangeAwareCopyOnWriteArrayListNotifier;
 import org.altbeacon.beacon.utils.ProcessUtils;
 
 import java.util.ArrayList;
@@ -69,7 +73,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
@@ -113,7 +116,7 @@ public class BeaconManager {
 
 
     @NonNull
-    private final List<BeaconParser> beaconParsers = new CopyOnWriteArrayList<>();
+    private final List<BeaconParser> beaconParsers;
 
     @Nullable
     private NonBeaconLeScanCallback mNonBeaconLeScanCallback;
@@ -133,7 +136,9 @@ public class BeaconManager {
     @Nullable
     private Notification mForegroundServiceNotification = null;
     private int mForegroundServiceNotificationId = -1;
-    public static boolean useAsyncTask = true;
+
+    private Handler mServiceSyncHandler = new Handler(Looper.getMainLooper());
+    private boolean mServiceSyncScheduled = false;
 
     /**
      * Private lock object for singleton initialization protecting against denial-of-service attack.
@@ -325,6 +330,16 @@ public class BeaconManager {
         if (!sManifestCheckingDisabled) {
            verifyServiceDeclaration();
          }
+        ChangeAwareCopyOnWriteArrayList<BeaconParser> beaconParsers =  new ChangeAwareCopyOnWriteArrayList<>();
+        beaconParsers.setNotifier(new ChangeAwareCopyOnWriteArrayListNotifier() {
+            @Override
+            public void onChange() {
+                LogManager.d(TAG, "API Beacon parsers changed");
+                BeaconManager.this.applySettings();
+            }
+        });
+
+        this.beaconParsers = beaconParsers;
         this.beaconParsers.add(new AltBeaconParser());
         setScheduledScanJobsEnabledDefault();
     }
@@ -378,7 +393,6 @@ public class BeaconManager {
      */
    @NonNull
     public List<BeaconParser> getBeaconParsers() {
-       LogManager.d(TAG, "API getBeaconParsers, current count "+beaconParsers.size());
        return beaconParsers;
     }
 
@@ -1071,7 +1085,7 @@ public class BeaconManager {
         }
     }
 
-    protected void syncSettingsToService() {
+    protected synchronized void syncSettingsToService() {
         if (mIntentScanStrategyCoordinator != null) {
             mIntentScanStrategyCoordinator.applySettings();
             return;
@@ -1082,10 +1096,32 @@ public class BeaconManager {
             }
             return;
         }
-        try {
-            applyChangesToServices(BeaconService.MSG_SYNC_SETTINGS, null);
-        } catch (RemoteException e) {
-            LogManager.e(TAG, "Failed to sync settings to service", e);
+        if (!isAnyConsumerBound()) {
+            // If no services are bound, there is no reason to sync settings
+            LogManager.d(TAG, "No settings sync to running service -- service not bound");
+            return;
+        }
+
+        // Because may API calls may be called in sequence, here we batch the sync to the service.
+        if (mServiceSyncScheduled == false) {
+            // call this at most every 100ms
+            mServiceSyncScheduled = true;
+            LogManager.d(TAG, "API Scheduling settings sync to running service.");
+            mServiceSyncHandler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    mServiceSyncScheduled = false;
+                    try {
+                        LogManager.d(TAG, "API Performing settings sync to running service.");
+                        applyChangesToServices(BeaconService.MSG_SYNC_SETTINGS, null);
+                    } catch (RemoteException e) {
+                        LogManager.e(TAG, "Failed to sync settings to service", e);
+                    }
+                }
+            }, 100l);
+        }
+        else {
+            LogManager.d(TAG, "Already scheduled settings sync to running service.");
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -150,6 +150,10 @@ class ScanHelper {
     }
 
     void setBeaconParsers(Set<BeaconParser> beaconParsers) {
+        Log.d(TAG, "BeaconParsers set to  count: "+beaconParsers.size());
+        if (beaconParsers.size() > 0) {
+            Log.d(TAG, "First parser layout: "+beaconParsers.iterator().next().getLayout());
+        }
         mBeaconParsers = beaconParsers;
     }
 
@@ -206,6 +210,10 @@ class ScanHelper {
                 matchBeaconsByServiceUUID = false;
                 newBeaconParsers.addAll(beaconParser.getExtraDataParsers());
             }
+        }
+        Log.d(TAG, "Parser reload count: "+newBeaconParsers.size());
+        if (newBeaconParsers.size() > 0) {
+            Log.d(TAG, "First parser layout: "+newBeaconParsers.iterator().next().getLayout());
         }
         mBeaconParsers = newBeaconParsers;
         //initialize the extra data beacon tracker
@@ -449,6 +457,12 @@ class ScanHelper {
             if (LogManager.isVerboseLoggingEnabled()) {
                 LogManager.d(TAG, "Processing packet");
             }
+            if (ScanHelper.this.mBeaconParsers.size() > 0) {
+                Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
+            }
+            else {
+                Log.w(TAG, "No beacon parsers registered when decoding beacon");
+            }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {
                 beacon = parser.fromScanData(scanData.scanRecord, scanData.rssi, scanData.device, scanData.timestampMs);
@@ -495,6 +509,13 @@ class ScanHelper {
             scanResultProcessedTime = new Date();
             if (LogManager.isVerboseLoggingEnabled()) {
                 LogManager.d(TAG, "Processing packet");
+            }
+
+            if (ScanHelper.this.mBeaconParsers.size() > 0) {
+                Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
+            }
+            else {
+                Log.w(TAG, "No beacon parsers registered when decoding beacon");
             }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -461,7 +461,7 @@ class ScanHelper {
                 Log.d(TAG, "Decoding beacon. First parser layout: "+mBeaconParsers.iterator().next().getLayout());
             }
             else {
-                Log.w(TAG, "No beacon parsers registered when decoding beacon");
+                Log.w(TAG, "API No beacon parsers registered when decoding beacon");
             }
 
             for (BeaconParser parser : ScanHelper.this.mBeaconParsers) {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanHelper.java
@@ -84,10 +84,10 @@ class ScanHelper {
 
     private ExecutorService getExecutor() {
         if (mExecutor != null && mExecutor.isShutdown()) {
-            LogManager.d(TAG, "API ThreadPoolExecutor unexpectedly shut down");
+            LogManager.w(TAG, "ThreadPoolExecutor unexpectedly shut down");
         }
         if (mExecutor == null) {
-            LogManager.d(TAG, "API ThreadPoolExecutor created");
+            LogManager.d(TAG, "ThreadPoolExecutor created");
             mExecutor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() + 1);
         }
         return mExecutor;

--- a/lib/src/main/java/org/altbeacon/beacon/utils/ChangeAwareCopyOnWriteArrayList.kt
+++ b/lib/src/main/java/org/altbeacon/beacon/utils/ChangeAwareCopyOnWriteArrayList.kt
@@ -1,0 +1,61 @@
+package org.altbeacon.beacon.utils
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.util.ArrayList
+import java.util.function.Predicate
+
+class ChangeAwareCopyOnWriteArrayList<E>: ArrayList<E>() {
+    var notifier: ChangeAwareCopyOnWriteArrayListNotifier? = null
+
+    override fun add(element: E): Boolean {
+        val result = super.add(element)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun remove(element: E): Boolean {
+        val result = super.remove(element)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun clear() {
+        super.clear()
+        notifier?.onChange()
+    }
+
+    override fun addAll(elements: Collection<E>): Boolean {
+        val result = super.addAll(elements)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun removeAll(elements: Collection<E>): Boolean {
+        val result = super.removeAll(elements)
+        notifier?.onChange()
+        return result
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    override fun removeIf(filter: Predicate<in E>): Boolean {
+        val result = super.removeIf(filter)
+        notifier?.onChange()
+        return result
+    }
+
+    override fun removeRange(fromIndex: Int, toIndex: Int) {
+        super.removeRange(fromIndex, toIndex)
+        notifier?.onChange()
+    }
+
+    override fun set(index: Int, element: E): E {
+        val result = super.set(index, element)
+        notifier?.onChange()
+        return result
+    }
+}
+
+interface ChangeAwareCopyOnWriteArrayListNotifier {
+    fun onChange()
+}


### PR DESCRIPTION
This fixes a number of bugs with the way the library applies settings to a running scan service, particularly BeaconParsers.   Prior to this change, apps using a Foreground Service that attempted to add or remove a new BeaconParser after scanning had already started, failed to do so, and race conditions could cause the BeaconParser list to be stuck with an empty list blocking detections.

After this change, configuration changes are automatically applied to a running service and the public API method. `beaconManager.applySettings()` can once again be used to force apply changes to running services. (Calling that method directly is not necessary as it is automatically called if needed when you make config changes.)

Since Android 8, the use of a Scanning Service usually only applies to a Foreground Service, as long-running scanning services are forbidden on Android 8+.  The Job Scheduler is used by default on Android 8+ and the problems described in this PR do not apply to using the Job Scheduler.  
