### PR TITLE
Improved support for GATT Service Advertisements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.21.0-beta4 / 2024-11-16
+
+- Improved support for beacon layouts based on 128-bit Service UUIDs
+
 ### 2.21.0-beta3 / 2024-11-05
 
 - Fix non-Samsung screen off scan failure (#1208, David G. Young)

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconTransmitter.java
@@ -168,8 +168,12 @@ public class BeaconTransmitter {
         }
         int manufacturerCode = mBeacon.getManufacturer();
         int serviceUuid = -1;
+        byte[] serviceUuid128Bit = {};
         if (mBeaconParser.getServiceUuid() != null) {
             serviceUuid = mBeaconParser.getServiceUuid().intValue();
+        }
+        if (mBeaconParser.getServiceUuid128Bit() != null) {
+            serviceUuid128Bit = mBeaconParser.getServiceUuid128Bit();
         }
 
         if (mBeaconParser == null) {
@@ -196,11 +200,28 @@ public class BeaconTransmitter {
                         (byte) ((serviceUuid >> 8) & 0xff)};
                 ParcelUuid parcelUuid = parseUuidFrom(serviceUuidBytes);
                 dataBuilder.addServiceData(parcelUuid, advertisingBytes);
-                dataBuilder.addServiceUuid(parcelUuid);
+                if (serviceUuid128Bit == null) {
+                    dataBuilder.addServiceUuid(parcelUuid);
+                }
                 dataBuilder.setIncludeTxPowerLevel(false);
                 dataBuilder.setIncludeDeviceName(false);
 
-            } else {
+            }
+            else if (serviceUuid128Bit != null && serviceUuid128Bit.length == 16) {
+                ParcelUuid parcelUuid = parseUuidFrom(serviceUuid128Bit);
+                dataBuilder.addServiceData(parcelUuid, advertisingBytes);
+                //dataBuilder.addServiceUuid(parcelUuid); // no room for 128 bit service UUIDs and data
+                dataBuilder.setIncludeTxPowerLevel(false);
+                dataBuilder.setIncludeDeviceName(false);
+            }
+            else if (serviceUuid128Bit != null && serviceUuid128Bit.length == 4) {
+                ParcelUuid parcelUuid = parseUuidFrom(serviceUuid128Bit);
+                dataBuilder.addServiceData(parcelUuid, advertisingBytes);
+                dataBuilder.addServiceUuid(parcelUuid);
+                dataBuilder.setIncludeTxPowerLevel(false);
+                dataBuilder.setIncludeDeviceName(false);
+            }
+            else {
                 dataBuilder.addManufacturerData(manufacturerCode, advertisingBytes);
             }
 

--- a/lib/src/main/java/org/altbeacon/bluetooth/Pdu.java
+++ b/lib/src/main/java/org/altbeacon/bluetooth/Pdu.java
@@ -9,10 +9,11 @@ import android.os.Build;
  */
 public class Pdu {
     private static final String  TAG = "Pdu";
-    public static final byte MANUFACTURER_DATA_PDU_TYPE = (byte) 0xff;
-    public static final byte GATT_SERVICE_UUID_PDU_TYPE = (byte) 0x16;
-    public static final byte GATT_SERVICE_UUID_128_BIT_PDU_TYPE = (byte) 0x21;
-    public static final byte GATT_SERVICE_FULL_UUID_128_BIT_PDU_TYPE = (byte) 0x07;
+    public static final byte MANUFACTURER_DATA_AD_TYPE = (byte) 0xff;
+    public static final byte GATT_SERVICE_DATA_UUID_16_BIT_AD_TYPE = (byte) 0x16;
+    public static final byte GATT_SERVICE_DATA_UUID_32_BIT_AD_TYPE = (byte) 0x20;
+    public static final byte GATT_SERVICE_DATA_UUID_128_BIT_AD_TYPE = (byte) 0x21;
+    public static final byte GATT_SERVICE_COMPLETE_UUID_128_BIT_AD_TYPE = (byte) 0x07;
 
     private byte mType;
     private int mDeclaredLength;


### PR DESCRIPTION
This adds several improvements for beacon layouts based on GATT Service Advertisements

* Supports 128-bit service uuids with attached data
* Allows transmitting the above
* Uses data matching bytes in service UUID layouts inside Bluetooth filters