### PR TITLE
Fix intermittent bug blocking screen off detections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-### 2.20.6 / 2024 04-27
+### 2.20.7 / 2024-10-09
+
+- Fix intermittent screen off detection failures on Andorid 14 (#1205, David G. Young)
+
+### 2.20.6 / 2024-04-27
 
 - Fix distance calculator overwrite, (#1191, David G. Young)
 - Fix bad model distance config url, (#1190, David G. Young)


### PR DESCRIPTION
A problem was reported in #1204, where Android 14 sometimes  failed to start a new scan with filters necessary to detect beacons with the screen off.  

This failure to start a scan has an error description indicating that the scan has already started (in fact, a similar scan without the filters has, so the code that checks for equality seems to be flawed in some way.)

The fix is to stop the scan before starting it if we believe a scan is already started.

After making this change I was unable to reproduce the problem using the same procedure from #1204.  However, since the problem was intermittent, I am not 100% confident this fixes anything.  Maybe I am just lucky in my tests with the fix?