### PR TITLE
[1213] Fixed crash when addObserver could be called not from main thread

### DIFF
--- a/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
+++ b/lib/src/main/java/org/altbeacon/beacon/powersave/BackgroundPowerSaverInternal.java
@@ -6,6 +6,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.PowerManager;
 
 import androidx.annotation.NonNull;
@@ -41,7 +43,9 @@ public class BackgroundPowerSaverInternal implements DefaultLifecycleObserver {
 
         beaconManager = BeaconManager.getInstanceForApplication(applicationContext);
 
-        ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
+        Handler mainHandler = new Handler(Looper.getMainLooper());
+
+        mainHandler.post(() -> ProcessLifecycleOwner.get().getLifecycle().addObserver(this));
     }
 
     @Override


### PR DESCRIPTION
This pull request fixes an issue #1213 that was created after changing background state detection logic.

The function 'addObserver' should be called on main thread.  Otherwise, it made the app to crash in application where start ranging, monitoring beacons were called not from main thread.