### PR TITLE
Fix crash on background thead start of ranging or monitoring per #1213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.21.1-beta1 / 2025-03-07
+
+- Fix crash starting ranging or monitoring on a background thread (#1223, David G. Young)
+
 ### 2.21.0 / 2025-1-25
 
 - Fix rssiFilterClass in new Settings API (#1218, David G. Young)


### PR DESCRIPTION
An earlier change in #1195 altered the mechanism for monitoring background state, and the new mechanism can only be started up on the main thread otherwise the app crashes.  The consequence of this is that if you start monitoring or ranging on a background thread the app crashes.  

This fixes that by detecting if we are on a background thread, and if so, switching to the foreground thread before starting background monitoring.

Fixes #1213