### PR TITLE
Update foreground service support for Android 14 restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+### 2.20-beta1 / 2023-09-02
+
+- Updates to support Android 14 foreground services. (#1155, David G. Young)
+
 ### 2.19.6 / 2023-07-02
 
 - Fix scans being stuck on when Bluetooth turned off in quick settings on

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ replacing `${altbeacon.version}` with the version you wish to use.
 
 ## How to build this Library
 
-This project uses an AndroidStudio/gradle build system and is known working with Android Studio
-4.1.3 and Gradle 6.5
+This project uses an AndroidStudio/gradle build system and is known working with Android Studio Flamingo | 2022.2.1 Patch 1 and Gradle 8.0
 
 Key Gradle build targets:
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -7,8 +7,8 @@ apply plugin: 'kotlin-android'
 android.buildFeatures.buildConfig true
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "30.0.3"
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
 
     kotlinOptions {
         jvmTarget = "17"
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 31
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
         // The hack below is because VERSION_NAME has been removed from BuildConfig as of Gradle Plugin 4.1

--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.BLUETOOTH" android:required="false"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:required="false"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
@@ -16,6 +17,7 @@
         <service android:enabled="true"
             android:exported="false"
             android:isolatedProcess="false"
+            android:foregroundServiceType="location"
             android:label="beacon"
             android:name=".service.BeaconService"
             />

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1784,7 +1784,7 @@ public class BeaconManager {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && mContext.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             LogManager.d(TAG, "Checking fine location permission as required for foreground service");
             if (mContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                throw new SecurityException("Foreground service may not be enabled on until after user grants Manifest.permission.ACCESS_FINE_LOCATION when target SdkVersion is set to TIRAMISU or above.");
+                throw new SecurityException("Foreground service may not be enabled until after user grants Manifest.permission.ACCESS_FINE_LOCATION when target SdkVersion is set to SDK 24 or above.  See: https://altbeacon.github.io/android-beacon-library/foreground-service.html");
             }
         }
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -23,6 +23,7 @@
  */
 package org.altbeacon.beacon;
 
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Notification;
@@ -1779,6 +1780,14 @@ public class BeaconManager {
         if (notification == null) {
             throw new NullPointerException("Notification cannot be null");
         }
+        LogManager.d(TAG, "Running SDK 24? %b.  Targeting SDK 24? %b", Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE, mContext.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && mContext.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            LogManager.d(TAG, "Checking fine location permission as required for foreground service");
+            if (mContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                throw new SecurityException("Foreground service may not be enabled on until after user grants Manifest.permission.ACCESS_FINE_LOCATION when target SdkVersion is set to TIRAMISU or above.");
+            }
+        }
+
         setEnableScheduledScanJobs(false);
         mForegroundServiceNotification = notification;
         mForegroundServiceNotificationId = notificationId;


### PR DESCRIPTION
This updates the library to support the upcoming Android 14 release, which imposes new restrictions on starting a foreground service.

This adds the necessary AndroidManifest.xml declarations for foreground services on Android 14, and also checks that `Manifest.permission.ACCESS_FINE_LOCATION` has been granted by the user in the call to `beaconManager.enableForegroundServiceScanning(...)`. If permission is not obtained when this call is made, the method now throws a `SecurityException` to let the user know this is a requirement.  

I have tested this on a Pixel 7 running Android 14 Beta 5 using a special branch of the Kotlin reference app and confirmed that the SecurityException crashes the app as described above before permission is granted, and it works to detect beacons with the Foreground service if the call is made after permission is granted.

It is unfortunate that this solution crashes the app rather than gracefully recover.  But at least the SecurityException happens during a library call, with a helpful message about what the developer needs to do, vs. during the OS startup of the service with a less helpful message.

A more graceful recovery would mean one of two things:

1. Don't crash the app, but leave beacon scanning broken.  (I like this solution even less, as it will hide the problem for many developers.)
2. Avoid a crash by not starting the foreground service if permission is not granted, then listen for the permission being granted, and if it is granted, start the foreground service at that time.

The problem with option 2 is that it is very complicated -- it is not easy to listen for this permission being granted.  And then the library gets in the business of managing permissions, something it does not do now.  Any alternative thoughts appreciated.

