### PR TITLE
Fix distance calculator overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ The following instructions are for project administrators.
         ./gradlew closeAndReleaseRepository
 
 4. Keep checking for a half hour or so at https://repo1.maven.org/maven2/org/altbeacon/android-beacon-library/ to see that the new release shows up.
+
+Note:  you must have Java 17 to build the projecdt.  If that is not the version on the path, and you have Android Studio installed, you may be able to add it to the path with:
+
+`export PATH=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home/bin:$PATH`

--- a/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/BeaconService.java
@@ -236,8 +236,10 @@ public class BeaconService extends Service {
 
         mScanHelper.reloadParsers();
 
-        DistanceCalculator defaultDistanceCalculator =  new ModelSpecificDistanceCalculator(this, BeaconManager.getDistanceModelUpdateUrl());
-        Beacon.setDistanceCalculator(defaultDistanceCalculator);
+        if (Beacon.getDistanceCalculator() == null) {
+            DistanceCalculator defaultDistanceCalculator =  new ModelSpecificDistanceCalculator(this, BeaconManager.getDistanceModelUpdateUrl());
+            Beacon.setDistanceCalculator(defaultDistanceCalculator);
+        }
 
         // Look for simulated scan data
         try {

--- a/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/ScanJob.java
@@ -19,6 +19,7 @@ import org.altbeacon.beacon.Beacon;
 import org.altbeacon.beacon.BeaconManager;
 import org.altbeacon.beacon.BuildConfig;
 import org.altbeacon.beacon.Region;
+import org.altbeacon.beacon.distance.DistanceCalculator;
 import org.altbeacon.beacon.distance.ModelSpecificDistanceCalculator;
 import org.altbeacon.beacon.logging.LogManager;
 import org.altbeacon.beacon.utils.ProcessUtils;
@@ -326,8 +327,10 @@ public class ScanJob extends JobService {
             ProcessUtils processUtils = new ProcessUtils(ScanJob.this);
             LogManager.i(TAG, "beaconScanJob PID is "+processUtils.getPid()+" with process name "+processUtils.getProcessName());
         }
-        ModelSpecificDistanceCalculator defaultDistanceCalculator =  new ModelSpecificDistanceCalculator(ScanJob.this, BeaconManager.getDistanceModelUpdateUrl());
-        Beacon.setDistanceCalculator(defaultDistanceCalculator);
+        if (Beacon.getDistanceCalculator() == null) {
+            DistanceCalculator defaultDistanceCalculator =  new ModelSpecificDistanceCalculator(this, BeaconManager.getDistanceModelUpdateUrl());
+            Beacon.setDistanceCalculator(defaultDistanceCalculator);
+        }
         return restartScanning();
     }
 


### PR DESCRIPTION
Changes code to set  default distance calculator if a one has already been initialized.  This prevents overwriting a custom distance calculator class.

Fixes #1186