### PR TITLE
Add lastPacketRawBytes when using copyBeaconFields

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -851,6 +851,7 @@ public class Beacon implements Parcelable, Serializable {
             setRssi(beacon.getRssi());
             setServiceUuid(beacon.getServiceUuid());
             setMultiFrameBeacon(beacon.isMultiFrameBeacon());
+            setLastPacketRawBytes(beacon.getLastPacketRawBytes());
             return this;
         }
 
@@ -1023,6 +1024,16 @@ public class Beacon implements Parcelable, Serializable {
          */
         public Builder setMultiFrameBeacon(boolean multiFrameBeacon) {
             mBeacon.mMultiFrameBeacon = multiFrameBeacon;
+            return this;
+        }
+
+        /**
+         * @see Beacon#mLastPacketRawBytes
+         * @param lastPacketRawBytes
+         * @return builder
+         */
+        public Builder setLastPacketRawBytes(byte[] lastPacketRawBytes) {
+            mBeacon.mLastPacketRawBytes = lastPacketRawBytes;
             return this;
         }
     }

--- a/lib/src/test/java/org/altbeacon/beacon/AltBeaconTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/AltBeaconTest.java
@@ -130,7 +130,9 @@ public class AltBeaconTest {
                                                        .setRunningAverageRssi(-12.3)
                                                        .setServiceUuid(13)
                                                        .setTxPower(14)
+                                                       .setLastPacketRawBytes(new byte[]{ 0x1, 0x2})
                                                        .build();
+
         original.setPacketCount(15);
         original.setRssiMeasurementCount(16);
         final AltBeacon copied = new AltBeacon(original);
@@ -153,7 +155,8 @@ public class AltBeaconTest {
                         hasProperty("serviceUuid", equalTo(13)),
                         hasProperty("txPower", equalTo(14)),
                         hasProperty("packetCount", equalTo(15)),
-                        hasProperty("measurementCount", equalTo(16))
+                        hasProperty("measurementCount", equalTo(16)),
+                        hasProperty("lastPacketRawBytes", equalTo(new byte[]{ 0x1, 0x2}))
                 )
         );
     }

--- a/lib/src/test/java/org/altbeacon/beacon/BeaconTest.java
+++ b/lib/src/test/java/org/altbeacon/beacon/BeaconTest.java
@@ -290,6 +290,7 @@ public class BeaconTest {
                                                     .setRunningAverageRssi(-12.3)
                                                     .setServiceUuid(13)
                                                     .setTxPower(14)
+                                                    .setLastPacketRawBytes(new byte[]{ 0x1, 0x2})
                                                     .build();
         original.setPacketCount(15);
         original.setRssiMeasurementCount(16);
@@ -314,7 +315,8 @@ public class BeaconTest {
                         hasProperty("serviceUuid", equalTo(13)),
                         hasProperty("txPower", equalTo(14)),
                         hasProperty("packetCount", equalTo(15)),
-                        hasProperty("measurementCount", equalTo(16))
+                        hasProperty("measurementCount", equalTo(16)),
+                        hasProperty("lastPacketRawBytes", equalTo(new byte[]{ 0x1, 0x2}))
                 )
         );
     }


### PR DESCRIPTION
When using `Beacon.Builder().copyBeaconFields()`, beacon's raw data is not copied in the new object. This PR fixes that and updates copyBeaconFields test cases.