### PR TITLE
Fix absent distance calculator init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.21.1-beta1 / 2025-03-07
+
+- Fix crash starting ranging or monitoring on a background thread (#1223, David G. Young)
+
 ### 2.21.0 / 2025-1-25
 
 - Fix rssiFilterClass in new Settings API (#1218, David G. Young)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### 2.21.1-beta1 / 2025-03-07
+### 2.21.1-beta2 / 2025-03-08
 
 - Fix crash starting ranging or monitoring on a background thread (#1223, David G. Young)
+- Fix missing distance calculator init (#1224, David G. Young)
 
 ### 2.21.0 / 2025-1-25
 

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -1510,6 +1510,10 @@ public class BeaconManager {
             LogManager.w(TAG, "The BeaconManager is not bound to the service.  Call beaconManager.bind(BeaconConsumer consumer) and wait for a callback to onBeaconServiceConnect()");
             return;
         }
+
+        DistanceCalculator distanceCalculator = settings.getDistanceCalculatorFactory().getInstance(mContext);
+        Beacon.setDistanceCalculatorInternal(distanceCalculator);
+
         if (mIntentScanStrategyCoordinator != null) {
             mIntentScanStrategyCoordinator.applySettings();
             return;


### PR DESCRIPTION
As described in #1215 distance calculations are always returning -1.0 meters because the distance calculator is not being initialized in releases 2.20+

This fixes the above.