### PR TITLE
Backward compatibility - add 'fromScanData' to AltBeaconParser and BeaconParser

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
@@ -57,6 +57,22 @@ public class AltBeaconParser extends BeaconParser {
      * Construct an AltBeacon from a Bluetooth LE packet collected by Android's Bluetooth APIs,
      * including the raw Bluetooth device info
      *
+     * timestampMs excluded for backward compatibility with older api consumers.
+     *
+     * @param scanData The actual packet bytes
+     * @param rssi The measured signal strength of the packet
+     * @param device The Bluetooth device that was detected
+     * @return An instance of an <code>Beacon</code>
+     */
+    @Override
+    public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
+        return fromScanData(scanData, rssi, device, 0, new AltBeacon());
+    }
+
+    /**
+     * Construct an AltBeacon from a Bluetooth LE packet collected by Android's Bluetooth APIs,
+     * including the raw Bluetooth device info
+     *
      * @param scanData The actual packet bytes
      * @param rssi The measured signal strength of the packet
      * @param device The Bluetooth device that was detected

--- a/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
@@ -59,14 +59,19 @@ public class AltBeaconParser extends BeaconParser {
      *
      * timestampMs excluded for backward compatibility with older api consumers.
      *
+     * @Deprecated New implementations should not use this method. It is not intended as a public
+     * API and is subject to change or removal in the future.
+     *
+     *
      * @param scanData The actual packet bytes
      * @param rssi The measured signal strength of the packet
      * @param device The Bluetooth device that was detected
-     * @return An instance of an <code>Beacon</code>
+     * @return An instance of a <code>Beacon</code>
      */
+    @Deprecated
     @Override
     public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
-        return fromScanData(scanData, rssi, device, 0, new AltBeacon());
+        return fromScanData(scanData, rssi, device, System.currentTimeMillis(), new AltBeacon());
     }
 
     /**
@@ -77,7 +82,7 @@ public class AltBeaconParser extends BeaconParser {
      * @param rssi The measured signal strength of the packet
      * @param device The Bluetooth device that was detected
      * @param timestampMs The timestamp in milliseconds of the scan execution
-     * @return An instance of an <code>Beacon</code>
+     * @return An instance of a <code>Beacon</code>
      */
     @Override
     public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device, long timestampMs) {

--- a/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/AltBeaconParser.java
@@ -62,7 +62,6 @@ public class AltBeaconParser extends BeaconParser {
      * @Deprecated New implementations should not use this method. It is not intended as a public
      * API and is subject to change or removal in the future.
      *
-     *
      * @param scanData The actual packet bytes
      * @param rssi The measured signal strength of the packet
      * @param device The Bluetooth device that was detected

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -441,6 +441,21 @@ public class BeaconParser implements Serializable {
 
     /**
      * Construct a Beacon from a Bluetooth LE packet collected by Android's Bluetooth APIs,
+     * including the raw Bluetooth device info.
+     *
+     * timestampMs excluded for backward compatibility with older api consumers.
+     *
+     * @param scanData The actual packet bytes
+     * @param rssi The measured signal strength of the packet
+     * @param device The Bluetooth device that was detected
+     * @return An instance of a <code>Beacon</code>
+     */
+    public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
+        return fromScanData(scanData, rssi, device, 0, new Beacon());
+    }
+
+    /**
+     * Construct a Beacon from a Bluetooth LE packet collected by Android's Bluetooth APIs,
      * including the raw Bluetooth device info
      *
      * @param scanData The actual packet bytes

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconParser.java
@@ -445,13 +445,17 @@ public class BeaconParser implements Serializable {
      *
      * timestampMs excluded for backward compatibility with older api consumers.
      *
+     * @Deprecated New implementations should not use this method. It is not intended as a public
+     * API and is subject to change or removal in the future.
+     *
      * @param scanData The actual packet bytes
      * @param rssi The measured signal strength of the packet
      * @param device The Bluetooth device that was detected
      * @return An instance of a <code>Beacon</code>
      */
+    @Deprecated
     public Beacon fromScanData(byte[] scanData, int rssi, BluetoothDevice device) {
-        return fromScanData(scanData, rssi, device, 0, new Beacon());
+        return fromScanData(scanData, rssi, device, System.currentTimeMillis(), new Beacon());
     }
 
     /**


### PR DESCRIPTION
Add back original/older method signatures which don't require the `timestampMs` field, to maintain backward compatibility with older closed-source clients which depend on android-beacon-library.