### PR TITLE
Partial fix for ScanState.restore IllegalStateException

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanState.java
@@ -147,7 +147,7 @@ public class ScanState implements Serializable {
             } catch (FileNotFoundException fnfe) {
                 LogManager.w(TAG, "Serialized ScanState does not exist.  This may be normal on first run.");
             }
-            catch (IOException | ClassNotFoundException | ClassCastException e) {
+            catch (IllegalStateException | IOException | ClassNotFoundException | ClassCastException e) {
                 if (e instanceof InvalidClassException) {
                     LogManager.d(TAG, "Serialized ScanState has wrong class. Just ignoring saved state...");
                 }


### PR DESCRIPTION
This PR adds `IllegalStateException` to caught exceptions during state restoring and considers them as deserialization errors.

This doesn't fix all the issues of #1129 like excessive file growth, but it's a quick fix to avoid crashes in existing apps.