### PR TITLE
Additional Android 14 Improvements

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1780,14 +1780,6 @@ public class BeaconManager {
         if (notification == null) {
             throw new NullPointerException("Notification cannot be null");
         }
-        LogManager.d(TAG, "Running SDK 24? %b.  Targeting SDK 24? %b", Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE, mContext.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && mContext.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            LogManager.d(TAG, "Checking fine location permission as required for foreground service");
-            if (mContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                throw new SecurityException("Foreground service may not be enabled until after user grants Manifest.permission.ACCESS_FINE_LOCATION when target SdkVersion is set to SDK 24 or above.  See: https://altbeacon.github.io/android-beacon-library/foreground-service.html");
-            }
-        }
-
         setEnableScheduledScanJobs(false);
         mForegroundServiceNotification = notification;
         mForegroundServiceNotificationId = notificationId;

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -472,6 +472,7 @@ public class BeaconManager {
                                     " service.  A consumer is already bound, so it should be started");
                         }
                         else {
+                            verifyLocationPermissionGrantedForForegroundService();
                             LogManager.i(TAG, "Attempting to starting foreground beacon scanning service.");
                             try {
                                 mContext.startForegroundService(intent);
@@ -1636,6 +1637,19 @@ public class BeaconManager {
                         PackageManager.MATCH_DEFAULT_ONLY);
         if (resolveInfo != null && resolveInfo.isEmpty()) {
             throw new ServiceNotDeclaredException();
+        }
+    }
+
+    /*
+     * Location permission must be granted in order to run foreground services on Android 14+
+     */
+    private void verifyLocationPermissionGrantedForForegroundService() {
+        LogManager.d(TAG, "Running SDK 34? %b.  Targeting SDK 34? %b", Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE, mContext.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && mContext.getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            LogManager.d(TAG, "Checking fine location permission as required for foreground service");
+            if (mContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                throw new SecurityException("Foreground service may not be enabled until after user grants Manifest.permission.ACCESS_FINE_LOCATION when target SdkVersion is set to SDK 34 or above.  See: https://altbeacon.github.io/android-beacon-library/foreground-service.html");
+            }
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -273,26 +273,12 @@ public class BeaconService extends Service {
                 .getForegroundServiceNotificationId();
         if (notification != null &&
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            this.verifyLocationPermissionGrantedForForegroundService();
             try {
                 this.startForeground(notificationId, notification);
             }
             catch (SecurityException exception) {
                 // https://issuetracker.google.com/issues/294408576
                 LogManager.w(TAG, "Suppress startForeground() SecurityException");
-            }
-        }
-    }
-
-    /*
-     * Location permission must be granted in order to run foreground services on Android 14+
-     */
-    private void verifyLocationPermissionGrantedForForegroundService() {
-        LogManager.d(TAG, "Running SDK 34? %b.  Targeting SDK 34? %b", Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE, getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            LogManager.d(TAG, "Checking fine location permission as required for foreground service");
-            if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                throw new SecurityException("Foreground service may not be enabled until after user grants Manifest.permission.ACCESS_FINE_LOCATION when target SdkVersion is set to SDK 34 or above.  See: https://altbeacon.github.io/android-beacon-library/foreground-service.html");
             }
         }
     }

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -24,6 +24,7 @@
 package org.altbeacon.beacon.service;
 
 
+import android.Manifest;
 import android.app.AlarmManager;
 import android.app.Notification;
 import android.app.PendingIntent;
@@ -272,7 +273,30 @@ public class BeaconService extends Service {
                 .getForegroundServiceNotificationId();
         if (notification != null &&
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-            this.startForeground(notificationId, notification);
+            this.verifyLocationPermissionGrantedForForegroundService();
+            try {
+                this.startForeground(notificationId, notification);
+            }
+            catch (SecurityException exception) {
+                // https://issuetracker.google.com/issues/294408576
+                LogManager.w(TAG, "Foreground service blocked by SecurityException.  Falling back to job scheduler");
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    ScanJobScheduler.getInstance().applySettingsToScheduledJob(this, beaconManager);
+                }
+            }
+        }
+    }
+
+    /*
+     * Location permission must be granted in order to run foreground services on Android 14+
+     */
+    private void verifyLocationPermissionGrantedForForegroundService() {
+        LogManager.d(TAG, "Running SDK 34? %b.  Targeting SDK 34? %b", Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE, getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && getApplicationInfo().targetSdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            LogManager.d(TAG, "Checking fine location permission as required for foreground service");
+            if (checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                throw new SecurityException("Foreground service may not be enabled until after user grants Manifest.permission.ACCESS_FINE_LOCATION when target SdkVersion is set to SDK 34 or above.  See: https://altbeacon.github.io/android-beacon-library/foreground-service.html");
+            }
         }
     }
 

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -279,10 +279,7 @@ public class BeaconService extends Service {
             }
             catch (SecurityException exception) {
                 // https://issuetracker.google.com/issues/294408576
-                LogManager.w(TAG, "Foreground service blocked by SecurityException.  Falling back to job scheduler");
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                    ScanJobScheduler.getInstance().applySettingsToScheduledJob(this, beaconManager);
-                }
+                LogManager.w(TAG, "Suppress startForeground() SecurityException");
             }
         }
     }

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -278,7 +278,7 @@ public class BeaconService extends Service {
             }
             catch (SecurityException exception) {
                 // https://issuetracker.google.com/issues/294408576
-                LogManager.w(TAG, "Suppress startForeground() SecurityException");
+                LogManager.w(TAG, "Call to service startForeground() threw a SecurityException.  The Foreground Service for beacon scanning may have started anyway, but this behavior might change in  different conditions or a future Android version.");
             }
         }
     }


