### PR TITLE
Fix Android 13 Crash 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### 2.19.5-beta6 / 2022-06-13
+### 2.19.5-beta7 / 2022-06-24
 
+- Fix Crash on Android 13 beta (#1095, David G. Young)
 - Handle Foreground Service Start Failures in Android 12 (#1090, David G. Young)
 - Fix region persistence usability problems (#1089, David G. Young)
 - Fix bugs with changing BeaconParsers for running scan service (#1091, David G. Young)

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -280,7 +280,7 @@ public class BeaconService extends Service {
         String value = null;
         try {
             PackageItemInfo info = this.getPackageManager().getServiceInfo(new ComponentName(this, BeaconService.class), PackageManager.GET_META_DATA);
-            if (info != null && info.metaData != null) {
+            if (info != null && info.metaData != null && info.metaData.get(key) != null) {
                 return info.metaData.get(key).toString();
             }
         }


### PR DESCRIPTION
This crash started showing up with Android 13 beta builds as reported in #1083.   It appears that a change in Android 13 alerts how null checks must be done for looking for Manifest metadata.