### PR TITLE
Fix scan failures when screen is off on Pixel phones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.21.0-beta3 / 2024-11-05
+
+- Fix non-Samsung screen off scan failure (#1208, David G. Young)
+
 ### 2.21.0-beta2 / 2024-10-21
 
 - Fix scan dropouts after 10 minutes (#1207, David G. Young)

--- a/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
+++ b/lib/src/main/java/org/altbeacon/beacon/service/scanner/CycledLeScannerForLollipop.java
@@ -204,7 +204,8 @@ public class CycledLeScannerForLollipop extends CycledLeScanner {
                             mBeaconManager.getBeaconParsers());
                 }
                 else {
-                    if (Build.MANUFACTURER.equalsIgnoreCase("samsung")) {
+                    if (Build.MANUFACTURER.equalsIgnoreCase("samsung") ||
+                            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                         LogManager.d(TAG, "Using a wildcard scan filter because the screen is on.  We will switch to a non-empty filter if the screen goes off");
                         // as soon as the screen goes off we will need to start a different scan
                         // that has scan filters


### PR DESCRIPTION
This fixes a bug seen on non-Samsung phones with Android 14+ where a constant scan in the background at 100% duty cycle never starts a new scan, so never sets the scan filter required when the screen is off. 

The change registers a broadcast receiver on all devices with Andorid 14+ (not just Samsung) so that we switch to using the required non-empty scan filter when the screen goes off.