### PR TITLE
Fix get filter nullpointerexception

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1529,7 +1529,7 @@ public class BeaconManager {
     }
 
     /**
-     * Default class for rssi filter/calculation implementation
+     * Set class for rssi filter/calculation implementation
      */
     protected static Class rssiFilterImplClass = null;
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1531,7 +1531,7 @@ public class BeaconManager {
     /**
      * Default class for rssi filter/calculation implementation
      */
-    protected static Class rssiFilterImplClass = RunningAverageRssiFilter.class;
+    protected static Class rssiFilterImplClass = null;
 
     public static void setRssiFilterImplClass(@NonNull Class c) {
         warnIfScannerNotInSameProcess();

--- a/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -107,8 +107,7 @@ public class RangedBeacon implements Serializable {
             // Use custom RSSI filter
             if (BeaconManager.getRssiFilterImplClass() != null) {
                 try {
-                    Constructor[] constructors = BeaconManager.getRssiFilterImplClass().getConstructors();
-                    Constructor cons = constructors[0];
+                    Constructor cons = BeaconManager.getRssiFilterImplClass().getConstructor();
                     mFilter = (RssiFilter) cons.newInstance();
                 } catch (Exception e) {
                     LogManager.e(TAG, "Failed with exception %s", e.toString());

--- a/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -110,7 +110,7 @@ public class RangedBeacon implements Serializable {
                     mFilter = (RssiFilter) BeaconManager.getRssiFilterImplClass().newInstance();
                 } catch (Exception e) {
                     LogManager.e(TAG, "Failed with exception %s", e.toString());
-                    LogManager.e(TAG, "Could not construct RssiFilterImplClass %s", BeaconManager.getRssiFilterImplClass().getName());
+                    LogManager.e(TAG, "Could not construct class %s", BeaconManager.getRssiFilterImplClass().getName());
                     LogManager.e(TAG, "Will default to RunningAverageRssiFilter");
                     mFilter = new RunningAverageRssiFilter();
                 }

--- a/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -104,15 +104,23 @@ public class RangedBeacon implements Serializable {
 
     private RssiFilter getFilter() {
         if (mFilter == null) {
-            //set RSSI filter
-            try {
-            Constructor cons = BeaconManager.getRssiFilterImplClass().getConstructors()[0];
-                mFilter = (RssiFilter)cons.newInstance();
-            } catch (Exception e) {
-                LogManager.e(TAG, "Could not construct RssiFilterImplClass %s", BeaconManager.getRssiFilterImplClass().getName());
+            // Use custom RSSI filter
+            if (BeaconManager.getRssiFilterImplClass() != null) {
+                try {
+                    Constructor[] constructors = BeaconManager.getRssiFilterImplClass().getConstructors();
+                    Constructor cons = constructors[0];
+                    mFilter = (RssiFilter) cons.newInstance();
+                } catch (Exception e) {
+                    LogManager.e(TAG, "Failed with exception %s", e.toString());
+                    LogManager.e(TAG, "Could not construct RssiFilterImplClass %s", BeaconManager.getRssiFilterImplClass().getName());
+                    LogManager.e(TAG, "Will default to RunningAverageRssiFilter");
+                    mFilter = new RunningAverageRssiFilter();
+                }
+            } else {
+                // Use default rssi filter
+                mFilter = new RunningAverageRssiFilter();
             }
         }
         return mFilter;
     }
-
 }

--- a/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/RangedBeacon.java
@@ -107,8 +107,7 @@ public class RangedBeacon implements Serializable {
             // Use custom RSSI filter
             if (BeaconManager.getRssiFilterImplClass() != null) {
                 try {
-                    Constructor cons = BeaconManager.getRssiFilterImplClass().getConstructor();
-                    mFilter = (RssiFilter) cons.newInstance();
+                    mFilter = (RssiFilter) BeaconManager.getRssiFilterImplClass().newInstance();
                 } catch (Exception e) {
                     LogManager.e(TAG, "Failed with exception %s", e.toString());
                     LogManager.e(TAG, "Could not construct RssiFilterImplClass %s", BeaconManager.getRssiFilterImplClass().getName());


### PR DESCRIPTION
Proposal fix for issue #1164

Proposal is to set default RSSI filter (RunningAverageRSSIFilter) in RangedBeacon class 
And use RunningAverageRSSIFilter as a fallback in case there is an issue during custom RSSI filter instantiation.