### PR TITLE
Use scan filters on Android 14 when the screen is off

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -192,7 +192,7 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
             // to cause scan failures on some Samsung devices with Android 5.x
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
                 if ((Build.MANUFACTURER.equalsIgnoreCase("samsung") ||
-                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.U) &&
+                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) &&
                         !mPowerManager.isInteractive()) {
                     // On the Samsung 8.1 and Android 14.0, scans are blocked with screen off when the
                     // scan filter is empty (wildcard).  We do a more detailed filter on such devices


### PR DESCRIPTION
This appears to be necessary on a Pixel 7 running Android 14.   Is this real?  Tests in #1174 show that only the Pixel 7 (not the 6a) has this issue on Android 14.

I see no official mention of it.  Is this in the AOSP code, or is this a Pixel-specific change?  

Tests show that the app has to target Android 14 of the problem to come up (setting targetSdk to 33 will NOT cause the problem to show up on Android 14.)