### PR TITLE
Fix bad model distance config url

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ The following instructions are for project administrators.
         ./gradlew closeAndReleaseRepository
 
 4. Keep checking for a half hour or so at https://repo1.maven.org/maven2/org/altbeacon/android-beacon-library/ to see that the new release shows up.
+
+Note:  you must have Java 17 to build the projecdt.  If that is not the version on the path, and you have Android Studio installed, you may be able to add it to the path with:
+
+`export PATH=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home/bin:$PATH`

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1517,7 +1517,7 @@ public class BeaconManager {
     @Nullable
     protected static BeaconSimulator beaconSimulator;
 
-    protected static String distanceModelUpdateUrl = "https://s3.amazonaws.com/android-beacon-library/android-distance.json";
+    protected static String distanceModelUpdateUrl = null;
 
     public static String getDistanceModelUpdateUrl() {
         return distanceModelUpdateUrl;


### PR DESCRIPTION
Two changes:

* Remove  the default model distance config URL that no longer works.  Library users can not specify their own URL.
* Change the storage mechanism for model distance JSON to be shared preferences so no permissions are needed to access storage on Android 14.