### PR TITLE
Update region state on requestStateForRegion with IntentScanStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.21.0-beta3 / 2024-11-05
 
 - Fix non-Samsung screen off scan failure (#1208, David G. Young)
+- Check for region exits on requestStateforRegion with IntentScanStrategy (#1209, David G. Young) 
 
 ### 2.21.0-beta2 / 2024-10-21
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1101,6 +1101,11 @@ public class BeaconManager {
         if (determineIfCalledFromSeparateScannerProcess()) {
             return;
         }
+        if (mIntentScanStrategyCoordinator != null) {
+            LogManager.d(TAG, "Forcing IntentScanStrategyCoordinator to update state on requestStateForregion");
+            mIntentScanStrategyCoordinator.processScanResults(new ArrayList<ScanResult?>())
+        }
+
         MonitoringStatus status = MonitoringStatus.getInstanceForApplication(mContext);
         RegionMonitoringState stateObj = status.stateOf(region);
         int state = MonitorNotifier.OUTSIDE;


### PR DESCRIPTION
One of the problems with using the IntentScanStrategy is that you do not get rapid detections of region exits -- the only time the failure to detect your region is checked if no beacons are detected is when the ~15 minute scan job is called.

This change augments that a bit by forcing a re-calculation of region state whenever beaconManager.requestStateForRegion(...) is called and the IntentScanStrategy is active.  If you call that method periodically (or on an event of interest) and a beacon has not been seen in some time, an exit region event will fire.

