### PR TITLE
Publishing upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,27 +80,28 @@ If you want to help with the open source project, contact david@radiusnetworks.c
 
 The following instructions are for project administrators.
 
-1. Prerequisites: https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/ 
+1. Prerequisites: https://github.com/vanniktech/gradle-maven-publish-plugin
 
 2. Configure your  ~/.gradle/gradle.properties with:
 
-        signing.keyId=<my key id>
-        signing.password=<my passphrase>
-        signing.secretKeyRingFile=<path to exported gpg file>
-        signing.password=<my passphrase>
-        ossrhUsername=<sonotype server username>
-        ossrhPassword=<sonotype server password>
+        mavenCentralUsername=<actually the token generated on central.sonatype.com>
+        mavenCentralPassword=<the password to go with the above token>
+        signing.keyId=<my GPG signing key id>
+        signing.password=<passphrase associated with the GPG signing key>
+        signing.secretKeyRingFile=<file path on the local machine to the signing key file XXXX.gpg>
 
 3. Run the build and upload
 
         git tag <version>
         git push --tags 
-        ./gradlew release
-        ./gradlew mavenPublish # Wait 10 mins before using the next command
-        ./gradlew closeAndReleaseRepository
+        ./gradlew publishToMavenCentral
 
-4. Keep checking for a half hour or so at https://repo1.maven.org/maven2/org/altbeacon/android-beacon-library/ to see that the new release shows up.
+4. Verify you see this line, the only real indication artifact upload happened:
 
-Note:  you must have Java 17 to build the projecdt.  If that is not the version on the path, and you have Android Studio installed, you may be able to add it to the path with:
+        Skipping deployment validation!
+        
+5. Go to this URL  https://central.sonatype.com/publishing/deployments, verify you see the new release, and hit the Publish button.  Keep refeshing until it is published, or check at  https://repo1.maven.org/maven2/org/altbeacon/android-beacon-library/ to see that the new release shows up.
+
+Note:  you must have Java 17 to build the project.  If that is not the version on the path, and you have Android Studio installed, you may be able to add it to the path with:
 
 `export PATH=/Applications/Android\ Studio.app/Contents/jbr/Contents/Home/bin:$PATH`

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/publish-mavencentral.gradle
+++ b/gradle/publish-mavencentral.gradle
@@ -106,7 +106,9 @@ afterEvaluate {
         repositories {
             maven {
                 name = "sonatype"
-                url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                url = "https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/"
+                //url = "https://central.sonatype.com/service/local/staging/deploy/maven2/"
+                //url = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
                 credentials {
                     username ossrhToken

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id("org.jetbrains.dokka") version "1.5.0"
+    id "com.vanniktech.maven.publish" version "0.35.0"
 }
 apply plugin: 'kotlin-android'
 
@@ -85,18 +86,55 @@ dependencies {
     dokkaHtmlPlugin("org.jetbrains.dokka:kotlin-as-java-plugin:1.5.0")
 }
 
+/*
 ext {
     PUBLISH_GROUP_ID = 'org.altbeacon'
     PUBLISH_VERSION = version
     PUBLISH_ARTIFACT_ID = 'android-beacon-library'
 }
+ */
 
 repositories {
     mavenCentral()
 }
+
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+
+    coordinates("org.altbeacon", "android-beacon-library", version)
+    pom {
+        name = "Android Beacon Library"
+        description = "Detects and transmits Bluetooth beacons"
+        inceptionYear = "2013"
+        url ="https://altbeacon.github.io/android-beacon-library/"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = "davidgyoung"
+                name = "David G. Young"
+                url = "https://github.com/davidgyoung/"
+            }
+        }
+        scm {
+            url = "https://github.com/AltBeacon/android-beacon-library"
+            connection = "scm:git:git://github.com/AltBeacon/android-beacon-library.git"
+            developerConnection = "scm:git:ssh://git@github.com/AltBeacon/android-beacon-library.git"
+        }
+    }
+}
+
+/*
 if (getGradle().getStartParameter().getTaskRequests().toString().contains("release") ||
         getGradle().getStartParameter().getTaskRequests().toString().contains("mavenPublish") ||
         getGradle().getStartParameter().getTaskRequests().toString().contains("closeAndReleaseRepository")) {
     apply from: "../gradle/publish-mavencentral.gradle"
 }
+ */
 