### PR DESCRIPTION
Hi David,

I have been doing some more experimentation with the library and targeting API 34.  I have two issues I would like to discuss.

1).  [In this commit](https://github.com/AltBeacon/android-beacon-library/commit/68f7320d1b9cfbc135c162fd0e8357b17bf830f0), you added logic to throw an exception when calling `enableForegroundServiceScanning()` without location permission.  I understand your reasoning for this but I was hoping we could move this check further down the chain.
The problem I ran into is that my application does things in a slightly different order.  One of the first things I do is configure the BeaconManager and call `enableForegroundServiceScanning()`.  I do this before I request location permission from the user.  In my app, the Beacons are an optional feature and I don't request permission until the last possible moment before monitoring/ranging.
I could rewrite or reorder my code so that I make sure not to call `enableForegroundServiceScanning()` until AFTER I have location permission.  However, I don't feel like that is necessary as calling `enableForegroundServiceScanning()` doesn't actually start the service itself.  We should throw the exception from the method that actually needs the location permission.

2).  [I filed a bug with Google](https://issuetracker.google.com/issues/294408576) regarding the new `foregroundServiceType="location"` changes.
In short, even if an app has full permissions (access to background location permission, unoptimized battery usage, etc), it will throw an exception when trying to start a foreground service on boot if device location is disabled.
You can reproduce this problem easily by disabling location services on your device and rebooting.  You will crash when attempting to start the foreground service in the background despite having all of the documented permissions necessary.  This is a bug as there is no problem with starting the foreground service when the app is in the foreground, the bug only occurs when the app is in the background (like on boot).
My app utilizes several location-based foreground service beyond the `BeaconService` and all of them are impacted.
This is problematic for our app because even if the user does re-enable their location services, the foreground service was never started and thus Beacon monitoring will not occur until they have launched the app and the foreground service could be started.
My suggested solution for this is to fallback to the JobScheduler when this occurs [just like you do when there is a `ServiceStartNotAllowedException`.](https://github.com/AltBeacon/android-beacon-library/blob/master/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java#L487) This would allow beacon monitoring to continue despite the service not running.

I have briefly tested these changes and they seem to be working well.  Please let me know what your thoughts are or if you have any questions.  I am happy to make additional tweaks or split this into two separate pull-requests if needed.  I am not sure if these suggested solutions are ideal - I just wanted to start a discussion about the problems and what can be done about it (if anything).