--- a/lib/src/main/java/org/altbeacon/beacon/Beacon.java
+++ b/lib/src/main/java/org/altbeacon/beacon/Beacon.java
@@ -221,6 +221,7 @@ public class Beacon implements Parcelable, Serializable {
      * Sets the DistanceCalculator to use with this beacon
      * @param dc
      */
+    @Deprecated
     public static void setDistanceCalculator(DistanceCalculator dc) {
         sDistanceCalculator = dc;
     }
@@ -232,6 +233,7 @@ public class Beacon implements Parcelable, Serializable {
      * @deprecated get the distanceCalculatorFactory method on the Settings class
      * Gets the DistanceCalculator to use with this beacon
      */
+    @Deprecated
     public static DistanceCalculator getDistanceCalculator() {
         return sDistanceCalculator;
     }

--- a/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
+++ b/lib/src/main/java/org/altbeacon/beacon/BeaconManager.java
@@ -253,6 +253,10 @@ public class BeaconManager {
         AppliedSettings oldSettings = settings;
         this.settings = newSettings;
         Beacon.setHardwareEqualityEnforced(Boolean.TRUE.equals(this.settings.getHardwareEqualityEnforced()));
+        if (BeaconManager.getDistanceModelUpdateUrl() == null ||
+                !BeaconManager.getDistanceModelUpdateUrl().equals(settings.getDistanceModelUpdateUrl())) {
+            BeaconManager.setDistanceModelUpdateUrl(settings.getDistanceModelUpdateUrl());
+        }
 
         if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             if (settings.getScanPeriods().getBackgroundBetweenScanPeriodMillis() < 15*60*1000 /* 15 min */ &&
@@ -1704,11 +1708,13 @@ public class BeaconManager {
     @Deprecated
     public static void setDistanceModelUpdateUrl(@NonNull String url) {
         warnIfScannerNotInSameProcess();
+        distanceModelUpdateUrl = url;
+        Log.i(TAG, "setDistanceModelUpdateUrl with "+url+" with BeaconManager instance "+sInstance);
+
         if (sInstance != null) {
             Settings settingsChange = new Settings.Builder().setDistanceModelUpdateUrl(url).build();
-            sInstance.adjustSettings(settingsChange);
+            Objects.requireNonNull(sInstance).adjustSettings(settingsChange);
         }
-        distanceModelUpdateUrl = url;
     }
 
     /**

--- a/lib/src/test/java/org/altbeacon/beacon/SettingsTest.kt
+++ b/lib/src/test/java/org/altbeacon/beacon/SettingsTest.kt
@@ -33,7 +33,6 @@ class SettingsTest {
         // This works but it is not designed for Kotlin
         beaconManager.adjustSettings(Settings.Builder().setDebug(true).setDistanceModelUpdateUrl("www.google.com").build())
         // This is the preferred usage for Kotlin
-        Settings.Defaults.distanceModelUpdateUrl
         val settings = Settings(
             debug = true,
             distanceModelUpdateUrl = "www.google.com",
@@ -54,6 +53,9 @@ class SettingsTest {
         beaconManager.activeSettings.debug // can read but not write
         Assert.assertEquals(BeaconManager.getDistanceModelUpdateUrl(), "www.google.com")
     }
+
+    @Test
+    @Throws(Exception::class)
     fun configureScheduledJobStrategyTest() {
         val context = RuntimeEnvironment.getApplication()
         val beaconManager = BeaconManager
@@ -74,6 +76,9 @@ class SettingsTest {
         )
         beaconManager.adjustSettings(settings)
     }
+
+    @Test
+    @Throws(Exception::class)
     fun configureJobServiceStrategyTest() {
         val context = RuntimeEnvironment.getApplication()
         val beaconManager = BeaconManager
@@ -94,6 +99,9 @@ class SettingsTest {
         )
         beaconManager.adjustSettings(settings)
     }
+
+    @Test
+    @Throws(Exception::class)
     fun configureBackgroundServiceStrategyTest() {
         val context = RuntimeEnvironment.getApplication()
         val beaconManager = BeaconManager
@@ -104,6 +112,8 @@ class SettingsTest {
         beaconManager.adjustSettings(settings)
     }
 
+    @Test
+    @Throws(Exception::class)
     fun configureIntentScanStrategyTest() {
         val context = RuntimeEnvironment.getApplication()
         val beaconManager = BeaconManager


### PR DESCRIPTION
This fixes publishing so it works again in Maven Central, after they sunsetted their old servers and legacy SDK in June 2025.

See README.md for changes in publishing instructions.